### PR TITLE
Automatically rewrites the Header of OutputTXT after setting length o…

### DIFF
--- a/src/module/OutputTXT.cpp
+++ b/src/module/OutputTXT.cpp
@@ -78,10 +78,12 @@ TextOutput::TextOutput(const std::string &filename,
 
 void TextOutput::setEnergyScale(double scale) {
 	energyScale = scale;
+	printHeader();
 }
 
 void TextOutput::setLengthScale(double scale) {
 	lengthScale = scale;
+	printHeader();
 }
 
 void TextOutput::set1D(bool value) {


### PR DESCRIPTION
…r energy scale. When the function setLengthScale or setEnergyScale is used the header of the file is not updated automatically. This problem is solved by this pull request.