### PR TITLE
Nuclear decay behaves not as expected

### DIFF
--- a/src/module/NuclearDecay.cpp
+++ b/src/module/NuclearDecay.cpp
@@ -77,7 +77,7 @@ void NuclearDecay::process(Candidate *candidate) const {
 
 		for (size_t i = 0; i < decays.size(); i++) {
 			double rate = decays[i].rate;
-			rate *= candidate->current.getLorentzFactor();
+			rate /= candidate->current.getLorentzFactor();
 			totalRate += rate;
 			double d = -log(random.rand()) / rate;
 			if (d > randDistance)

--- a/src/module/NuclearDecay.cpp
+++ b/src/module/NuclearDecay.cpp
@@ -77,7 +77,7 @@ void NuclearDecay::process(Candidate *candidate) const {
 
 		for (size_t i = 0; i < decays.size(); i++) {
 			double rate = decays[i].rate;
-			rate /= candidate->current.getLorentzFactor();
+			rate *= candidate->current.getLorentzFactor();
 			totalRate += rate;
 			double d = -log(random.rand()) / rate;
 			if (d > randDistance)


### PR DESCRIPTION
The current implementation of the relativistic gamma factor in the decay rate leads to a strange behavior. Particles with higher energies and therefore higher gamma factors decay faster. The opposite behavior is expected, e.g atmospheric myons which can be detected at the Earth's surface.
Or do I see something terribly wrong? 

I created a python script notebook where I tried to explain this problem (see below). 
[Decay.txt](https://github.com/CRPropa/CRPropa3/files/95931/Decay.txt)

This pull request leads to the expected behavior.


