### PR TITLE
Wrong unit comparison in PropagationCK::process

### DIFF
--- a/src/module/PropagationCK.cpp
+++ b/src/module/PropagationCK.cpp
@@ -108,7 +108,7 @@ void PropagationCK::process(Candidate *candidate) const {
 		// limit change of new step size
 		h = clip(h, 0.1 * hTry, 5 * hTry);
 
-	} while (r > 1 && h > minStep);
+	} while (r > 1 && h > minStep / c_light);
 
 	current.setPosition(yOut.x);
 	current.setDirection(yOut.u.getUnitVector());


### PR DESCRIPTION
bug fix: h [time] was compared to minStep [length]. Fixed units.