### PR TITLE
Secondary trajectory length

### DIFF
--- a/src/Candidate.cpp
+++ b/src/Candidate.cpp
@@ -110,7 +110,7 @@ void Candidate::addSecondary(int id, double energy) {
 void Candidate::addSecondary(int id, double energy, Vector3d position) {
 	ref_ptr<Candidate> secondary = new Candidate;
 	secondary->setRedshift(redshift);
-	secondary->setTrajectoryLength(trajectoryLength);
+	secondary->setTrajectoryLength(trajectoryLength-(current.getPosition()-position).getR());
 	secondary->source = source;
 	secondary->previous = previous;
 	secondary->created = current;


### PR DESCRIPTION
Using the new interpolated position of the secondary particle, the trajectory length became too long. Therefore, the trajectory length was changed using the difference of the interpolated position and the current position. So, this commit is supposed to fix the problem.