### PR TITLE
Fix for JF12 field slice example 

### DIFF
--- a/test/python/testJF12Field.py
+++ b/test/python/testJF12Field.py
@@ -19,8 +19,8 @@ samples = (linspace(-20, 20, N, endpoint=True))
 B = zeros((N,N))
 X, Y = meshgrid(samples, samples)
 
-for i,x in enumerate(samples):
-  for j,y in enumerate(samples):
+for i, y in enumerate(samples):
+  for j, x in enumerate(samples):
     pos = Vector3d(x, y, z) * kpc
     B[i, j] = bField.getField(pos).getR() / gauss # B in [G]
 
@@ -31,8 +31,8 @@ gca().set_aspect(1)
 cbar = colorbar(pc, shrink=0.8)
 cbar.set_label(r'$\vert \vec{B} \vert$ [G]')
 plot(-8.5, 0, 'wo')
-xlabel('x [kpx]')
-ylabel('y [kpx]')
+xlabel('x [kpc]')
+ylabel('y [kpc]')
 xlim(-20, 20)
 ylim(-20, 20)
 savefig('JF12.png', bbox_inches='tight')


### PR DESCRIPTION
Change order of x and y to get right rotation in field, change axis labels