### PR TITLE
Fixed cosmological scaling

### DIFF
--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -126,7 +126,7 @@ void EMDoublePairProduction::process(Candidate *candidate) const {
 	double randDistance = std::numeric_limits<double>::max();
 
 	// comological scaling of interaction distance (comoving)
-	double scaling = pow(1 + z, 3) * photonFieldScaling(photonField, z);
+	double scaling = pow(1 + z, 2) * photonFieldScaling(photonField, z);
 	double rate = scaling * interpolate(E, tabPhotonEnergy, tabInteractionRate);
 	randDistance = -log(random.rand()) / rate;
 

--- a/src/module/EMInverseComptonScattering.cpp
+++ b/src/module/EMInverseComptonScattering.cpp
@@ -251,7 +251,7 @@ void EMInverseComptonScattering::process(Candidate *candidate) const {
 	double randDistance = std::numeric_limits<double>::max();
 
 	// cosmological scaling of interaction distance (comoving)
-	double scaling = pow(1 + z, 3) * photonFieldScaling(photonField, z);
+	double scaling = pow(1 + z, 2) * photonFieldScaling(photonField, z);
 	double rate = scaling * interpolate(E, tabElectronEnergy, tabInteractionRate);
 	randDistance = -log(random.rand()) / rate;
 

--- a/src/module/EMPairProduction.cpp
+++ b/src/module/EMPairProduction.cpp
@@ -259,7 +259,7 @@ void EMPairProduction::process(Candidate *candidate) const {
 	double randDistance = std::numeric_limits<double>::max();
 
 	// comological scaling of interaction distance (comoving)
-	double scaling = pow(1 + z, 3) * photonFieldScaling(photonField, z);
+	double scaling = pow(1 + z, 2) * photonFieldScaling(photonField, z);
 	double rate = scaling * interpolate(E, tabPhotonEnergy, tabInteractionRate);
 	randDistance = -log(random.rand()) / rate;
 

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -192,7 +192,7 @@ void EMTripletPairProduction::process(Candidate *candidate) const {
 	double randDistance = std::numeric_limits<double>::max();
 
 	// comological scaling of interaction distance (comoving)
-	double scaling = pow(1 + z, 3) * photonFieldScaling(photonField, z);
+	double scaling = pow(1 + z, 2) * photonFieldScaling(photonField, z);
 	double rate = scaling * interpolate(E, tabElectronEnergy, tabInteractionRate);
 	randDistance = -log(random.rand()) / rate;
 	candidate->limitNextStep(limit / rate);


### PR DESCRIPTION
use scaling for interaction rate instead of scaling for energy loss rate