### PR TITLE
Bug fix

### DIFF
--- a/src/magneticField/JF12Field.cpp
+++ b/src/magneticField/JF12Field.cpp
@@ -215,7 +215,7 @@ Vector3d JF12Field::getRegularField(const Vector3d& pos) const {
 	if (r < rc) {
 		// varying elevation region
 		rp = r * rXc / rc;
-		bMagX = bX * exp(-1 * rp / rX) * pow(rp / r, 2.);
+		bMagX = bX * exp(-1 * rp / rX) * pow(rXc / rc, 2.);
 		double thetaX = atan2(fabs(pos.z), (r - rp));
 		if (pos.z == 0)
 			thetaX = M_PI / 2.;

--- a/src/magneticField/JF12Field.cpp
+++ b/src/magneticField/JF12Field.cpp
@@ -224,7 +224,7 @@ Vector3d JF12Field::getRegularField(const Vector3d& pos) const {
 	} else {
 		// constant elevation region
 		rp = r - fabs(pos.z) / tanThetaX0;
-		bMagX = bX * exp(-rp / rX) * (rXc / rc);
+		bMagX = bX * exp(-rp / rX) * (rp / r);
 		sinThetaX = sinThetaX0;
 		cosThetaX = cosThetaX0;
 	}

--- a/src/magneticField/JF12Field.cpp
+++ b/src/magneticField/JF12Field.cpp
@@ -224,7 +224,7 @@ Vector3d JF12Field::getRegularField(const Vector3d& pos) const {
 	} else {
 		// constant elevation region
 		rp = r - fabs(pos.z) / tanThetaX0;
-		bMagX = bX * exp(-rp / rX) * (rp / r);
+		bMagX = bX * exp(-rp / rX) * (rXc / rc);
 		sinThetaX = sinThetaX0;
 		cosThetaX = cosThetaX0;
 	}


### PR DESCRIPTION
The calculation of the poloidal component of the JF12 field lead to "nan" values at the z-axis. Since rXc/rc = rp/r the code is mathematically the same but  the computer is not forced to calculate the quotient of 0./0. at the z-axis.