### PR TITLE
Fixes in SynchrotronRadition and NuclearDecay modules

### DIFF
--- a/include/crpropa/module/SynchrotronRadiation.h
+++ b/include/crpropa/module/SynchrotronRadiation.h
@@ -24,6 +24,7 @@ private:
 	std::vector<double> tabCDF; /*< tabulated cumulative synchrotron spectrum*/
 
 	double limit; ///< fraction of energy loss length to limit the next step
+	double secondaryThreshold; ///< energy threshold for production of secondaries
 	bool havePhotons;
 
 public:
@@ -38,6 +39,8 @@ public:
 	double getBrms();
 	void setHavePhotons(bool havePhotons);
 	void setLimit(double limit);
+	void setSecondaryThreshold(double t);
+	double getSecondaryThreshold() const;
 	void initSpectrum();
 	void process(Candidate *candidate) const;
 	void addPhotons(Candidate *candidate, double loss) const;

--- a/src/module/NuclearDecay.cpp
+++ b/src/module/NuclearDecay.cpp
@@ -167,8 +167,11 @@ void NuclearDecay::gammaEmission(Candidate *candidate, int channel, double &Egam
 	for (int i = 0; i < energy.size(); ++i) {
 		if (random.rand() <= intensity[i]) {
 			Egamma += energy[i];
+			// boost to lab frame
+			double cosTheta = 2 * random.rand() - 1;
+			double E = energy[i] * candidate->current.getLorentzFactor() * (1. - cosTheta);
 			if (havePhotons) {
-				candidate->addSecondary(22, energy[i], pos);
+				candidate->addSecondary(22, E, pos);
 			}
 		}
 	}


### PR DESCRIPTION
- Added missing boost to lab frame for photon energy in NuclearDecay module.
- Added set and get functions to define an energy threshold for production of synchrotron photons