### PR TITLE
Add source class: SourceSNRDistribution

### DIFF
--- a/include/crpropa/Source.h
+++ b/include/crpropa/Source.h
@@ -226,6 +226,35 @@ public:
 	void setDescription();
 };
 
+/**
+@class SourceSNRDistribution
+@brief Source distribution that follows the Galactic SNR distribution
+
+The origin of the distribution is the Galactic center. The maximum radius is set 
+to R_max=20 kpc.
+See G. Case and D. Bhattacharya (1996) for the details.
+*/
+
+class SourceSNRDistribution: public SourceFeature {
+	double R_earth; // parameter given by observation
+	double beta; // parameter to shift the maximum in R direction
+	double Zg; // exponential cut parameter in z direction
+	double frMax; // helper for efficient sampling
+	double fzMax; // helper for efficient sampling
+
+public:
+	SourceSNRDistribution();	
+	SourceSNRDistribution(double R_earth, double beta, double Zg);
+	void prepareParticle(ParticleState &particle) const;
+	void f_r(double r, double &fr) const;
+	void f_z(double z, double &fz) const;
+	void set_frMax(double R, double b);
+	void set_fzMax(double Zg);
+	double get_frMax();
+	double get_fzMax();
+	void setDescription();
+};
+
 
 /**
  @class SourceUniform1D

--- a/test/testSource.cpp
+++ b/test/testSource.cpp
@@ -72,6 +72,31 @@ TEST(SourceUniformCylinder, simpleTest) {
 	EXPECT_GE(height/2., H);
 }
 
+TEST(SourceSNRDistribution, simpleTest) {
+	double R_earth = 8.5*kpc;
+	double beta = 3.53;
+	double Z_G = 0.3*kpc;
+	SourceSNRDistribution snr(R_earth, beta, Z_G);
+	ParticleState ps;
+	snr.prepareParticle(ps);
+	Vector3d pos = ps.getPosition();
+	double R2 = pos.x*pos.x+pos.y*pos.y;
+	EXPECT_GE(20*kpc*20*kpc, R2); // radius must be smaller than 20 kpc
+	
+	double R2_mean = 0.;
+	double Z_mean = 0.;
+	for (size_t i=0; i<100000; i++) {
+		snr.prepareParticle(ps);
+		Vector3d pos = ps.getPosition();
+		R2_mean += pow(pos.x/kpc, 2.)+pow(pos.y/kpc, 2.);
+		Z_mean += pos.z/kpc;
+	}
+	R2_mean/=100000.;
+	Z_mean/=100000.;
+	EXPECT_NEAR(64.4, R2_mean, 0.4);
+	EXPECT_NEAR(0., Z_mean, 0.02);
+}
+
 TEST(SourceDensityGrid, withInRange) {
 	// Create a grid with 10^3 cells ranging from (0, 0, 0) to (10, 10, 10)
 	Vector3d origin(0, 0, 0);


### PR DESCRIPTION
Add a simple source class for drawing source positions from the Galactic SNR distribution. For details of the distribution see G. Case and D. Bhattacharya, _Revisiting the galactic supernova remnant distribution_, Astron.& Astroph. Suppl. **120** (Dec., 1996)