### PR TITLE
Fix the bug in SourceUniformShell. Now the center of the shell is taken into account

### DIFF
--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -282,7 +282,7 @@ SourceUniformShell::SourceUniformShell(Vector3d center, double radius) :
 
 void SourceUniformShell::prepareParticle(ParticleState& particle) const {
 	Random &random = Random::instance();
-	particle.setPosition(random.randVector() * radius);
+	particle.setPosition(center + random.randVector() * radius);
 }
 
 void SourceUniformShell::setDescription() {


### PR DESCRIPTION
Test-Script:

from crpropa import *
d=1.
source = SourceUniformShell(Vector3d(50.)*Mpc, d * Mpc)
can = Candidate()
canPos = can.current
can = Candidate()
canPos = can.current
source.prepareParticle(canPos)
Pos = canPos.getPosition()
print Pos/Mpc, (Pos/Mpc-Vector3d(50.)).getR()

