### PR TITLE
Add candidate properties to output files

### DIFF
--- a/include/crpropa/Variant.h
+++ b/include/crpropa/Variant.h
@@ -113,6 +113,11 @@ public:
 
 	static const char *getTypeName(Type type);
 
+	// copy the data to buffer via memcpy. Returns the size of the data
+	size_t copyToBuffer(void* buffer);
+	/// returns size of used data type in bytes
+	size_t getSize() const;
+
 	template<class T>
 	T to() const
 	{

--- a/include/crpropa/module/HDF5Output.h
+++ b/include/crpropa/module/HDF5Output.h
@@ -10,6 +10,8 @@
 
 namespace crpropa {
 
+const size_t propertyBufferSize = 1024;
+
 class HDF5Output: public Output {
 
 	typedef struct OutputRow {
@@ -42,7 +44,10 @@ class HDF5Output: public Output {
 		double P1x;
 		double P1y;
 		double P1z;
+		unsigned char propertyBuffer[propertyBufferSize];
 	} OutputRow;
+
+	std::string filename;
 
 	hid_t file, sid;
 	hid_t dset, dataspace;

--- a/include/crpropa/module/Output.h
+++ b/include/crpropa/module/Output.h
@@ -2,8 +2,12 @@
 #define CRPROPA_ABSTRACT_OUTPUT_H
 
 #include "crpropa/Module.h"
+#include "crpropa/Variant.h"
 
 #include <bitset>
+#include <vector>
+#include <string>
+
 
 namespace crpropa {
 
@@ -15,9 +19,18 @@ class Output: public Module {
 protected:
 	double lengthScale, energyScale;
 	std::bitset<64> fields;
+
+	struct Property
+	{
+		std::string name;
+		std::string comment;
+		Variant defaultValue;
+	};
+	std::vector<Property> properties;
+
 	bool oneDimensional;
 	mutable size_t count;
-	
+
 	void modify();
 
 public:
@@ -49,12 +62,15 @@ public:
 
 	Output();
 	Output(OutputType outputtype);
-	
+
 	void setEnergyScale(double scale);
 	void setLengthScale(double scale);
 
 	void setOutputType(OutputType outputtype);
 	void set(OutputColumn field, bool value);
+	/// Add a property to output. Default value is required to assign a type in
+	/// the output
+	void enableProperty(const std::string &property, const Variant& defaultValue, const std::string &comment = "");
 	void enable(OutputColumn field);
 	void disable(OutputColumn field);
 	void enableAll();

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -123,32 +123,7 @@
 %include "crpropa/ParticleID.h"
 %include "crpropa/ParticleMass.h"
 
-%ignore pxl::Variant::Variant(Variant const *);
-%ignore pxl::Variant::operator bool&;
-%ignore pxl::Variant::operator const bool&;
-%ignore pxl::Variant::operator char&;
-%ignore pxl::Variant::operator const char&;
-%ignore pxl::Variant::operator unsigned char&;
-%ignore pxl::Variant::operator const unsigned char&;
-%ignore pxl::Variant::operator int16_t&;
-%ignore pxl::Variant::operator const int16_t&;
-%ignore pxl::Variant::operator uint16_t&;
-%ignore pxl::Variant::operator const uint16_t&;
-%ignore pxl::Variant::operator int32_t&;
-%ignore pxl::Variant::operator const int32_t&;
-%ignore pxl::Variant::operator uint32_t&;
-%ignore pxl::Variant::operator const uint32_t&;
-%ignore pxl::Variant::operator int64_t&;
-%ignore pxl::Variant::operator const int64_t&;
-%ignore pxl::Variant::operator uint64_t&;
-%ignore pxl::Variant::operator const uint64_t&;
-%ignore pxl::Variant::operator std::string&;
-%ignore pxl::Variant::operator const std::string&;
-%ignore pxl::Variant::operator double&;
-%ignore pxl::Variant::operator const double&;
-%ignore pxl::Variant::operator float&;
-%ignore pxl::Variant::operator const float&;
-%include "crpropa/Variant.h"
+%import "crpropa/Variant.h"
 
 /* override Candidate::getProperty() */
 %ignore crpropa::Candidate::getProperty(const std::string &) const;
@@ -390,6 +365,79 @@
 %include "crpropa/module/Observer.h"
 %include "crpropa/module/SimplePropagation.h"
 %include "crpropa/module/PropagationCK.h"
+
+%ignore crpropa::Output::enableProperty(const std::string &property, const Variant& defaultValue, const std::string &comment = "");
+%extend crpropa::Output{
+  PyObject * enableProperty(const std::string &name, PyObject* defaultValue, const std::string &comment="")
+  {
+
+       if (defaultValue == Py_None)
+        {
+          Py_RETURN_TRUE;
+        }
+        else if (PyBool_Check(defaultValue))
+        {
+         if(defaultValue == Py_True)
+         {
+          $self->enableProperty(name, true, comment);
+         }
+         else
+         {
+          $self->enableProperty(name, false, comment);
+         }
+          Py_RETURN_TRUE;
+        }
+        else if (PyInt_Check(defaultValue))
+        {
+          $self->enableProperty(name, PyInt_AsLong(defaultValue), comment);
+          Py_RETURN_TRUE;
+        }
+        else if (PyLong_Check(defaultValue))
+        {
+          $self->enableProperty(name, PyLong_AsLong(defaultValue), comment);
+          Py_RETURN_TRUE;
+        }
+        else if (PyFloat_Check(defaultValue))
+        {
+          $self->enableProperty(name, PyFloat_AsDouble(defaultValue), comment);
+          Py_RETURN_TRUE;
+        }
+        else if (PyUnicode_Check(defaultValue)){
+        #ifdef SWIG_PYTHON3
+          std::string ss = PyUnicode_AsUTF8(defaultValue);
+        #else
+          PyObject *s =  PyUnicode_AsUTF8String(defaultValue);
+          std::string ss = PyString_AsString(s);
+        #endif
+          $self->enableProperty(name, ss, comment);
+          Py_RETURN_TRUE;
+        }
+        #ifndef SWIG_PYTHON3
+        else if (PyString_Check( defaultValue))
+        {
+          std::string ss = PyString_AsString(defaultValue);
+          $self->enableProperty(name, ss, comment);
+          Py_RETURN_TRUE;
+        }
+        #endif
+        else
+        {
+          PyObject *t = PyObject_Str(PyObject_Type(defaultValue));
+          std::string ot;
+
+          #ifdef SWIG_PYTHON3
+            ot = PyUnicode_AsUTF8(t);
+          #else
+            ot = PyString_AsString(t);
+          #endif
+          std::cerr << "ERROR: Unknown Type: " << ot << std::endl;
+          return NULL;
+        }
+
+  }
+}
+
+
 %include "crpropa/module/Output.h"
 %include "crpropa/module/DiffusionSDE.h"
 %include "crpropa/module/TextOutput.h"

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -835,4 +835,128 @@ double Variant::toDouble() const
 	}
 }
 
+
+#define MEMCPYRET(VAR) \
+	memcpy(buffer, &VAR, sizeof( VAR) );\
+  return sizeof( VAR );
+
+size_t Variant::copyToBuffer(void* buffer)
+{
+  if (type == TYPE_CHAR)
+	{
+		MEMCPYRET( data._Char )
+	}
+	else if (type == TYPE_UCHAR)
+	{
+		MEMCPYRET( data._UChar )
+	}
+	else if (type == TYPE_INT16)
+	{
+		MEMCPYRET(data._Int16);
+	}
+	else if (type == TYPE_UINT16)
+	{
+		MEMCPYRET(data._UInt16);
+	}
+	else if (type == TYPE_INT32)
+	{
+		MEMCPYRET(data._Int32);
+	}
+	else if (type == TYPE_UINT32)
+	{
+		MEMCPYRET(data._UInt32);
+	}
+	else if (type == TYPE_INT64)
+	{
+		MEMCPYRET(data._Int64);
+	}
+	else if (type == TYPE_UINT64)
+	{
+		MEMCPYRET(data._UInt64);
+	}
+	else if (type == TYPE_FLOAT)
+	{
+		MEMCPYRET(data._Float);
+	}
+	else if (type == TYPE_DOUBLE)
+	{
+		MEMCPYRET(data._Double);
+	}
+	else if (type == TYPE_STRING)
+	{
+		size_t len = data._String->size();
+		memcpy(buffer, data._String->c_str(), len);
+		return len;
+	}
+	else if (type == TYPE_BOOL)
+	{
+		MEMCPYRET(data._Bool);
+	}
+	else if (type == TYPE_NONE)
+	{
+		return 0;
+	}
+	throw std::runtime_error("This is serious: Type not handled in copyToBuffer()!");
+};
+
+size_t Variant::getSize() const
+{
+  if (type == TYPE_CHAR)
+	{
+		return sizeof(data._Char);
+	}
+	else if (type == TYPE_UCHAR)
+	{
+		return sizeof(data._UChar);
+	}
+	else if (type == TYPE_INT16)
+	{
+		return sizeof(data._Int16);
+	}
+	else if (type == TYPE_UINT16)
+	{
+		return sizeof(data._UInt16);
+	}
+	else if (type == TYPE_INT32)
+	{
+		return sizeof(data._Int32);
+	}
+	else if (type == TYPE_UINT32)
+	{
+		return sizeof(data._UInt32);
+	}
+	else if (type == TYPE_INT64)
+	{
+		return sizeof(data._Int64);
+	}
+	else if (type == TYPE_UINT64)
+	{
+		return sizeof(data._UInt64);
+	}
+	else if (type == TYPE_FLOAT)
+	{
+		return sizeof(data._Float);
+	}
+	else if (type == TYPE_DOUBLE)
+	{
+		return sizeof(data._Double);
+	}
+	else if (type == TYPE_STRING)
+	{
+		size_t len = strlen(data._String->c_str()+1);
+		return len;
+	}
+	else if (type == TYPE_BOOL)
+	{
+		return sizeof(data._Bool);
+	}
+	else if (type == TYPE_NONE)
+	{
+		return 0;
+	}
+	throw std::runtime_error("This is serious: Type not handled in getSize()!");
+};
+
+
+
 } // namespace pxl

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -367,11 +367,11 @@ std::string Variant::toString() const
 	}
 	else if (type == TYPE_FLOAT)
 	{
-		sstr << data._Float;
+		sstr << std::scientific << data._Float;
 	}
 	else if (type == TYPE_DOUBLE)
 	{
-		sstr << data._Double;
+		sstr << std::scientific << data._Double;
 	}
 
 	return sstr.str();

--- a/src/module/Output.cpp
+++ b/src/module/Output.cpp
@@ -111,7 +111,7 @@ size_t Output::getCount() const {
 	return count;
 }
 
-void Output::enableProperty(const std::string &property, const Variant& defaultValue, const std::string &comment)
+void Output::enableProperty(const std::string &property, const Variant &defaultValue, const std::string &comment)
 {
 	modify();
 	Property prop;

--- a/src/module/Output.cpp
+++ b/src/module/Output.cpp
@@ -111,4 +111,14 @@ size_t Output::getCount() const {
 	return count;
 }
 
+void Output::enableProperty(const std::string &property, const Variant& defaultValue, const std::string &comment)
+{
+	modify();
+	Property prop;
+	prop.name = property;
+	prop.comment = comment;
+	prop.defaultValue = defaultValue;
+	properties.push_back(prop);
+}
+;
 } // namespace crpropa

--- a/src/module/TextOutput.cpp
+++ b/src/module/TextOutput.cpp
@@ -86,6 +86,11 @@ void TextOutput::printHeader() const {
 		*out << "\tX1\tY1\tZ1";
 	if (fields.test(CreatedDirectionColumn) && not oneDimensional)
 		*out << "\tP1x\tP1y\tP1z";
+	for(std::vector<Property>::const_iterator iter = properties.begin();
+			iter != properties.end(); ++iter)
+	{
+		*out << "\t" << (*iter).name;
+	}
 
 	*out << "\n#\n";
 	if (fields.test(TrajectoryLengthColumn))
@@ -108,12 +113,18 @@ void TextOutput::printHeader() const {
 			|| fields.test(CreatedDirectionColumn)
 			|| fields.test(SourceDirectionColumn))
 		*out << "# Px/P0x/P1x... Heading (unit vector of momentum)\n";
+	for(std::vector<Property>::const_iterator iter = properties.begin();
+			iter != properties.end(); ++iter)
+	{
+			*out << "# " << (*iter).name << " " << (*iter).comment << "\n";
+	}
+
 	*out
 			<< "# no index = current, 0 = at source, 1 = at point of creation\n#\n";
 }
 
 void TextOutput::process(Candidate *c) const {
-	if (fields.none())
+	if (fields.none() && properties.empty())
 		return;
 
 	char buffer[1024];
@@ -204,7 +215,21 @@ void TextOutput::process(Candidate *c) const {
 					pos.z);
 		}
 	}
-
+	for(std::vector<Output::Property>::const_iterator iter = properties.begin();
+			iter != properties.end(); ++iter)
+	{
+		  Variant v;
+			if (c->hasProperty((*iter).name))
+			{
+				v = c->getProperty((*iter).name);
+			}
+			else
+			{
+				v = (*iter).defaultValue;
+			}
+			p += sprintf(buffer + p, v.toString().c_str());
+			p += sprintf(buffer + p, "\t");
+	}
 	buffer[p - 1] = '\n';
 
 	std::locale::global(old_locale);

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -538,6 +538,28 @@ TEST(Variant, copyToBuffer)
 	EXPECT_EQ(a, b);
 }
 
+TEST(Variant, stringConversion)
+{
+	Variant v, w;
+	{
+		int32_t a = 12;
+		v = Variant::fromInt32(a);
+		EXPECT_EQ(a, v.asInt32());
+
+		w = Variant::fromString(v.toString(), v.getType());
+		EXPECT_EQ(a, w.asInt32());
+	}
+
+	{
+		int64_t a = 12;
+		v = Variant::fromInt64(a);
+		EXPECT_EQ(a, v.asInt64());
+
+		w = Variant::fromString(v.toString(), v.getType());
+		EXPECT_EQ(a, w.asInt64());
+	}
+}
+
 
 int main(int argc, char **argv) {
 	::testing::InitGoogleTest(&argc, argv);

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -529,6 +529,16 @@ TEST(EmissionMap, merge) {
 }
 
 
+TEST(Variant, copyToBuffer)
+{
+	double a = 23.42;
+	Variant v(a);
+	double b;
+	v.copyToBuffer(&b);
+	EXPECT_EQ(a, b);
+}
+
+
 int main(int argc, char **argv) {
 	::testing::InitGoogleTest(&argc, argv);
 	return RUN_ALL_TESTS();

--- a/test/testOutput.cpp
+++ b/test/testOutput.cpp
@@ -92,6 +92,21 @@ TEST(TextOutput, printHeader_Custom) {
 	          "#\tSN\tID\tE\tSN0\tID0\tE0\tSN1");
 }
 
+TEST(TextOutput, printProperty) {
+	Candidate c;
+	TextOutput output(Output::Event1D);
+	output.disableAll();
+	output.enableProperty("foo", 2.0, "Bar");
+
+	::testing::internal::CaptureStdout();
+	output.process(&c);
+	std::string captured = testing::internal::GetCapturedStdout();
+
+	// name in first line of header
+	EXPECT_EQ(captured.substr(0, captured.find("\n")),
+	          "#\tfoo");
+}
+
 //-- ParticleCollector
 
 TEST(ParticleCollector, getCount) {


### PR DESCRIPTION
Candidate properties can be added to Text and HDF Output as follos:

```python
import crpropa

output1 = crpropa.HDF5Output('test.h5')
output2 = crpropa.TextOutput('test.txt')

# enableProperty(NAMEOFTHEPROPERTY, DEFAULTVALUE, COMMENT="")
output1.enableProperty('bool', False, "Foo Bar Spam and Eggs")
output1.enableProperty('int', 23)
output1.enableProperty('float', 42.23)
output1.enableProperty('string', "WTF") # For strings the default value defines the maximum size of the string in HDF5!

output2.enableProperty('bool', False, "Foo Bar Spam and Eggs")
output2.enableProperty('int', 23)
output2.enableProperty('float', 42.23)
output2.enableProperty('string', "WTF") 

c = crpropa.Candidate()
for i in range(5):
    c.setProperty('int', i+12)
    output1.process(c)
    output2.process(c)

output1.close()
output2.close()
```