### PR TITLE
Geometry system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,7 @@ add_library(crpropa SHARED
 	src/module/PhotonOutput1D.cpp
 	src/module/PropagationCK.cpp
 	src/module/Redshift.cpp
+	src/module/RestrictToRegion.cpp
 	src/module/SimplePropagation.cpp
 	src/module/SynchrotronRadiation.cpp
 	src/module/TextOutput.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,7 @@ add_library(crpropa SHARED
 	src/Common.cpp
 	src/Cosmology.cpp
 	src/EmissionMap.cpp
+	src/Geometry.cpp
 	src/GridTools.cpp
 	src/Module.cpp
 	src/ModuleList.cpp

--- a/include/CRPropa.h
+++ b/include/CRPropa.h
@@ -46,6 +46,7 @@
 #include "crpropa/module/PhotonOutput1D.h"
 #include "crpropa/module/PropagationCK.h"
 #include "crpropa/module/Redshift.h"
+#include "crpropa/module/RestrictToRegion.h"
 #include "crpropa/module/SimplePropagation.h"
 #include "crpropa/module/SynchrotronRadiation.h"
 #include "crpropa/module/TextOutput.h"

--- a/include/CRPropa.h
+++ b/include/CRPropa.h
@@ -6,6 +6,7 @@
 #include "crpropa/Common.h"
 #include "crpropa/Cosmology.h"
 #include "crpropa/EmissionMap.h"
+#include "crpropa/Geometry.h"
 #include "crpropa/Grid.h"
 #include "crpropa/GridTools.h"
 #include "crpropa/Logging.h"

--- a/include/crpropa/Geometry.h
+++ b/include/crpropa/Geometry.h
@@ -1,0 +1,99 @@
+#ifndef GEOMETRY_H
+#define GEOMETRY_H
+
+#include <vector>
+
+#include "crpropa/Candidate.h"
+#include "crpropa/Vector3.h"
+
+namespace crpropa
+{
+/**
+ * \addtogroup Core
+ * @{
+ */
+
+/**
+ @class Surface
+ @brief A geometrical surface
+
+ Defines a surface. Can be queried if the candidate has crossed the surface in the last step.
+ */
+
+class Surface
+{
+	public:
+
+	/**
+		Returns the distance of a point to the surface. Negative on the one side,
+		positive on the other. For closed surfaces it is negative on the inside.
+	 */
+    virtual double distance(const Vector3d& point) const = 0;
+};
+
+/**
+ @class Plane
+ @brief A plane given by a point x0 and two axes v1 and v2 with normal n = v1.cross(v2) or the normal n. Note that distance is negative on one side of the plane and positive on the other, depending on the orientation of the normal vector.
+ */
+class Plane: public Surface
+{
+	private:
+		Vector3d x0, n;
+	public:
+		Plane(const Vector3d& _x0, const Vector3d& v1,const Vector3d& v2);
+		Plane(const Vector3d& _x0, const Vector3d& _n);
+    virtual double distance(const Vector3d &x) const;
+};
+
+
+/**
+ @class Sphere
+ @brief A sphere around point _center with radius _radius.
+ */
+class Sphere: public Surface
+{
+	private:
+		Vector3d center;
+		double radius;
+	public:
+		Sphere(const Vector3d& _center, double _radius);
+    virtual double distance(const Vector3d &point) const;
+};
+
+
+///**
+// @class Box
+// @brief A box with arbitrary orientation and not necessarily perpendicular surfaces (Rhombohedron). For performance reasons use the ParaxialBox if applicable.
+// */
+//class Box: public Surface
+//{
+//	private:
+//		Vector3d corner, x1, x2, x3, u, v, w;
+//		std::vector<Plane> facets;
+//		double A,B,C;
+//	public:
+//		Box(const Vector3d& _corner, const Vector3d& _x1,const Vector3d& _x2, const Vector3d& _x3);
+//    virtual double distance(const Vector3d &point) const;
+//};
+
+
+/**
+ @class ParaxialBox
+ @brief A box with arbitrary orientation and not necessarily perpendicular surfaces (Rhombohedron)
+ */
+class ParaxialBox: public Surface
+{
+	private:
+		Vector3d corner, size;
+	public:
+		ParaxialBox(const Vector3d& _corner, const Vector3d& _size);
+    virtual double distance(const Vector3d &point) const;
+};
+
+
+
+
+/** @}*/
+} // namespace crpropa
+
+#endif // GEOMETRY_H

--- a/include/crpropa/Geometry.h
+++ b/include/crpropa/Geometry.h
@@ -2,9 +2,11 @@
 #define GEOMETRY_H
 
 #include <vector>
+#include <string>
 
 #include "crpropa/Candidate.h"
 #include "crpropa/Vector3.h"
+#include "crpropa/Referenced.h"
 
 namespace crpropa
 {
@@ -20,7 +22,7 @@ namespace crpropa
  Defines a surface. Can be queried if the candidate has crossed the surface in the last step.
  */
 
-class Surface
+class Surface : public Referenced
 {
 	public:
 
@@ -29,6 +31,7 @@ class Surface
 		positive on the other. For closed surfaces it is negative on the inside.
 	 */
     virtual double distance(const Vector3d& point) const = 0;
+		virtual std::string getDescription() const {return "Surface without description.";};
 };
 
 /**
@@ -43,6 +46,7 @@ class Plane: public Surface
 		Plane(const Vector3d& _x0, const Vector3d& v1,const Vector3d& v2);
 		Plane(const Vector3d& _x0, const Vector3d& _n);
     virtual double distance(const Vector3d &x) const;
+		virtual std::string getDescription() const;
 };
 
 
@@ -58,6 +62,7 @@ class Sphere: public Surface
 	public:
 		Sphere(const Vector3d& _center, double _radius);
     virtual double distance(const Vector3d &point) const;
+		virtual std::string getDescription() const;
 };
 
 
@@ -88,6 +93,7 @@ class ParaxialBox: public Surface
 	public:
 		ParaxialBox(const Vector3d& _corner, const Vector3d& _size);
     virtual double distance(const Vector3d &point) const;
+		virtual std::string getDescription() const;
 };
 
 

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -10,6 +10,7 @@
 #include "../Module.h"
 #include "../Referenced.h"
 #include "../Vector3.h"
+#include "../Geometry.h"
 
 namespace crpropa {
 
@@ -65,6 +66,21 @@ class ObserverDetectAll: public ObserverFeature {
 public:
 	DetectionState checkDetection(Candidate *candidate) const;
 	std::string getDescription() const;
+};
+
+
+/**
+ @class ObserverSurface
+ @brief Detects particles crossing the durface
+ */
+class ObserverSurface: public ObserverFeature {
+	private:
+		ref_ptr<Surface> surface;
+
+	public:
+		ObserverSurface(Surface* _surface);
+		DetectionState checkDetection(Candidate *candidate) const;
+		std::string getDescription() const;
 };
 
 /**

--- a/include/crpropa/module/RestrictToRegion.h
+++ b/include/crpropa/module/RestrictToRegion.h
@@ -1,6 +1,10 @@
+#ifndef CRPROPA_RESTRICTTOREGION_H
+#define CRPROPA_RESTRICTTOREGION_H
+
 #include "crpropa/Referenced.h"
+#include "crpropa/Candidate.h"
 #include "crpropa/Module.h"
-#include "crpropa/Surface.h"
+#include "crpropa/Geometry.h"
 
 namespace crpropa {
 /**
@@ -16,9 +20,9 @@ namespace crpropa {
 class RestrictToRegion: public Module {
 private:
 	ref_ptr<Surface> surface;
-	ref_ptr<module> module;
+	ref_ptr<Module> module;
 public:
-	RestrictToRegion(ref_ptr<Module> _module, ref_ptr<Surface> _surface);
+	RestrictToRegion(Module* _module, Surface* _surface);
 	void process(Candidate *candidate) const;
 	std::string getDescription() const;
 };
@@ -27,3 +31,4 @@ public:
 
 } // namespace crpropa
 
+#endif // CRPROPA_RESTRICTTOREGION_H

--- a/include/crpropa/module/RestrictToRegion.h
+++ b/include/crpropa/module/RestrictToRegion.h
@@ -1,0 +1,29 @@
+#include "crpropa/Referenced.h"
+#include "crpropa/Module.h"
+#include "crpropa/Surface.h"
+
+namespace crpropa {
+/**
+ * \addtogroup Condition
+ * @{
+ */
+
+/**
+ @class RestrictToRegion
+ @brief Limit Module to region in simulation.
+
+ */
+class RestrictToRegion: public Module {
+private:
+	ref_ptr<Surface> surface;
+	ref_ptr<module> module;
+public:
+	RestrictToRegion(ref_ptr<Module> _module, ref_ptr<Surface> _surface);
+	void process(Candidate *candidate) const;
+	std::string getDescription() const;
+};
+
+/** @}*/
+
+} // namespace crpropa
+

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -405,6 +405,7 @@
 %include "crpropa/module/PhotoDisintegration.h"
 %include "crpropa/module/ElasticScattering.h"
 %include "crpropa/module/Redshift.h"
+%include "crpropa/module/RestrictToRegion.h"
 %include "crpropa/module/EMPairProduction.h"
 %include "crpropa/module/EMDoublePairProduction.h"
 %include "crpropa/module/EMTripletPairProduction.h"

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -267,6 +267,9 @@
 %template(CandidateRefPtr) crpropa::ref_ptr<crpropa::Candidate>;
 %include "crpropa/Candidate.h"
 
+%feature("director") crpropa::Surface;
+%feature("director") crpropa::ClosedSurface;
+%include "crpropa/Geometry.h"
 
 %template(ModuleRefPtr) crpropa::ref_ptr<crpropa::Module>;
 %template(stdModuleList) std::list< crpropa::ref_ptr<crpropa::Module> >;

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -1,0 +1,51 @@
+#include <limits>
+#include <cmath>
+#include "kiss/logger.h"
+#include "crpropa/Geometry.h"
+
+namespace crpropa
+{
+Plane::Plane(const Vector3d& _x0, const Vector3d& _n) : x0(_x0), n(_n) {};
+
+Plane::Plane(const Vector3d& _x0, const Vector3d& v1,const Vector3d& v2) : x0(_x0), n(0,0,0)
+{
+	n = v1.cross(v2);
+	n /= n.getR();
+};
+
+double Plane::distance(const Vector3d &x) const
+{
+	Vector3d dX = x - x0;
+	return n.dot(dX);
+};
+
+
+Sphere::Sphere(const Vector3d& _center, double _radius) : center(_center), radius(_radius) {};
+double Sphere::distance(const Vector3d &point) const
+{
+	Vector3d dR = point - center;
+	return dR.getR() - radius;
+}
+
+
+ParaxialBox::ParaxialBox(const Vector3d& _corner, const Vector3d& _size) : corner(_corner), size(_size) {};
+double ParaxialBox::distance(const Vector3d &point) const
+{
+	Vector3d X = point - corner - size/2.;
+
+	if ((fabs(X.x) <= size.x/2.) and (fabs(X.y) <= size.y/2.) and (fabs(X.z) <= size.z/2.))
+	{ // inside the cube
+		Vector3d Xp = size/2. - X.abs();
+		double d = Xp.min();
+		return -1. * d;
+	}
+
+	double a = std::max(0., fabs(X.x) - size.x/2.);
+	double b = std::max(0., fabs(X.y) - size.y/2.);
+	double c = std::max(0., fabs(X.z) - size.z/2.);
+
+	return sqrt(a*a + b*b +c*c);
+}
+
+
+} // namespace

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -3,6 +3,7 @@
 #include "kiss/logger.h"
 #include "crpropa/Geometry.h"
 
+#include <iostream>
 namespace crpropa
 {
 Plane::Plane(const Vector3d& _x0, const Vector3d& _n) : x0(_x0), n(_n) {};
@@ -19,6 +20,15 @@ double Plane::distance(const Vector3d &x) const
 	return n.dot(dX);
 };
 
+std::string Plane::getDescription() const
+{
+	std::stringstream ss;
+	ss << "Plane: " << std::endl
+		 << "   x0: " << x0 << std::endl
+		 << "    n: " << n << std::endl;
+	return ss.str();
+};
+
 
 Sphere::Sphere(const Vector3d& _center, double _radius) : center(_center), radius(_radius) {};
 double Sphere::distance(const Vector3d &point) const
@@ -26,6 +36,15 @@ double Sphere::distance(const Vector3d &point) const
 	Vector3d dR = point - center;
 	return dR.getR() - radius;
 }
+
+std::string Sphere::getDescription() const
+{
+	std::stringstream ss;
+	ss << "Sphere: " << std::endl
+		 << "   Center: " << center << std::endl
+		 << "   Radius: " << radius << std::endl;
+	return ss.str();
+};
 
 
 ParaxialBox::ParaxialBox(const Vector3d& _corner, const Vector3d& _size) : corner(_corner), size(_size) {};
@@ -46,6 +65,14 @@ double ParaxialBox::distance(const Vector3d &point) const
 
 	return sqrt(a*a + b*b +c*c);
 }
+std::string ParaxialBox::getDescription() const
+{
+	std::stringstream ss;
+	ss << "ParaxialBox: " << std::endl
+		 << "   corner: " << corner << std::endl
+		 << "     size: " << size << std::endl;
+	return ss.str();
+};
 
 
 } // namespace

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -3,7 +3,10 @@
 #include "crpropa/ParticleID.h"
 #include "crpropa/Cosmology.h"
 
+#include "kiss/logger.h"
+
 #include <iostream>
+#include <cmath>
 
 namespace crpropa {
 
@@ -98,6 +101,7 @@ std::string ObserverDetectAll::getDescription() const {
 // ObserverSmallSphere --------------------------------------------------------
 ObserverSmallSphere::ObserverSmallSphere(Vector3d center, double radius) :
 		center(center), radius(radius) {
+			KISS_LOG_WARNING << "ObserverSmallSphere deprecated and will be removed in the future. Replace with ObserverSurface( Sphere(center, radius)).";
 }
 
 DetectionState ObserverSmallSphere::checkDetection(Candidate *candidate) const {
@@ -176,6 +180,7 @@ std::string ObserverTracking::getDescription() const {
 // ObserverLargeSphere --------------------------------------------------------
 ObserverLargeSphere::ObserverLargeSphere(Vector3d center, double radius) :
 		center(center), radius(radius) {
+		KISS_LOG_WARNING << "ObserverLargeSphere deprecated and will be removed in the future. Replace with ObserverSurface( Sphere(center, radius) ).";
 }
 
 DetectionState ObserverLargeSphere::checkDetection(Candidate *candidate) const {
@@ -371,5 +376,27 @@ std::string ObserverTimeEvolution::getDescription() const {
 	  s << "  - " << detList[i] / kpc;
 	return s.str();
 }
+
+ObserverSurface::ObserverSurface(Surface* _surface) : surface(_surface) { };
+
+DetectionState ObserverSurface::checkDetection(Candidate *candidate) const
+{
+		double currentDistance = surface->distance(candidate->current.getPosition());
+		double previousDistance = surface->distance(candidate->previous.getPosition());
+		candidate->limitNextStep(fabs(currentDistance));
+
+		if (currentDistance * previousDistance > 0)
+			return NOTHING;
+		else if (previousDistance == 0)
+			return NOTHING;
+		else
+			return DETECTED;
+};
+
+std::string ObserverSurface::getDescription() const {
+	std::stringstream ss;
+	ss << "ObserverSurface: << " << surface->getDescription();
+	return ss.str();
+};
 
 } // namespace crpropa

--- a/src/module/RestrictToRegion.cpp
+++ b/src/module/RestrictToRegion.cpp
@@ -1,14 +1,16 @@
 #include <sstream>
+#include "crpropa/module/RestrictToRegion.h" 
 
-#include "crpropa/RestrictToRegion.h" 
+namespace crpropa {
 
-RestrictToRegion::RestrictToRegion(ref_ptr<Module> _module, ref_ptr<Surface> _surface) : module(_module), _surface(surface) { };
-	void RestrictToRegion::process(Candidate *candidate) const
+  RestrictToRegion::RestrictToRegion(Module* _module, Surface* _surface) : module(_module), surface(_surface) { };
+
+void RestrictToRegion::process(Candidate *candidate) const
 {
-	if (surface->distance(candidate->current.getPosition()) <=0)
-	{
-		module->process(candidate);
-	}
+if (surface->distance(candidate->current.getPosition()) <=0)
+{
+  module->process(candidate);
+}
 
 };
 
@@ -16,9 +18,10 @@ std::string RestrictToRegion::getDescription() const
 {
 	std::stringstream s;
 	s << "RestrictToArea:\n"
-		<< "  Module: " << module.getDescription() << std::endl
-		<< "  Region: " << surface.getDescription() << std::endl;
-	return s.str()
+		<< "  Module: " << module->getDescription() << std::endl
+		<< "  Region: " << surface->getDescription() << std::endl;
+	return s.str();
 };
 
 
+} // namespace crpropa

--- a/src/module/RestrictToRegion.cpp
+++ b/src/module/RestrictToRegion.cpp
@@ -1,0 +1,24 @@
+#include <sstream>
+
+#include "crpropa/RestrictToRegion.h" 
+
+RestrictToRegion::RestrictToRegion(ref_ptr<Module> _module, ref_ptr<Surface> _surface) : module(_module), _surface(surface) { };
+	void RestrictToRegion::process(Candidate *candidate) const
+{
+	if (surface->distance(candidate->current.getPosition()) <=0)
+	{
+		module->process(candidate);
+	}
+
+};
+
+std::string RestrictToRegion::getDescription() const
+{
+	std::stringstream s;
+	s << "RestrictToArea:\n"
+		<< "  Module: " << module.getDescription() << std::endl
+		<< "  Region: " << surface.getDescription() << std::endl;
+	return s.str()
+};
+
+

--- a/test/testBreakCondition.cpp
+++ b/test/testBreakCondition.cpp
@@ -4,6 +4,7 @@
 #include "crpropa/module/Observer.h"
 #include "crpropa/module/Boundary.h"
 #include "crpropa/module/Tools.h"
+#include "crpropa/module/RestrictToRegion.h"
 #include "crpropa/ParticleID.h"
 #include "crpropa/Geometry.h"
 
@@ -412,6 +413,23 @@ TEST(CylindricalBoundary, limitStep) {
 	cylinder.process(&c);
 	EXPECT_DOUBLE_EQ(c.getNextStep(), 1.5);
 }
+
+TEST(RestrictToRegion, RestrictToRegion) {
+
+	ref_ptr<Observer> obs = new Observer();
+	obs->add(new ObserverDetectAll());
+	RestrictToRegion R(obs, new Sphere(Vector3d(0, 0, 0), 10));
+
+	Candidate c;
+	c.previous.setPosition(Vector3d(13,0,0));
+	c.current.setPosition(Vector3d(12,0,0));
+	R.process(&c);
+	EXPECT_TRUE(c.isActive());
+	c.current.setPosition(Vector3d(9,0,0));
+	R.process(&c);
+	EXPECT_FALSE(c.isActive());
+}
+
 
 int main(int argc, char **argv) {
 	::testing::InitGoogleTest(&argc, argv);

--- a/test/testBreakCondition.cpp
+++ b/test/testBreakCondition.cpp
@@ -5,6 +5,7 @@
 #include "crpropa/module/Boundary.h"
 #include "crpropa/module/Tools.h"
 #include "crpropa/ParticleID.h"
+#include "crpropa/Geometry.h"
 
 #include "gtest/gtest.h"
 
@@ -89,7 +90,7 @@ TEST(DetectionLength, test) {
 TEST(ObserverFeature, SmallSphere) {
 	// detect if the current position is inside and the previous outside of the sphere
 	Observer obs;
-	obs.add(new ObserverSmallSphere(Vector3d(0, 0, 0), 1));
+	obs.add(new ObserverSurface(new Sphere (Vector3d(0, 0, 0), 1)));
 	Candidate c;
 	c.setNextStep(10);
 
@@ -100,7 +101,7 @@ TEST(ObserverFeature, SmallSphere) {
 	EXPECT_TRUE(c.isActive());
 
 	// limit step
-	EXPECT_NEAR(c.getNextStep(), 0.436, 0.001);
+	EXPECT_NEAR(c.getNextStep(), 0.1, 0.001);
 
 	// detection: particle just entered
 	c.current.setPosition(Vector3d(0.9, 0, 0));
@@ -112,7 +113,7 @@ TEST(ObserverFeature, SmallSphere) {
 TEST(ObserverFeature, LargeSphere) {
 	// detect if the current position is outside and the previous inside of the sphere
 	Observer obs;
-	obs.add(new ObserverLargeSphere(Vector3d(0, 0, 0), 10));
+	obs.add(new ObserverSurface(new Sphere (Vector3d(0, 0, 0), 10)));
 	Candidate c;
 	c.setNextStep(10);
 

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -13,6 +13,7 @@
 #include "crpropa/Random.h"
 #include "crpropa/Grid.h"
 #include "crpropa/GridTools.h"
+#include "crpropa/Geometry.h"
 #include "crpropa/EmissionMap.h"
 
 #include <HepPID/ParticleIDMethods.hh>
@@ -558,6 +559,31 @@ TEST(Variant, stringConversion)
 	}
 }
 
+
+TEST(Geometry, Plane)
+{
+	Plane p(Vector3d(0,0,1), Vector3d(0,0,1));
+	EXPECT_DOUBLE_EQ(-1., p.distance(Vector3d(0, 0, 0)));
+	EXPECT_DOUBLE_EQ(9., p.distance(Vector3d(1, 1, 10)));
+}
+
+TEST(Geometry, Sphere)
+{
+	Sphere s(Vector3d(0,0,0), 1.);
+	EXPECT_DOUBLE_EQ(-1., s.distance(Vector3d(0, 0, 0)));
+	EXPECT_DOUBLE_EQ(9., s.distance(Vector3d(10, 0, 0)));
+}
+
+TEST(Geometry, ParaxialBox)
+{
+	ParaxialBox b(Vector3d(0,0,0), Vector3d(3,4,5));
+	EXPECT_NEAR(-.1, b.distance(Vector3d(0.1, 0.1, 0.1)), 1E-10);
+	EXPECT_NEAR(-.1, b.distance(Vector3d(0.1, 3.8, 0.1)), 1E-10);
+	EXPECT_NEAR(-.2, b.distance(Vector3d(0.9, 3.8, 0.9)), 1E-10);
+	EXPECT_NEAR(7., b.distance(Vector3d(10., 0., 0.)), 1E-10);
+	EXPECT_NEAR(7., b.distance(Vector3d(10., 2., 0.)), 1E-10);
+	EXPECT_NEAR(8., b.distance(Vector3d(-8., 0., 0.)), 1E-10);
+}
 
 int main(int argc, char **argv) {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
I added a small geometry system that is mainly useful for the acceleration simulations, but can also be used in other parts of CRPropa.  I introduced an abstract base class `Surface` with implementations `Sphere`, `Plane` and `ParaxialBox`. Each `Surface` has a method `distance` that returns the closest distance of a point to the surface. For bounded surfaces the distance is
negative on the inside.

This is used in a new Module `RestrictToRegion` that restricts module executions to certain regions e.g.
```
sim.add( RestricToRegion( SecondOrderFermiAcceleration(), Sphere( Vector3d(0,0,0), 10) ))
```
This is used for the implementation of the acceleration simulation.

I also introduced a new `ObserverFeature`, `ObserverSurface`, that detects a candidate crossing the surface. It can be used e.g. as follows:
```
obs = Observer()
obs.add( ObserverSurface( Plane( Vector3d(0, 0, 0), Vector3d(0, 0, 1) ) ))
```
to define an observer in the xy plane (normal vector 0,0,1).

This potentially deprecates the `ObserverSmallSphere` and `ObserverLargeSphere` as
```
obs.add( ObserverSurface( Sphere( Vector3d(0,0,0), 10 )))
```

can be used for both depending on the source position. I already added according deprecation warnings. Also the tracking observer can be updated in the future to work with arbitrary geometries.