### PR TITLE
Add a modified, smoothed and solenoidal JF12 Galactic magnetic field

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,7 @@ add_library(crpropa SHARED
 	src/module/AdiabaticCooling.cpp
 	src/module/Tools.cpp
 	src/magneticField/JF12Field.cpp
+	src/magneticField/JF12FieldSolenoidal.cpp
 	src/magneticField/MagneticField.cpp
 	src/magneticField/MagneticFieldGrid.cpp
 	src/magneticField/PT11Field.cpp

--- a/include/CRPropa.h
+++ b/include/CRPropa.h
@@ -55,6 +55,7 @@
 
 #include "crpropa/magneticField/AMRMagneticField.h"
 #include "crpropa/magneticField/JF12Field.h"
+#include "crpropa/magneticField/JF12FieldSolenoidal.h"
 #include "crpropa/magneticField/MagneticField.h"
 #include "crpropa/magneticField/MagneticFieldGrid.h"
 #include "crpropa/magneticField/PT11Field.h"

--- a/include/crpropa/magneticField/JF12Field.h
+++ b/include/crpropa/magneticField/JF12Field.h
@@ -3,6 +3,7 @@
 
 #include "crpropa/magneticField/MagneticField.h"
 #include "crpropa/Grid.h"
+#include "kiss/logger.h"
 
 namespace crpropa {
 
@@ -23,17 +24,23 @@ namespace crpropa {
  The field is defined in the usual galactocentric coordinate system with the
  Galactic center at the origin, the x-axis pointing in the opposite direction of
  the Sun, and the z-axis pointing towards Galactic north.
+
+ The regular field components (disk, toroidal halo and polodial halo field) 
+ may be turned on and off individually for tests.
  */
 class JF12Field: public MagneticField {
-private:
+protected:
 	bool useRegular;
 	bool useStriated;
 	bool useTurbulent;
+	bool useDiskField;
+	bool useToroidalHaloField;
+	bool useXField;
 
 	// disk spiral arms
 	double rArms[8];       // radii where each arm crosses the negative x-axis
 	double pitch;          // pitch angle
-	double sinPitch, cosPitch, tan90MinusPitch;
+	double sinPitch, cosPitch, tanPitch, cotPitch, tan90MinusPitch;
 
 	// Regular field ----------------------------------------------------------
 	// disk
@@ -47,7 +54,7 @@ private:
 	// poloidal halo
 	double bX;             // field strength at origin
 	double thetaX0;        // constant elevation angle at r > rXc, z = 0
-	double sinThetaX0, cosThetaX0, tanThetaX0;
+	double sinThetaX0, cosThetaX0, tanThetaX0, cotThetaX0;
 	double rXc;            // radius of varying elevation angle region
 	double rX;             // exponential scale height
 
@@ -93,17 +100,26 @@ public:
 	ref_ptr<VectorGrid> getTurbulentGrid();
 
 	void setUseRegular(bool use);
-	void setUseStriated(bool use);
-	void setUseTurbulent(bool use);
+	virtual void setUseStriated(bool use);
+	virtual void setUseTurbulent(bool use);
+	void setUseDiskField(bool use);
+	void setUseToroidalHaloField(bool use);
+	void setUseXField(bool use);
 
 	bool isUsingRegular();
 	bool isUsingStriated();
 	bool isUsingTurbulent();
-	
-	double logisticFunction(const double x, const double x0, const double w) const;
+	bool isUsingDiskField();
+	bool isUsingToroidalHaloField();
+	bool isUsingXField();
 
-	// Regular field component
+	double logisticFunction(const double& x, const double& x0, const double& w) const;
+
+	// Regular field components
 	Vector3d getRegularField(const Vector3d& pos) const;
+	virtual Vector3d getDiskField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const;
+	Vector3d getToroidalHaloField(const double& r, const double& z, const double& sinPhi, const double& cosPhi) const;
+	virtual Vector3d getXField(const double& r, const double& z, const double& sinPhi, const double& cosPhi) const;
 
 	// Regular and striated field component
 	Vector3d getStriatedField(const Vector3d& pos) const;

--- a/include/crpropa/magneticField/JF12Field.h
+++ b/include/crpropa/magneticField/JF12Field.h
@@ -99,6 +99,8 @@ public:
 	bool isUsingRegular();
 	bool isUsingStriated();
 	bool isUsingTurbulent();
+	
+	double logisticFunction(const double x, const double x0, const double w) const;
 
 	// Regular field component
 	Vector3d getRegularField(const Vector3d& pos) const;

--- a/include/crpropa/magneticField/JF12Field.h
+++ b/include/crpropa/magneticField/JF12Field.h
@@ -26,13 +26,13 @@ namespace crpropa {
  the Sun, and the z-axis pointing towards Galactic north.
 
  The regular field components (disk, toroidal halo and polodial halo field) 
- may be turned on and off individually for tests.
+ may be turned on and off individually.
  */
 class JF12Field: public MagneticField {
 protected:
-	bool useRegular;
-	bool useStriated;
-	bool useTurbulent;
+	bool useRegularField;
+	bool useStriatedField;
+	bool useTurbulentField;
 	bool useDiskField;
 	bool useToroidalHaloField;
 	bool useXField;
@@ -44,7 +44,7 @@ protected:
 
 	// Regular field ----------------------------------------------------------
 	// disk
-	double bDisk[8];       // field strengths of arms at r=5 kpc
+	double bDisk[11];      // field strengths of the 8 arms at r=5 kpc; additional entries added for periodic closure in JF12FieldSolenoidal
 	double bRing;          // ring field strength 3<r<5 kpc
 	double hDisk, wDisk;   // disk/halo transistion and width
 	// toroidal halo
@@ -99,16 +99,16 @@ public:
 	ref_ptr<ScalarGrid> getStriatedGrid();
 	ref_ptr<VectorGrid> getTurbulentGrid();
 
-	void setUseRegular(bool use);
-	virtual void setUseStriated(bool use);
-	virtual void setUseTurbulent(bool use);
+	void setUseRegularField(bool use);
+	virtual void setUseStriatedField(bool use);
+	virtual void setUseTurbulentField(bool use);
 	void setUseDiskField(bool use);
 	void setUseToroidalHaloField(bool use);
 	void setUseXField(bool use);
 
-	bool isUsingRegular();
-	bool isUsingStriated();
-	bool isUsingTurbulent();
+	bool isUsingRegularField();
+	bool isUsingStriatedField();
+	bool isUsingTurbulentField();
 	bool isUsingDiskField();
 	bool isUsingToroidalHaloField();
 	bool isUsingXField();

--- a/include/crpropa/magneticField/JF12FieldSolenoidal.h
+++ b/include/crpropa/magneticField/JF12FieldSolenoidal.h
@@ -1,7 +1,7 @@
 #ifndef CRPROPA_JF12FIELDSOLENOIDAL_H
 #define CRPROPA_JF12FIELDSOLENOIDAL_H
 
-#include "crpropa/magneticField/MagneticField.h"
+#include "crpropa/magneticField/JF12Field.h"
 #include "crpropa/Grid.h"
 #include <crpropa/Units.h>
 
@@ -10,181 +10,85 @@ namespace crpropa {
 /**
  @class JF12FieldSolenoidal
  @brief JF12FieldSolenoidal galactic magnetic field model
- 
+
  Implements a modified JF2012 magnetic field model, see documentation of JF12Field for basics.
- 
+ This implemementation inherits most methods and variables from the initial JF12Field, 
+ just the regular disk and X field are altered.
+
  A solenoidal ring-spiral transition (of width delta = 3 kpc per default) for the disk field
  and a smooth X-field at z = 0 (parabolic field lines for abs(z) < zs; zs = 500 parsec per default)
  were added in order to smooth the field and avoid violations of magnetic flux conservation, see:
  Kleimann et al, 2018, arXiv:1809.07528, Solenoidal improvements for the JF12 Galactic magnetic field model.
- 
- The regular field components (disk, toroidal halo and polodial halo field) 
- may be turned on and off individually for tests.
- 
+
  The turbulent field component is the exact same as in the initial JF12 implementation
  and should be used with care since the new regular and old turbulent field
  do not match in the ring-spiral transition region.
  */
  
-class JF12FieldSolenoidal: public MagneticField {
+class JF12FieldSolenoidal: public JF12Field {
 private:
 
-	// allow for enabling and disabling of the individual components
-	bool useRegular;
-	bool useStriated;
-	bool useTurbulent;
-	
-	bool useDisk;
-	bool useToroidalHalo;
-	bool useX;
-	
-	// height paramter of the modified X-field
+	// height parameter of the modified X-field, field lines are parabolic for fabs(z) < zS
 	double zS;
-	
-	// disk spiral arms
-	double rArms[8]; // radii where each arm crosses the negative x-axis
-	
-	// angles at which the dividing spirals intersect the r1-ring, 
-	// longer array due to cyclicity
+
+	// angles at which the dividing 8 spirals of the disk field intersect the (r1 = 5kpc)-ring, 
+	// longer array due to cyclic closure of the values
 	double phi0Arms[11];
-	
-	// lower bound for phi integration
+
+	// lower bound for phi integration, somewhat arbitrary parameter
 	double phi0;
-	// corresponding index in phi0Arms
+	// corresponding index in phi0Arms such that phi0Arms[idx0-1] < phi0 < phi0Arms[idx0]
 	int idx0;
-	
+
 	// phi integration H(phi) = phiCoeff[j] + bDisk[j] * phi
 	double phiCoeff[10]; // for phi0Arms[j-1] < phi < phi0Arms[j], hence only 10
 	double corr; // correction term enforcing H(phi0) = 0
-	
-	// inner and outer boundaries of disk field
-	double r1; 
+
+	// inner and outer boundaries of disk field at r = 5 and 20 kpc
+	double r1;
 	double r2;
 	
-	// transitions region boundaries of disk field
+	// transitions region boundaries of disk field at r1 + delta, r2 - delta
 	double r1s;
 	double r2s;
-	
-	double pitch;          // pitch angle
-	double sinPitch, cosPitch, tanPitch, cotPitch, tan90MinusPitch;
 
-	// Regular field ----------------------------------------------------------
-	// disk
-	double bDisk[11];       // field strengths of arms at r=5 kpc
-	double bRing;          // ring field strength 3<r<5 kpc
-	double hDisk, wDisk;   // disk/halo transistion and width
-	// toroidal halo
-	double bNorth, bSouth; // northern, southern halo field strength
-	double rNorth, rSouth; // northern, southern transistion radius
-	double wHalo, z0;      // transistion width and vertical scale height
-	// poloidal halo
-	double bX;             // field strength at origin
-	double thetaX0;        // constant elevation angle at r > rXc, z = 0
-	double sinThetaX0, cosThetaX0, tanThetaX0, cotThetaX0;
-	double rXc;            // radius of varying elevation angle region
-	double rX;             // exponential scale height
-
-	// Striated field ---------------------------------------------------------
-	double sqrtbeta;       // relative strength of striated field
-	ref_ptr<ScalarGrid> striatedGrid;
-
-	// Turbulent field --------------------------------------------------------
-	ref_ptr<VectorGrid> turbulentGrid;
-	// disk
-	double bDiskTurb[8]; // field strengths in arms at r=5 kpc
-	double bDiskTurb5;   // field strength at r<5kpc
-	double zDiskTurb;	 // Gaussian scale height of disk
-	// halo
-	double bHaloTurb; // halo field strength
-	double rHaloTurb; // exponential scale length
-	double zHaloTurb; // Gaussian scale height
+	// initial JF12 field strengths of the 8 spiral arms  (index 1 to 8) at r = 5 kpc,
+	// cyclically closed s.t. b[0] = b[8], b[9] = b[1], b[10] = b[2]
+	double bDiskCyclicClosure[11]; 
 
 public:
-
-	JF12FieldSolenoidal(double delta=(3*kpc), double zs=(0.5*kpc));
-
-	// Create and set a random realization for the striated field
-	void randomStriated(int seed = 0);
-
-#ifdef CRPROPA_HAVE_FFTW3F
-	// Create a random realization for the turbulent field
-	void randomTurbulent(int seed = 0);
-#endif
-
-	/**
-	 * Set a striated grid and activate the striated field component
-	 * @param grid	scalar grid containing random +1/-1 values, 100 parsec grid spacing
-	 */
-	void setStriatedGrid(ref_ptr<ScalarGrid> grid);
-
-	/**
-	 * Set a turbulent grid and activate the turbulent field component
-	 * @param grid	vector grid containing a random field of Brms = 1
-	 */
-	void setTurbulentGrid(ref_ptr<VectorGrid> grid);
-
-	ref_ptr<ScalarGrid> getStriatedGrid();
-	ref_ptr<VectorGrid> getTurbulentGrid();
-
-	void setUseRegular(bool use);
-	void setUseStriated(bool use);
+	JF12FieldSolenoidal(double delta= 3 * kpc, double zs= 0.5 * kpc);
+	
+	void setUseStriated(bool use); // override these for correct warning messages
 	void setUseTurbulent(bool use);
-	void setUseDisk(bool use);
-	void setUseToroidalHalo(bool use);
-	void setUseX(bool use);
-	
+
+	// set and get transition width at inner and outer boundary of spiral field
 	void setDelta(double d);
-	void setZs(double z);
-
-	bool isUsingRegular();
-	bool isUsingStriated();
-	bool isUsingTurbulent();
-	bool isUsingDisk();
-	bool isUsingToroidalHalo();
-	bool isUsingX();
-	
 	double getDelta() const;
+
+	// set and get scale heigth for parabolic X field lines
+	void setZs(double z);
 	double getZs() const;
-	
+
+	// override old X and spiral field
+	Vector3d getXField(const double& r, const double& z, const double& sinPhi, const double& cosPhi) const;
+	Vector3d getDiskField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const;
+
 	// continue spiral field to r=20kpc without transition at the outer boundary
-	// you may reactivate the transition afterwards with setDelta()
+	// one may reactivate the transition afterwards with setDelta()
 	void deactivateOuterTransition();
-	
-	// scaling function for disk and toroidal halo field; same as in initial JF12
-	double logisticFunction(const double x, const double x0, const double w) const;
 
-	// Regular field component
-	Vector3d getRegularField(const Vector3d& pos) const;
+	// transition polynomial p_delta(r) for the spiral field
+	double p(const double& r) const;
 
-	// Regular and striated field component
-	Vector3d getStriatedField(const Vector3d& pos) const;
-
-	// Brms of the turbulent field
-	double getTurbulentStrength(const Vector3d& pos) const;
-
-	// Turbulent field component
-	Vector3d getTurbulentField(const Vector3d& pos) const;
-
-	// Total field
-	Vector3d getField(const Vector3d& pos) const;
-	
-	// Individual regular field components
-	Vector3d getXField(const double r, const double z, const double sinPhi, const double cosPhi) const;
-	Vector3d getDiskField(const double r, const double z, const double phi, const double sinPhi, const double cosPhi) const;
-	Vector3d getToroidalHaloField(const double r, const double z, const double sinPhi, const double cosPhi) const;
-	
-	// transition polynomial p_delta(r)
-	double p(const double r) const;
-	
 	// transition polynomial derivative
-	double q(const double r) const;
-	
-	// evaluate H-Integral
-	double PhiIntegralH(const double r, const double phi) const;
-	
-	// return correct field strength b_j for current spiral arm
-	double getSpiralStrength(const double r, const double phi) const;
-	
+	double q(const double& r) const;
+
+	// evaluate H-Integral needed for solenoidality of the spiral field
+	double PhiIntegralH(const double& r, const double& phi) const;
+
+	// return field strength b_j of initial field at r = 5 kpc for current spiral arm
+	double getSpiralStrength(const double& r, const double& phi) const;
 };
 
 } // namespace crpropa

--- a/include/crpropa/magneticField/JF12FieldSolenoidal.h
+++ b/include/crpropa/magneticField/JF12FieldSolenoidal.h
@@ -1,0 +1,188 @@
+#ifndef CRPROPA_JF12FIELDSOLENOIDAL_H
+#define CRPROPA_JF12FIELDSOLENOIDAL_H
+
+#include "crpropa/magneticField/MagneticField.h"
+#include "crpropa/Grid.h"
+#include <crpropa/Units.h>
+
+namespace crpropa {
+
+/**
+ @class JF12FieldSolenoidal
+ @brief JF12FieldSolenoidal galactic magnetic field model
+ 
+ Implements a modified JF2012 magnetic field model, see documentation of JF12Field for basics.
+ 
+ A solenoidal ring-spiral transition (of width delta = 3 kpc per default) for the disk field
+ and a smooth X-field at z = 0 (parabolic field lines for abs(z) < zs; zs = 500 parsec per default)
+ were added in order to smooth the field and avoid violations of magnetic flux conservation, see:
+ Kleimann et al, 2018, arXiv:1809.07528, Solenoidal improvements for the JF12 Galactic magnetic field model.
+ 
+ The regular field components (disk, toroidal halo and polodial halo field) 
+ may be turned on and off individually for tests.
+ 
+ The turbulent field component is the exact same as in the initial JF12 implementation
+ and should be used with care since the new regular and old turbulent field
+ do not match in the ring-spiral transition region.
+ */
+ 
+class JF12FieldSolenoidal: public MagneticField {
+private:
+
+	// allow for enabling and disabling of the individual components
+	bool useRegular;
+	bool useStriated;
+	bool useTurbulent;
+	
+	bool useDisk;
+	bool useToroidalHalo;
+	bool useX;
+	
+	// height paramter of the modified X-field
+	double zS;
+	
+	// disk spiral arms
+	double rArms[8]; // radii where each arm crosses the negative x-axis
+	
+	// angles at which the dividing spirals intersect the r1-ring, 
+	// longer array due to cyclicity
+	double phi0Arms[11];
+	
+	// lower bound for phi integration
+	double phi0;
+	// corresponding index in phi0Arms
+	int idx0;
+	
+	// phi integration H(phi) = phiCoeff[j] + bDisk[j] * phi
+	double phiCoeff[10]; // for phi0Arms[j-1] < phi < phi0Arms[j], hence only 10
+	double corr; // correction term enforcing H(phi0) = 0
+	
+	// inner and outer boundaries of disk field
+	double r1; 
+	double r2;
+	
+	// transitions region boundaries of disk field
+	double r1s;
+	double r2s;
+	
+	double pitch;          // pitch angle
+	double sinPitch, cosPitch, tanPitch, cotPitch, tan90MinusPitch;
+
+	// Regular field ----------------------------------------------------------
+	// disk
+	double bDisk[11];       // field strengths of arms at r=5 kpc
+	double bRing;          // ring field strength 3<r<5 kpc
+	double hDisk, wDisk;   // disk/halo transistion and width
+	// toroidal halo
+	double bNorth, bSouth; // northern, southern halo field strength
+	double rNorth, rSouth; // northern, southern transistion radius
+	double wHalo, z0;      // transistion width and vertical scale height
+	// poloidal halo
+	double bX;             // field strength at origin
+	double thetaX0;        // constant elevation angle at r > rXc, z = 0
+	double sinThetaX0, cosThetaX0, tanThetaX0, cotThetaX0;
+	double rXc;            // radius of varying elevation angle region
+	double rX;             // exponential scale height
+
+	// Striated field ---------------------------------------------------------
+	double sqrtbeta;       // relative strength of striated field
+	ref_ptr<ScalarGrid> striatedGrid;
+
+	// Turbulent field --------------------------------------------------------
+	ref_ptr<VectorGrid> turbulentGrid;
+	// disk
+	double bDiskTurb[8]; // field strengths in arms at r=5 kpc
+	double bDiskTurb5;   // field strength at r<5kpc
+	double zDiskTurb;	 // Gaussian scale height of disk
+	// halo
+	double bHaloTurb; // halo field strength
+	double rHaloTurb; // exponential scale length
+	double zHaloTurb; // Gaussian scale height
+
+public:
+
+	JF12FieldSolenoidal(double delta=(3*kpc), double zs=(0.5*kpc));
+
+	// Create and set a random realization for the striated field
+	void randomStriated(int seed = 0);
+
+#ifdef CRPROPA_HAVE_FFTW3F
+	// Create a random realization for the turbulent field
+	void randomTurbulent(int seed = 0);
+#endif
+
+	/**
+	 * Set a striated grid and activate the striated field component
+	 * @param grid	scalar grid containing random +1/-1 values, 100 parsec grid spacing
+	 */
+	void setStriatedGrid(ref_ptr<ScalarGrid> grid);
+
+	/**
+	 * Set a turbulent grid and activate the turbulent field component
+	 * @param grid	vector grid containing a random field of Brms = 1
+	 */
+	void setTurbulentGrid(ref_ptr<VectorGrid> grid);
+
+	ref_ptr<ScalarGrid> getStriatedGrid();
+	ref_ptr<VectorGrid> getTurbulentGrid();
+
+	void setUseRegular(bool use);
+	void setUseStriated(bool use);
+	void setUseTurbulent(bool use);
+	void setUseDisk(bool use);
+	void setUseToroidalHalo(bool use);
+	void setUseX(bool use);
+	
+	void setDelta(double d);
+	void setZs(double z);
+
+	bool isUsingRegular();
+	bool isUsingStriated();
+	bool isUsingTurbulent();
+	bool isUsingDisk();
+	bool isUsingToroidalHalo();
+	bool isUsingX();
+	
+	double getDelta() const;
+	double getZs() const;
+	
+	// scaling function for disk and toroidal halo field; same as in initial JF12
+	double logisticFunction(const double x, const double x0, const double w) const;
+
+	// Regular field component
+	Vector3d getRegularField(const Vector3d& pos) const;
+
+	// Regular and striated field component
+	Vector3d getStriatedField(const Vector3d& pos) const;
+
+	// Brms of the turbulent field
+	double getTurbulentStrength(const Vector3d& pos) const;
+
+	// Turbulent field component
+	Vector3d getTurbulentField(const Vector3d& pos) const;
+
+	// Total field
+	Vector3d getField(const Vector3d& pos) const;
+	
+	// Individual regular field components
+	Vector3d getXField(const double r, const double z, const double sinPhi, const double cosPhi) const;
+	Vector3d getDiskField(const double r, const double z, const double phi, const double sinPhi, const double cosPhi) const;
+	Vector3d getToroidalHaloField(const double r, const double z, const double sinPhi, const double cosPhi) const;
+	
+	// transition polynomial p_delta(r)
+	double p(const double r) const;
+	
+	// transition polynomial derivative
+	double q(const double r) const;
+	
+	// evaluate H-Integral
+	double PhiIntegralH(const double r, const double phi) const;
+	
+	// return correct field strength b_j for current spiral arm
+	double getSpiralStrength(const double r, const double phi) const;
+	
+};
+
+} // namespace crpropa
+
+#endif // CRPROPA_JF12FIELDSOLENOIDAL_H

--- a/include/crpropa/magneticField/JF12FieldSolenoidal.h
+++ b/include/crpropa/magneticField/JF12FieldSolenoidal.h
@@ -11,84 +11,101 @@ namespace crpropa {
  @class JF12FieldSolenoidal
  @brief JF12FieldSolenoidal galactic magnetic field model
 
- Implements a modified JF2012 magnetic field model, see documentation of JF12Field for basics.
- This implemementation inherits most methods and variables from the initial JF12Field, 
- just the regular disk and X field are altered.
+ Implements a modified JF2012 Galactic magnetic field model.
+ This implementation inherits most methods from the initial JF12Field, 
+ just the regular disk field and the poloidal halo "X field" are altered.
 
- A solenoidal ring-spiral transition (of width delta = 3 kpc per default) for the disk field
- and a smooth X-field at z = 0 (parabolic field lines for abs(z) < zs; zs = 500 parsec per default)
+ A solenoidal transition for the disk field (which redirects the magnetic flux of the magnetic spiral field at the boundaries and lets the field strength tend to 0 in a continuous way)
+ and an improved version of the JF12 X field (with parabolic field lines at z = 0 instead of sharp kinks)
  were added in order to smooth the field and avoid violations of magnetic flux conservation, see:
  Kleimann et al, 2018, arXiv:1809.07528, Solenoidal improvements for the JF12 Galactic magnetic field model.
 
  The turbulent field component is the exact same as in the initial JF12 implementation
  and should be used with care since the new regular and old turbulent field
- do not match in the ring-spiral transition region.
+ do not match in the transition regions of the spiral field.
  */
  
 class JF12FieldSolenoidal: public JF12Field {
 private:
+	double zS; // height parameter of the modified X-field, field lines are parabolic for fabs(z) < zS
+	double phi0Arms[11]; // azimuth angles in [-pi,pi] at which the dividing 8 spirals of the disk field intersect the (r1 = 5kpc)-ring at indices 1 to 8, remaining angles periodically filled.
 
-	// height parameter of the modified X-field, field lines are parabolic for fabs(z) < zS
-	double zS;
+	double phi0; // lower bound for azimuth phi integration to restore solenoidality of spiral field transition, arbitrary parameter
 
-	// angles at which the dividing 8 spirals of the disk field intersect the (r1 = 5kpc)-ring, 
-	// longer array due to cyclic closure of the values
-	double phi0Arms[11];
-
-	// lower bound for phi integration, somewhat arbitrary parameter
-	double phi0;
-	// corresponding index in phi0Arms such that phi0Arms[idx0-1] < phi0 < phi0Arms[idx0]
-	int idx0;
-
-	// phi integration H(phi) = phiCoeff[j] + bDisk[j] * phi
-	double phiCoeff[10]; // for phi0Arms[j-1] < phi < phi0Arms[j], hence only 10
-	double corr; // correction term enforcing H(phi0) = 0
+	// in order to restore solenoidality in the transition regions of the spiral field,
+	// a phi-integral over the piecwise constant field strengths at r=5kpc has to be evaluated. Here,
+	// we set H(phi) = phiCoeff[j] + bDisk[j] * phi as the result of this integration
+	double phiCoeff[10]; // only 10 since the array holds the results for the integral from phi0Arms[0] to phi0Arms[1]; phi0Arms[0] to phi0Arms[2] etc.
+	double corr; // correction term for enforcing H(phi0) = 0 afterwards which sets the lower boundary of the integration to phi0
 
 	// inner and outer boundaries of disk field at r = 5 and 20 kpc
 	double r1;
 	double r2;
-	
+
 	// transitions region boundaries of disk field at r1 + delta, r2 - delta
 	double r1s;
 	double r2s;
 
-	// initial JF12 field strengths of the 8 spiral arms  (index 1 to 8) at r = 5 kpc,
-	// cyclically closed s.t. b[0] = b[8], b[9] = b[1], b[10] = b[2]
-	double bDiskCyclicClosure[11]; 
-
 public:
-	JF12FieldSolenoidal(double delta= 3 * kpc, double zs= 0.5 * kpc);
+/** Constructor
+	@param delta 	Transition width for the disk field such that the magnetic flux of the spiral field lines is redirected between r = 5 kpc and r = 5 kpc + delta as well as r = 20 kpc - delta and r = 20 kpc. The input parameter delta should be non-negative and smaller than 7.5 kpc. The default value is 3 kpc.
+	@param zs 	Scale height for the X-shaped poloidal halo field such that the straight field lines are replaced by parabolas for abs(z) < zs. The input parameter zs should be non-negative. The default value is 500 pc.
+*/
+	JF12FieldSolenoidal(double delta = 3 * kpc, double zs = 0.5 * kpc);
 	
-	void setUseStriated(bool use); // override these for correct warning messages
-	void setUseTurbulent(bool use);
+	void setUseStriatedField(bool use); // override these for correct warning messages
+	void setUseTurbulentField(bool use);
 
-	// set and get transition width at inner and outer boundary of spiral field
-	void setDelta(double d);
-	double getDelta() const;
+/** @brief Adjust the transition width of the disk field
+	@param d	The new transition width for the disk field with field strength transitions and flux redirection between r = 5 kpc and r = 5 kpc + delta as well as r = 20 kpc - delta and r = 20 kpc. Should be non-negative and smaller than 7.5 kpc.
+	@return Void
+*/
+	void setDiskTransitionWidth(double delta);
+	double getDiskTransitionWidth() const;
 
-	// set and get scale heigth for parabolic X field lines
-	void setZs(double z);
-	double getZs() const;
 
-	// override old X and spiral field
-	Vector3d getXField(const double& r, const double& z, const double& sinPhi, const double& cosPhi) const;
+/** @brief Adjust the scale heigth of the X field
+	@param zs	The new scale height of the X field with parabolic field lines for abs(z) < zs. Should be non-negative.
+	@return Void
+*/
+	void setXScaleHeight(double zs);
+	double getXScaleHeight() const;
+
+	Vector3d getXField(const double& r, const double& z, const double& sinPhi, const double& cosPhi) const; // override old X and spiral field
 	Vector3d getDiskField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const;
 
-	// continue spiral field to r=20kpc without transition at the outer boundary
-	// one may reactivate the transition afterwards with setDelta()
+/** @brief Disable the transition of the spiral field strength to 0 at the outer boundary such that only the magnetic flux at the 5 kpc ring is redirected. 
+	Thus, the spiral field lines are continued to r = 20 kpc as in the initial JF12 field. You can reactivate the outer transition afterwards via setDiskTransitionWidth which sets both transition widths at the inner and outer boundary.
+	@return Void
+*/
 	void deactivateOuterTransition();
 
-	// transition polynomial p_delta(r) for the spiral field
-	double p(const double& r) const;
+/** @brief Evaluate the polynomial which provides the transition of the spiral field strength to zero in the transition regions. 
+	This transition is differentiable at the boundaries of the unaltered spiral field and contuinuous at the outer boundaries of the spiral field where the field strength goes to zero.
+	@param r Distance of the current position to the z axis in the usual galactocentric cylindrical coordinates. Should be non-negative.
+	@return The value of the transition polynomial at r if r is inside one of the transition regions. Otherwise, return (5 kpc)/r, i.e. the scaling of the spiral field, if r is inside the region where the spiral field remains unaltered.
+*/
+	double getDiskTransitionPolynomial(const double& r) const;
 
-	// transition polynomial derivative
-	double q(const double& r) const;
+/** @brief Evaluate the derivative of the polynomial which provides the transition of the spiral field strength to zero in the transition regions. The derivative is needed to restore solenoidality in the transition region
+	@param r 	Distance of the current position to the z axis in the usual galactocentric cylindrical coordinates. Should be non-negative.
+	@return The value of the transition polynomial derivative at r if r is inside one of the transition regions. Otherwise, return 0.
+*/
+	double getDiskTransitionPolynomialDerivative(const double& r) const;
 
-	// evaluate H-Integral needed for solenoidality of the spiral field
-	double PhiIntegralH(const double& r, const double& phi) const;
-
-	// return field strength b_j of initial field at r = 5 kpc for current spiral arm
-	double getSpiralStrength(const double& r, const double& phi) const;
+/** @brief Evaluate an angular azimuth integral over the piecewise constant spiral field strengths at r_1 = 5 kpc. This integral is needed to restore the solenoidality of the spiral field in the transition regions. 
+	@param r 	Distance of the current position to the z axis in the usual galactocentric cylindrical coordinates. Should be non-negative.
+	@param phi	Azimuth angle of the current position in galactocentric cylindrical coordinates. Can be any double.
+	@return The value of the azimuth integral over the spiral field strengths at r_1 = 5 kpc from at fixed phi0 to the current phi which is mapped back to r_1 = 5 kpc along the spiral field line passing through (r,phi).
+*/
+	double getHPhiIntegral(const double& r, const double& phi) const;
+	
+/** @brief Find the correct magnetic spiral arm for the current position and return its field strength at r_1 = 5 kpc
+	@param r 	Distance of the current position to the z axis in the usual galactocentric cylindrical coordinates. Should be non-negative.
+	@param phi	Azimuth angle of the current position in galactocentric cylindrical coordinates. Can be any double.
+	@return The value of the spiral field strength b_j
+*/
+	double getSpiralFieldStrengthConstant(const double& r, const double& phi) const;
 };
 
 } // namespace crpropa

--- a/include/crpropa/magneticField/JF12FieldSolenoidal.h
+++ b/include/crpropa/magneticField/JF12FieldSolenoidal.h
@@ -146,6 +146,10 @@ public:
 	double getDelta() const;
 	double getZs() const;
 	
+	// continue spiral field to r=20kpc without transition at the outer boundary
+	// you may reactivate the transition afterwards with setDelta()
+	void deactivateOuterTransition();
+	
 	// scaling function for disk and toroidal halo field; same as in initial JF12
 	double logisticFunction(const double x, const double x0, const double w) const;
 

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -307,6 +307,7 @@
 %include "crpropa/magneticField/QuimbyMagneticField.h"
 %include "crpropa/magneticField/AMRMagneticField.h"
 %include "crpropa/magneticField/JF12Field.h"
+%include "crpropa/magneticField/JF12FieldSolenoidal.h"
 %include "crpropa/magneticField/PT11Field.h"
 %include "crpropa/magneticField/ArchimedeanSpiralField.h"
 %include "crpropa/module/BreakCondition.h"

--- a/src/magneticField/JF12Field.cpp
+++ b/src/magneticField/JF12Field.cpp
@@ -7,10 +7,6 @@
 
 namespace crpropa {
 
-double logisticFunction(double x, double x0, double w) {
-	return 1. / (1. + exp(-2. * (fabs(x) - x0) / w));
-}
-
 JF12Field::JF12Field() {
 	useRegular = true;
 	useStriated = false;
@@ -155,6 +151,10 @@ bool JF12Field::isUsingStriated() {
 
 bool JF12Field::isUsingTurbulent() {
 	return useTurbulent;
+}
+
+double JF12Field::logisticFunction(const double x, const double x0, const double w) const {
+	return 1. / (1. + exp(-2. * (fabs(x) - x0) / w));
 }
 
 Vector3d JF12Field::getRegularField(const Vector3d& pos) const {

--- a/src/magneticField/JF12FieldSolenoidal.cpp
+++ b/src/magneticField/JF12FieldSolenoidal.cpp
@@ -8,24 +8,24 @@
 namespace crpropa {
 
 JF12FieldSolenoidal::JF12FieldSolenoidal(double delta, double zs) {
-	
+
 	// enable only the regular field per default; the turbulent component 
 	// is still the same as in the initial JF12 field and should be used with care
 	useRegular = true;
 	useStriated = false;
 	useTurbulent = false;
-	
-	useDisk = true;
-	useToroidalHalo = true;
-	useX = true;
-	
-	// set widths and heigths of field and transition zones
+
+	useDiskField = true;
+	useToroidalHaloField = true;
+	useXField = true;
+
+	// set widths and heights of field and transition zones
 	zS = zs;
 	r1 = 5 * kpc;
 	r2 = 20 * kpc;
 	r1s = r1 + delta;
 	r2s = r2 - delta;
-	
+
 	// set spiral arm parameters (pitch angle and r_-x)
 	pitch = 11.5 * M_PI / 180;
 	sinPitch = sin(pitch);
@@ -42,61 +42,61 @@ JF12FieldSolenoidal::JF12FieldSolenoidal(double delta, double zs) {
 	rArms[5] = 11.4 * kpc;
 	rArms[6] = 12.7 * kpc;
 	rArms[7] = 15.5 * kpc;
-	
+
 	// set angles of seperating spiral field lines at r1
 	phi0 = 0.; // somewhat arbitrary choice, see Kleimann et al.
-	
+
 	for (int i = 1;i < 9; i++){
 		phi0Arms[i] = M_PI - cotPitch * log(rArms[i-1] / r1);
 	}
-	
+
 	// cyclic closure
 	phi0Arms[0] = phi0Arms[8] + 2 * M_PI;
 	phi0Arms[9] = phi0Arms[1] - 2 * M_PI;
 	phi0Arms[10] = phi0Arms[2] - 2 *M_PI;
-	
+
 	// determine index of phi0
 	idx0 = 0;
 	while (phi0Arms[idx0] > phi0){
 		idx0 += 1;
 	}
-	
+
 	// set regular field parameters
 	bRing = 0.1 * muG;
 	hDisk = 0.40 * kpc;
 	wDisk = 0.27 * kpc;
 
-	bDisk[1] = 0.1 * muG; // called b_1 in Kleimann et al.
-	bDisk[2] = 3.0 * muG; // b_2
-	bDisk[3] = -0.9 * muG;// etc.
-	bDisk[4] = -0.8 * muG;
-	bDisk[5] = -2.0 * muG;
-	bDisk[6] = -4.2 * muG;
-	bDisk[7] = 0.0 * muG;
-	bDisk[8] = 2.7 * muG;
-	
+	bDiskCyclicClosure[1] = 0.1 * muG; // called b_1 in Kleimann et al.
+	bDiskCyclicClosure[2] = 3.0 * muG; // b_2
+	bDiskCyclicClosure[3] = -0.9 * muG;// etc.
+	bDiskCyclicClosure[4] = -0.8 * muG;
+	bDiskCyclicClosure[5] = -2.0 * muG;
+	bDiskCyclicClosure[6] = -4.2 * muG;
+	bDiskCyclicClosure[7] = 0.0 * muG;
+	bDiskCyclicClosure[8] = 2.7 * muG;
+
 	// re-compute b_8 for flux correction
 	double flux1to7 = 0.;
 	for (int i = 1; i < 8; i++){
-		flux1to7 += (phi0Arms[i-1] - phi0Arms[i]) * bDisk[i];
+		flux1to7 += (phi0Arms[i-1] - phi0Arms[i]) * bDiskCyclicClosure[i];
 	}
-	bDisk[8] = -flux1to7 / (phi0Arms[7] - phi0Arms[8]);
-	bDisk[0] = bDisk[8];
-	bDisk[9] = bDisk[1];
-	bDisk[10] = bDisk[2];
+	bDiskCyclicClosure[8] = -flux1to7 / (phi0Arms[7] - phi0Arms[8]);
+	bDiskCyclicClosure[0] = bDiskCyclicClosure[8];
+	bDiskCyclicClosure[9] = bDiskCyclicClosure[1];
+	bDiskCyclicClosure[10] = bDiskCyclicClosure[2];
 	
 	// set coefficients for phi integration
 	phiCoeff[0] = 0;
 	for (int i = 1; i < 10; i++){
-		phiCoeff[i] = phiCoeff[i-1] + (bDisk[i-1] - bDisk[i]) * phi0Arms[i-1];
+		phiCoeff[i] = phiCoeff[i-1] + (bDiskCyclicClosure[i-1] - bDiskCyclicClosure[i]) * phi0Arms[i-1];
 	}
-	
+
 	//correct for H(phi0) = 0
-	corr = phiCoeff[idx0] + bDisk[idx0] * phi0;
+	corr = phiCoeff[idx0] + bDiskCyclicClosure[idx0] * phi0;
 	for (int i = 1; i < 10; i++){
 		phiCoeff[i] = phiCoeff[i] - corr;
-	} 
-	
+	}
+
 	// azimuthal halo parameters
 	bNorth = 1.4 * muG;
 	bSouth = -1.1 * muG;
@@ -104,7 +104,7 @@ JF12FieldSolenoidal::JF12FieldSolenoidal(double delta, double zs) {
 	rSouth = 17 * kpc;
 	wHalo = 0.20 * kpc;
 	z0 = 5.3 * kpc;
-	
+
 	// X-field parameters
 	bX = 4.6 * muG;
 	thetaX0 = 49.0 * M_PI / 180.;
@@ -136,66 +136,6 @@ JF12FieldSolenoidal::JF12FieldSolenoidal(double delta, double zs) {
 	zHaloTurb = 2.84 * kpc;
 }
 
-void JF12FieldSolenoidal::randomStriated(int seed) {
-	useStriated = true;
-	int N = 100;
-	striatedGrid = new ScalarGrid(Vector3d(0.), N, 0.1 * kpc);
-
-	Random random;
-	if (seed != 0)
-		random.seed(seed);
-
-	for (int ix = 0; ix < N; ix++)
-		for (int iy = 0; iy < N; iy++)
-			for (int iz = 0; iz < N; iz++) {
-				float &f = striatedGrid->get(ix, iy, iz);
-				f = round(random.rand()) * 2 - 1;
-			}
-}
-
-#ifdef CRPROPA_HAVE_FFTW3F
-void JF12FieldSolenoidal::randomTurbulent(int seed) {
-	useTurbulent = true;
-	// turbulent field with Kolmogorov spectrum, B_rms = 1 and Lc = 60 parsec
-	turbulentGrid = new VectorGrid(Vector3d(0.), 256, 4 * parsec);
-	initTurbulence(turbulentGrid, 1, 8 * parsec, 272 * parsec, -11./3., seed);
-}
-#endif
-
-void JF12FieldSolenoidal::setStriatedGrid(ref_ptr<ScalarGrid> grid) {
-	useStriated = true;
-	striatedGrid = grid;
-}
-
-void JF12FieldSolenoidal::setTurbulentGrid(ref_ptr<VectorGrid> grid) {
-	useTurbulent = true;
-	turbulentGrid = grid;
-}
-
-ref_ptr<ScalarGrid> JF12FieldSolenoidal::getStriatedGrid() {
-	return striatedGrid;
-}
-
-ref_ptr<VectorGrid> JF12FieldSolenoidal::getTurbulentGrid() {
-	return turbulentGrid;
-}
-
-void JF12FieldSolenoidal::setUseRegular(bool use) {
-	useRegular = use;
-}
-
-void JF12FieldSolenoidal::setUseDisk(bool use) {
-	useDisk = use;
-}
-
-void JF12FieldSolenoidal::setUseToroidalHalo(bool use) {
-	useToroidalHalo = use;
-}
-
-void JF12FieldSolenoidal::setUseX(bool use) {
-	useX = use;
-}
-
 void JF12FieldSolenoidal::setDelta(double delta) {
 	r1s = r1 + delta;
 	r2s = r2 - delta;
@@ -219,7 +159,7 @@ void JF12FieldSolenoidal::deactivateOuterTransition() {
 
 void JF12FieldSolenoidal::setUseStriated(bool use) {
 	if ((use) and (striatedGrid)) {
-		std::cout << "JF12FieldSolenoidal: No striated field set: ignored" << std::endl;
+		KISS_LOG_WARNING << "JF12FieldSolenoidal: No striated field set: ignored.";
 		return;
 	}
 	useStriated = use;
@@ -227,168 +167,45 @@ void JF12FieldSolenoidal::setUseStriated(bool use) {
 
 void JF12FieldSolenoidal::setUseTurbulent(bool use) {
 	if ((use) and (turbulentGrid)) {
-		std::cout << "JF12FieldSolenoidal: No turbulent field set: ignored" << std::endl;
+		KISS_LOG_WARNING << "JF12FieldSolenoidal: No turbulent field set: ignored.";
 		return;
 	}
 	useTurbulent = use;
 }
 
-bool JF12FieldSolenoidal::isUsingRegular() {
-	return useRegular;
-}
-
-bool JF12FieldSolenoidal::isUsingStriated() {
-	return useStriated;
-}
-
-bool JF12FieldSolenoidal::isUsingTurbulent() {
-	return useTurbulent;
-}
-
-bool JF12FieldSolenoidal::isUsingDisk() {
-	return useDisk;
-}
-
-bool JF12FieldSolenoidal::isUsingToroidalHalo() {
-	return useToroidalHalo;
-}
-
-bool JF12FieldSolenoidal::isUsingX() {
-	return useX;
-}
-
-double JF12FieldSolenoidal::logisticFunction(const double x, const double x0, const double w) const {
-	return 1. / (1. + exp(-2. * (fabs(x) - x0) / w));
-}
-
-Vector3d JF12FieldSolenoidal::getRegularField(const Vector3d& pos) const {
-	Vector3d b(0.);
-
-	double r = sqrt(pos.x * pos.x + pos.y * pos.y); // in-plane radius
-	double d = pos.getR(); // distance to galactic center
-
-	double phi = pos.getPhi(); // azimuth
-	double sinPhi = sin(phi);
-	double cosPhi = cos(phi);
-	
-	b += getDiskField(r, pos.z, phi, sinPhi, cosPhi);
-	b += getToroidalHaloField(r, pos.z, sinPhi, cosPhi);
-	b += getXField(r, pos.z, sinPhi, cosPhi);
-
-	return b;
-}
-
-Vector3d JF12FieldSolenoidal::getStriatedField(const Vector3d& pos) const {
-	return (getRegularField(pos)
-			* (1. + sqrtbeta * striatedGrid->closestValue(pos)));
-}
-
-double JF12FieldSolenoidal::getTurbulentStrength(const Vector3d& pos) const {
-	// Turbulent JF12 field WITHOUT any alterations as of yet! Be careful when using this.
-	
-	if (pos.getR() > 20 * kpc)
-		return 0;
-
-	double r = sqrt(pos.x * pos.x + pos.y * pos.y); // in-plane radius
-	double phi = pos.getPhi(); // azimuth
-
-	// disk
-	double bDisk = 0;
-	if (r < 5 * kpc) {
-		bDisk = bDiskTurb5;
-	} else {
-		// spiral region
-		double r_negx = r * exp(-(phi - M_PI) / tan90MinusPitch);
-		if (r_negx > rArms[7])
-			r_negx = r * exp(-(phi + M_PI) / tan90MinusPitch);
-		if (r_negx > rArms[7])
-			r_negx = r * exp(-(phi + 3 * M_PI) / tan90MinusPitch);
-
-		for (int i = 7; i >= 0; i--)
-			if (r_negx < rArms[i])
-				bDisk = bDiskTurb[i];
-
-		bDisk *= (5 * kpc) / r;
-	}
-	bDisk *= exp(-0.5 * (pos.z / zDiskTurb) * (pos.z / zDiskTurb));
-
-	// halo
-	double bHalo = bHaloTurb * exp(-r / rHaloTurb)
-			* exp(-0.5 * (pos.z / zHaloTurb) * (pos.z / zHaloTurb));
-
-	// modulate turbulent field
-	return sqrt(bDisk * bDisk + bHalo * bHalo);
-}
-
-Vector3d JF12FieldSolenoidal::getTurbulentField(const Vector3d& pos) const {
-	return (turbulentGrid->interpolate(pos) * getTurbulentStrength(pos));
-}
-
-Vector3d JF12FieldSolenoidal::getField(const Vector3d& pos) const {
-	Vector3d b(0.);
-	if (useTurbulent)
-		b += getTurbulentField(pos);
-	if (useStriated)
-		b += getStriatedField(pos);
-	else if (useRegular)
-		b += getRegularField(pos);
-	return b;
-}
-
-Vector3d JF12FieldSolenoidal::getDiskField(const double r, const double z, const double phi, const double sinPhi, const double cosPhi) const {
+Vector3d JF12FieldSolenoidal::getDiskField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const {
 	// improved disk field with transition to ring region in [r1,r1s] and [r2s,r2]
 	Vector3d b(0.);
 
-	if (useDisk && (r * r + z * z < 400 * kpc * kpc)){
-		
+	if (useDiskField){
+
 		double lfDisk = logisticFunction(z, hDisk, wDisk); // for vertical scaling
-		
+
 		double hint = PhiIntegralH(r, phi);
 		double mag1 = getSpiralStrength(r, phi); // returns b_j for current spiral arm
-		
+
 		if ((r1 < r) && (r < r2)) {
-			
+
 			double pdelta = p(r);
 			double qdelta = q(r);
 			double br = pdelta * mag1 * sinPitch;
 			double bphi = pdelta * mag1 * cosPitch - qdelta * hint * sinPitch;
-		
+
 			b.x += br * cosPhi - bphi * sinPhi;
 			b.y += br * sinPhi + bphi * cosPhi;
-			
+
 			b *= (1 - lfDisk);
 		}
 	}
-	
 	return b;		
 }
 
-Vector3d JF12FieldSolenoidal::getToroidalHaloField(const double r, const double z, const double sinPhi, const double cosPhi) const {
-	// same as initial JF12, moved in a seperate function for clearness
-	Vector3d b(0.);
-	
-	if (useToroidalHalo && (r * r + z * z > 1 * kpc * kpc) && (r * r + z * z < 400 * kpc * kpc)){
-		
-		double lfDisk = logisticFunction(z, hDisk, wDisk);
-		double bMagH = exp(-fabs(z) / z0) * lfDisk;
-		
-		if (z >= 0)
-			bMagH *= bNorth * (1 - logisticFunction(r, rNorth, wHalo));
-		else
-			bMagH *= bSouth * (1 - logisticFunction(r, rSouth, wHalo));
-		b.x += -bMagH * sinPhi;
-		b.y += bMagH * cosPhi;
-	}
-	
-	return b;
-}
-
-Vector3d JF12FieldSolenoidal::getXField(const double r, const double z, const double sinPhi, const double cosPhi) const {
+Vector3d JF12FieldSolenoidal::getXField(const double& r, const double& z, const double& sinPhi, const double& cosPhi) const {
 	// improved X-field with parabolic field lines at abs(z) < zs
 	Vector3d b(0.);
-	
-	if (useX && (r * r + z * z < 400. * kpc * kpc)){
-		
+
+	if (useXField){
+
 		double bMagX;
 		double sinThetaX, cosThetaX;
 		double rp; // radius where current intial field line passes z = 0
@@ -396,79 +213,72 @@ Vector3d JF12FieldSolenoidal::getXField(const double r, const double z, const do
 		double r0c = rXc + zS / tanThetaX0; // radius where field line through rXc passes z = zS
 		double f, r0, br0, bz0;
 		bool inner = true; // distinguish between inner and outer region
-		
+
 		// return intial field if z>=zS
 		if (fabs(z) > zS){
-			
+
 			if ((r == 0.)){
 				b.z = bX / ((1. + fabs(z) * cotThetaX0 / rXc) * (1. + fabs(z) * cotThetaX0 / rXc));
 				return b;
 			}
-			
+
 			if (r < rc) {	
 			// inner varying elevation region
-			
+
 				rp = r * rXc / rc;
 				bMagX = bX * exp(-1 * rp / rX) * (rXc / rc) * (rXc / rc);
-				
+
 				double thetaX = atan(fabs(z) / (r - rp));
-				
+
 				if (z == 0)
 					thetaX = M_PI / 2.;
-				
+
 				sinThetaX = sin(thetaX);
 				cosThetaX = cos(thetaX);
-				
-				double zsign = z < 0 ? -1 : 1;
-				
-				b.x += zsign * bMagX * cosThetaX * cosPhi;
-				b.y += zsign * bMagX * cosThetaX * sinPhi;
-				b.z += bMagX * sinThetaX;
 			}
 			else {
 			// outer constant elevation region
 				rp = r - fabs(z) / tanThetaX0;
 				bMagX = bX * exp(-rp / rX) * (rp / r);
-				
+
 				sinThetaX = sinThetaX0;
 				cosThetaX = cosThetaX0;
-				
-				double zsign = z < 0 ? -1 : 1;
-				b.x += zsign * bMagX * cosThetaX * cosPhi;
-				b.y += zsign * bMagX * cosThetaX * sinPhi;
-				b.z += bMagX * sinThetaX;
 			}
+			double zsign = z < 0 ? -1 : 1;
+			b.x += zsign * bMagX * cosThetaX * cosPhi;
+			b.y += zsign * bMagX * cosThetaX * sinPhi;
+			b.z += bMagX * sinThetaX;
 		}
 		// parabolic field lines for z<zS
 		else {
 				// determine r at which parabolic field line through (r,z) passes z = zS
 				r0 = r * 1. / (1.- 1./ (2. * (zS + rXc * tanThetaX0)) * (zS - z * z / zS));
-				
+
 				// determine correct region (inner/outer)
 				if (r0 >= r0c){
 					r0 = r + 1. / (2. * tanThetaX0) * (zS - z * z / zS);
 					inner = false;
 				}
-				
+
 				// field strength at that position
 				 if (r0 < r0c){
-					 
+
 					 rp = r0 * rXc / r0c;
 					 double thetaX = atan(zS / (r0 - rp));
-					 
+
 					 // field strength at (r0,zS) for inner region
 					 br0 = bX * exp(- rp / rX) * (rXc/ r0c) * (rXc/ r0c) * cos(thetaX);
 					 bz0 = bX * exp(- rp / rX) * (rXc/ r0c) * (rXc/ r0c) * sin(thetaX);
 				 }
 				 else {
-					 
+
 					 // field strength at (r0,zS) for outer region
 					 rp = r0 - zS / tanThetaX0;
 					 br0 =  bX * exp(- rp / rX) * (rp/r0) * cosThetaX0;
 					 bz0 =  bX * exp(- rp / rX) * (rp/r0) * sinThetaX0;
-					 
+ 
 				 }
-				 
+
 				 // compute factor F for solenoidality
 				 if (inner){
 					 f = 1. / ((1. - 1./( 2. + 2. * (rXc * tanThetaX0/ zS)) * (1. - (z / zS) * (z / zS))) * (1. - 1./( 2. + 2. * (rXc * tanThetaX0/ zS)) * (1. - (z / zS) * (z / zS))));
@@ -476,10 +286,10 @@ Vector3d JF12FieldSolenoidal::getXField(const double r, const double z, const do
 				 else{
 					 f = 1. + 1/ (2 * r * tanThetaX0/ zS) * (1. - (z / zS) * (z / zS)); 
 				 }
-				 
+
 				 double br = z / zS * f * br0;
 				 double bz = bz0 * f;
-				 
+
 				 b.x += br * cosPhi;
 				 b.y += br * sinPhi;
 				 b.z += bz;
@@ -488,90 +298,88 @@ Vector3d JF12FieldSolenoidal::getXField(const double r, const double z, const do
 	return b;
 }
 
-double JF12FieldSolenoidal::p(const double r) const {
+double JF12FieldSolenoidal::p(const double& r) const {
 	//transition polynomial p_delta(r)
-	
+
 	// 0 disk field outside
 	if ((r < r1) || (r > r2)) {
 		return 0.;
-	}	
+	}
 	// unchanged field
 	if ((r > r1s) && (r < r2s)) {
 		return r1/r;
 	}
-	
+
 	// transitions region parameters
 	double r_a = r1;
 	double r_b = r1s;
-	
+
 	if (r >= r2s) {
 		r_a = r2;
 		r_b = r2s;
 	}
-	
+
 	// differentiable transition at r_s, continous at r_a
 	double fakt = (r_a / r_b - 2.) / ((r_a - r_b) *  (r_a - r_b));
 	return (r1/r_b) * (2. - r / r_b + fakt * (r-r_b) * (r-r_b));
 }	
 
-double JF12FieldSolenoidal::q(const double r) const {
+double JF12FieldSolenoidal::q(const double& r) const {
 	//transition polynomial derivative
-	
+
 	// 0 disk field outside
 	if ((r < r1) || (r > r2)) {
 		return 0.;
-	}	
+	}
+
 	// unchanged field
 	if ((r > r1s) && (r < r2s)) {
 		return 0.;
 	}
-	
+
 	// transitions region parameters
 	double r_a = r1;
 	double r_b = r1s;
-	
+
 	if (r >= r2s) {
 		r_a = r2;
 		r_b = r2s;
 	}
-	
+
 	// differentiable transition at r_s, continous at r_a
 	double fakt = (r_a / r_b - 2.) / ((r_a - r_b) * (r_a - r_b));
 	return (r1/r_b) * (2. - 2. * r/r_b + fakt * (3. * r * r - 4. * r * r_b + r_b * r_b));
 }
 
-double JF12FieldSolenoidal::PhiIntegralH(const double r, const double phi) const {
+double JF12FieldSolenoidal::PhiIntegralH(const double& r, const double& phi) const {
 	// evaluate BphiIntegral for solenodality/flux redistribution in ring-spiral transition region
 	double H_ret = 0.;
 	int idx = 1;
-	
+
 	if ((r1 < r) && (r < r2)){
 		double phi1 = phi - log(r/r1) * cotPitch;
 		phi1 = atan2(sin(phi1) , cos(phi1)); // map to [-pi,+pi]
 		while (phi1 < phi0Arms[idx]){
 			idx += 1;
 		}
-		H_ret = phi1 * bDisk[idx] + phiCoeff[idx];
+		H_ret = phi1 * bDiskCyclicClosure[idx] + phiCoeff[idx];
 	}
-	
 	return H_ret;
-	
 }
 
-double JF12FieldSolenoidal::getSpiralStrength(const double r, const double phi) const {
+double JF12FieldSolenoidal::getSpiralStrength(const double& r, const double& phi) const {
 	// return field strength b_j for current spiral arm
 	double b_ret = 0.;
 	int idx = 1;
-	
+
 	if ((r1 < r) && (r < r2)){
 		double phi1 = phi - log(r/r1) * cotPitch;
 		phi1 = atan2(sin(phi1), cos(phi1)); // map to [-pi,+pi]
 		while (phi1 < phi0Arms[idx]){
 			idx += 1;
 		}
-		b_ret = bDisk[idx];
+		b_ret = bDiskCyclicClosure[idx];
 	}
-	
 	return b_ret;
 }
 

--- a/src/magneticField/JF12FieldSolenoidal.cpp
+++ b/src/magneticField/JF12FieldSolenoidal.cpp
@@ -213,6 +213,10 @@ double JF12FieldSolenoidal::getZs() const {
 	return zS;
 }
 
+void JF12FieldSolenoidal::deactivateOuterTransition() {
+	r2s = r2;
+}
+
 void JF12FieldSolenoidal::setUseStriated(bool use) {
 	if ((use) and (striatedGrid)) {
 		std::cout << "JF12FieldSolenoidal: No striated field set: ignored" << std::endl;

--- a/src/magneticField/JF12FieldSolenoidal.cpp
+++ b/src/magneticField/JF12FieldSolenoidal.cpp
@@ -1,0 +1,574 @@
+#include "crpropa/magneticField/JF12FieldSolenoidal.h"
+#include "crpropa/Units.h"
+#include "crpropa/GridTools.h"
+#include "crpropa/Random.h"
+
+#include <iostream>
+
+namespace crpropa {
+
+JF12FieldSolenoidal::JF12FieldSolenoidal(double delta, double zs) {
+	
+	// enable only the regular field per default; the turbulent component 
+	// is still the same as in the initial JF12 field and should be used with care
+	useRegular = true;
+	useStriated = false;
+	useTurbulent = false;
+	
+	useDisk = true;
+	useToroidalHalo = true;
+	useX = true;
+	
+	// set widths and heigths of field and transition zones
+	zS = zs;
+	r1 = 5 * kpc;
+	r2 = 20 * kpc;
+	r1s = r1 + delta;
+	r2s = r2 - delta;
+	
+	// set spiral arm parameters (pitch angle and r_-x)
+	pitch = 11.5 * M_PI / 180;
+	sinPitch = sin(pitch);
+	cosPitch = cos(pitch);
+	tanPitch = tan(pitch);
+	cotPitch =  1. / tanPitch;
+	tan90MinusPitch = tan(M_PI / 2 - pitch);
+
+	rArms[0] = 5.1 * kpc;
+	rArms[1] = 6.3 * kpc;
+	rArms[2] = 7.1 * kpc;
+	rArms[3] = 8.3 * kpc;
+	rArms[4] = 9.8 * kpc;
+	rArms[5] = 11.4 * kpc;
+	rArms[6] = 12.7 * kpc;
+	rArms[7] = 15.5 * kpc;
+	
+	// set angles of seperating spiral field lines at r1
+	phi0 = 0.; // somewhat arbitrary choice, see Kleimann et al.
+	
+	for (int i = 1;i < 9; i++){
+		phi0Arms[i] = M_PI - cotPitch * log(rArms[i-1] / r1);
+	}
+	
+	// cyclic closure
+	phi0Arms[0] = phi0Arms[8] + 2 * M_PI;
+	phi0Arms[9] = phi0Arms[1] - 2 * M_PI;
+	phi0Arms[10] = phi0Arms[2] - 2 *M_PI;
+	
+	// determine index of phi0
+	idx0 = 0;
+	while (phi0Arms[idx0] > phi0){
+		idx0 += 1;
+	}
+	
+	// set regular field parameters
+	bRing = 0.1 * muG;
+	hDisk = 0.40 * kpc;
+	wDisk = 0.27 * kpc;
+
+	bDisk[1] = 0.1 * muG; // called b_1 in Kleimann et al.
+	bDisk[2] = 3.0 * muG; // b_2
+	bDisk[3] = -0.9 * muG;// etc.
+	bDisk[4] = -0.8 * muG;
+	bDisk[5] = -2.0 * muG;
+	bDisk[6] = -4.2 * muG;
+	bDisk[7] = 0.0 * muG;
+	bDisk[8] = 2.7 * muG;
+	
+	// re-compute b_8 for flux correction
+	double flux1to7 = 0.;
+	for (int i = 1; i < 8; i++){
+		flux1to7 += (phi0Arms[i-1] - phi0Arms[i]) * bDisk[i];
+	}
+	bDisk[8] = -flux1to7 / (phi0Arms[7] - phi0Arms[8]);
+	bDisk[0] = bDisk[8];
+	bDisk[9] = bDisk[1];
+	bDisk[10] = bDisk[2];
+	
+	// set coefficients for phi integration
+	phiCoeff[0] = 0;
+	for (int i = 1; i < 10; i++){
+		phiCoeff[i] = phiCoeff[i-1] + (bDisk[i-1] - bDisk[i]) * phi0Arms[i-1];
+	}
+	
+	//correct for H(phi0) = 0
+	corr = phiCoeff[idx0] + bDisk[idx0] * phi0;
+	for (int i = 1; i < 10; i++){
+		phiCoeff[i] = phiCoeff[i] - corr;
+	} 
+	
+	// azimuthal halo parameters
+	bNorth = 1.4 * muG;
+	bSouth = -1.1 * muG;
+	rNorth = 9.22 * kpc;
+	rSouth = 17 * kpc;
+	wHalo = 0.20 * kpc;
+	z0 = 5.3 * kpc;
+	
+	// X-field parameters
+	bX = 4.6 * muG;
+	thetaX0 = 49.0 * M_PI / 180.;
+	sinThetaX0 = sin(thetaX0);
+	cosThetaX0 = cos(thetaX0);
+	tanThetaX0 = tan(thetaX0);
+	cotThetaX0 = 1. / tanThetaX0;
+	rXc = 4.8 * kpc;
+	rX = 2.9 * kpc;
+
+	// set striated field parameter
+	sqrtbeta = sqrt(1.36);
+
+	// set turbulent field parameters
+	bDiskTurb[0] = 10.81 * muG;
+	bDiskTurb[1] = 6.96 * muG;
+	bDiskTurb[2] = 9.59 * muG;
+	bDiskTurb[3] = 6.96 * muG;
+	bDiskTurb[4] = 1.96 * muG;
+	bDiskTurb[5] = 16.34 * muG;
+	bDiskTurb[6] = 37.29 * muG;
+	bDiskTurb[7] = 10.35 * muG;
+
+	bDiskTurb5 = 7.63 * muG;
+	zDiskTurb = 0.61 * kpc;
+
+	bHaloTurb = 4.68 * muG; 
+	rHaloTurb = 10.97 * kpc;
+	zHaloTurb = 2.84 * kpc;
+}
+
+void JF12FieldSolenoidal::randomStriated(int seed) {
+	useStriated = true;
+	int N = 100;
+	striatedGrid = new ScalarGrid(Vector3d(0.), N, 0.1 * kpc);
+
+	Random random;
+	if (seed != 0)
+		random.seed(seed);
+
+	for (int ix = 0; ix < N; ix++)
+		for (int iy = 0; iy < N; iy++)
+			for (int iz = 0; iz < N; iz++) {
+				float &f = striatedGrid->get(ix, iy, iz);
+				f = round(random.rand()) * 2 - 1;
+			}
+}
+
+#ifdef CRPROPA_HAVE_FFTW3F
+void JF12FieldSolenoidal::randomTurbulent(int seed) {
+	useTurbulent = true;
+	// turbulent field with Kolmogorov spectrum, B_rms = 1 and Lc = 60 parsec
+	turbulentGrid = new VectorGrid(Vector3d(0.), 256, 4 * parsec);
+	initTurbulence(turbulentGrid, 1, 8 * parsec, 272 * parsec, -11./3., seed);
+}
+#endif
+
+void JF12FieldSolenoidal::setStriatedGrid(ref_ptr<ScalarGrid> grid) {
+	useStriated = true;
+	striatedGrid = grid;
+}
+
+void JF12FieldSolenoidal::setTurbulentGrid(ref_ptr<VectorGrid> grid) {
+	useTurbulent = true;
+	turbulentGrid = grid;
+}
+
+ref_ptr<ScalarGrid> JF12FieldSolenoidal::getStriatedGrid() {
+	return striatedGrid;
+}
+
+ref_ptr<VectorGrid> JF12FieldSolenoidal::getTurbulentGrid() {
+	return turbulentGrid;
+}
+
+void JF12FieldSolenoidal::setUseRegular(bool use) {
+	useRegular = use;
+}
+
+void JF12FieldSolenoidal::setUseDisk(bool use) {
+	useDisk = use;
+}
+
+void JF12FieldSolenoidal::setUseToroidalHalo(bool use) {
+	useToroidalHalo = use;
+}
+
+void JF12FieldSolenoidal::setUseX(bool use) {
+	useX = use;
+}
+
+void JF12FieldSolenoidal::setDelta(double delta) {
+	r1s = r1 + delta;
+	r2s = r2 - delta;
+}
+
+void JF12FieldSolenoidal::setZs(double zs) {
+	zS = zs;
+}
+
+double JF12FieldSolenoidal::getDelta() const {
+	return (r1s - r1);
+}
+
+double JF12FieldSolenoidal::getZs() const {
+	return zS;
+}
+
+void JF12FieldSolenoidal::setUseStriated(bool use) {
+	if ((use) and (striatedGrid)) {
+		std::cout << "JF12FieldSolenoidal: No striated field set: ignored" << std::endl;
+		return;
+	}
+	useStriated = use;
+}
+
+void JF12FieldSolenoidal::setUseTurbulent(bool use) {
+	if ((use) and (turbulentGrid)) {
+		std::cout << "JF12FieldSolenoidal: No turbulent field set: ignored" << std::endl;
+		return;
+	}
+	useTurbulent = use;
+}
+
+bool JF12FieldSolenoidal::isUsingRegular() {
+	return useRegular;
+}
+
+bool JF12FieldSolenoidal::isUsingStriated() {
+	return useStriated;
+}
+
+bool JF12FieldSolenoidal::isUsingTurbulent() {
+	return useTurbulent;
+}
+
+bool JF12FieldSolenoidal::isUsingDisk() {
+	return useDisk;
+}
+
+bool JF12FieldSolenoidal::isUsingToroidalHalo() {
+	return useToroidalHalo;
+}
+
+bool JF12FieldSolenoidal::isUsingX() {
+	return useX;
+}
+
+double JF12FieldSolenoidal::logisticFunction(const double x, const double x0, const double w) const {
+	return 1. / (1. + exp(-2. * (fabs(x) - x0) / w));
+}
+
+Vector3d JF12FieldSolenoidal::getRegularField(const Vector3d& pos) const {
+	Vector3d b(0.);
+
+	double r = sqrt(pos.x * pos.x + pos.y * pos.y); // in-plane radius
+	double d = pos.getR(); // distance to galactic center
+
+	double phi = pos.getPhi(); // azimuth
+	double sinPhi = sin(phi);
+	double cosPhi = cos(phi);
+	
+	b += getDiskField(r, pos.z, phi, sinPhi, cosPhi);
+	b += getToroidalHaloField(r, pos.z, sinPhi, cosPhi);
+	b += getXField(r, pos.z, sinPhi, cosPhi);
+
+	return b;
+}
+
+Vector3d JF12FieldSolenoidal::getStriatedField(const Vector3d& pos) const {
+	return (getRegularField(pos)
+			* (1. + sqrtbeta * striatedGrid->closestValue(pos)));
+}
+
+double JF12FieldSolenoidal::getTurbulentStrength(const Vector3d& pos) const {
+	// Turbulent JF12 field WITHOUT any alterations as of yet! Be careful when using this.
+	
+	if (pos.getR() > 20 * kpc)
+		return 0;
+
+	double r = sqrt(pos.x * pos.x + pos.y * pos.y); // in-plane radius
+	double phi = pos.getPhi(); // azimuth
+
+	// disk
+	double bDisk = 0;
+	if (r < 5 * kpc) {
+		bDisk = bDiskTurb5;
+	} else {
+		// spiral region
+		double r_negx = r * exp(-(phi - M_PI) / tan90MinusPitch);
+		if (r_negx > rArms[7])
+			r_negx = r * exp(-(phi + M_PI) / tan90MinusPitch);
+		if (r_negx > rArms[7])
+			r_negx = r * exp(-(phi + 3 * M_PI) / tan90MinusPitch);
+
+		for (int i = 7; i >= 0; i--)
+			if (r_negx < rArms[i])
+				bDisk = bDiskTurb[i];
+
+		bDisk *= (5 * kpc) / r;
+	}
+	bDisk *= exp(-0.5 * (pos.z / zDiskTurb) * (pos.z / zDiskTurb));
+
+	// halo
+	double bHalo = bHaloTurb * exp(-r / rHaloTurb)
+			* exp(-0.5 * (pos.z / zHaloTurb) * (pos.z / zHaloTurb));
+
+	// modulate turbulent field
+	return sqrt(bDisk * bDisk + bHalo * bHalo);
+}
+
+Vector3d JF12FieldSolenoidal::getTurbulentField(const Vector3d& pos) const {
+	return (turbulentGrid->interpolate(pos) * getTurbulentStrength(pos));
+}
+
+Vector3d JF12FieldSolenoidal::getField(const Vector3d& pos) const {
+	Vector3d b(0.);
+	if (useTurbulent)
+		b += getTurbulentField(pos);
+	if (useStriated)
+		b += getStriatedField(pos);
+	else if (useRegular)
+		b += getRegularField(pos);
+	return b;
+}
+
+Vector3d JF12FieldSolenoidal::getDiskField(const double r, const double z, const double phi, const double sinPhi, const double cosPhi) const {
+	// improved disk field with transition to ring region in [r1,r1s] and [r2s,r2]
+	Vector3d b(0.);
+
+	if (useDisk && (r * r + z * z < 400 * kpc * kpc)){
+		
+		double lfDisk = logisticFunction(z, hDisk, wDisk); // for vertical scaling
+		
+		double hint = PhiIntegralH(r, phi);
+		double mag1 = getSpiralStrength(r, phi); // returns b_j for current spiral arm
+		
+		if ((r1 < r) && (r < r2)) {
+			
+			double pdelta = p(r);
+			double qdelta = q(r);
+			double br = pdelta * mag1 * sinPitch;
+			double bphi = pdelta * mag1 * cosPitch - qdelta * hint * sinPitch;
+		
+			b.x += br * cosPhi - bphi * sinPhi;
+			b.y += br * sinPhi + bphi * cosPhi;
+			
+			b *= (1 - lfDisk);
+		}
+	}
+	
+	return b;		
+}
+
+Vector3d JF12FieldSolenoidal::getToroidalHaloField(const double r, const double z, const double sinPhi, const double cosPhi) const {
+	// same as initial JF12, moved in a seperate function for clearness
+	Vector3d b(0.);
+	
+	if (useToroidalHalo && (r * r + z * z > 1 * kpc * kpc) && (r * r + z * z < 400 * kpc * kpc)){
+		
+		double lfDisk = logisticFunction(z, hDisk, wDisk);
+		double bMagH = exp(-fabs(z) / z0) * lfDisk;
+		
+		if (z >= 0)
+			bMagH *= bNorth * (1 - logisticFunction(r, rNorth, wHalo));
+		else
+			bMagH *= bSouth * (1 - logisticFunction(r, rSouth, wHalo));
+		b.x += -bMagH * sinPhi;
+		b.y += bMagH * cosPhi;
+	}
+	
+	return b;
+}
+
+Vector3d JF12FieldSolenoidal::getXField(const double r, const double z, const double sinPhi, const double cosPhi) const {
+	// improved X-field with parabolic field lines at abs(z) < zs
+	Vector3d b(0.);
+	
+	if (useX && (r * r + z * z < 400. * kpc * kpc)){
+		
+		double bMagX;
+		double sinThetaX, cosThetaX;
+		double rp; // radius where current intial field line passes z = 0
+		double rc = rXc + fabs(z) / tanThetaX0; 
+		double r0c = rXc + zS / tanThetaX0; // radius where field line through rXc passes z = zS
+		double f, r0, br0, bz0;
+		bool inner = true; // distinguish between inner and outer region
+		
+		// return intial field if z>=zS
+		if (fabs(z) > zS){
+			
+			if ((r == 0.)){
+				b.z = bX / ((1. + fabs(z) * cotThetaX0 / rXc) * (1. + fabs(z) * cotThetaX0 / rXc));
+				return b;
+			}
+			
+			if (r < rc) {	
+			// inner varying elevation region
+			
+				rp = r * rXc / rc;
+				bMagX = bX * exp(-1 * rp / rX) * (rXc / rc) * (rXc / rc);
+				
+				double thetaX = atan(fabs(z) / (r - rp));
+				
+				if (z == 0)
+					thetaX = M_PI / 2.;
+				
+				sinThetaX = sin(thetaX);
+				cosThetaX = cos(thetaX);
+				
+				double zsign = z < 0 ? -1 : 1;
+				
+				b.x += zsign * bMagX * cosThetaX * cosPhi;
+				b.y += zsign * bMagX * cosThetaX * sinPhi;
+				b.z += bMagX * sinThetaX;
+			}
+			else {
+			// outer constant elevation region
+				rp = r - fabs(z) / tanThetaX0;
+				bMagX = bX * exp(-rp / rX) * (rp / r);
+				
+				sinThetaX = sinThetaX0;
+				cosThetaX = cosThetaX0;
+				
+				double zsign = z < 0 ? -1 : 1;
+				b.x += zsign * bMagX * cosThetaX * cosPhi;
+				b.y += zsign * bMagX * cosThetaX * sinPhi;
+				b.z += bMagX * sinThetaX;
+			}
+		}
+		// parabolic field lines for z<zS
+		else {
+				// determine r at which parabolic field line through (r,z) passes z = zS
+				r0 = r * 1. / (1.- 1./ (2. * (zS + rXc * tanThetaX0)) * (zS - z * z / zS));
+				
+				// determine correct region (inner/outer)
+				if (r0 >= r0c){
+					r0 = r + 1. / (2. * tanThetaX0) * (zS - z * z / zS);
+					inner = false;
+				}
+				
+				// field strength at that position
+				 if (r0 < r0c){
+					 
+					 rp = r0 * rXc / r0c;
+					 double thetaX = atan(zS / (r0 - rp));
+					 
+					 // field strength at (r0,zS) for inner region
+					 br0 = bX * exp(- rp / rX) * (rXc/ r0c) * (rXc/ r0c) * cos(thetaX);
+					 bz0 = bX * exp(- rp / rX) * (rXc/ r0c) * (rXc/ r0c) * sin(thetaX);
+				 }
+				 else {
+					 
+					 // field strength at (r0,zS) for outer region
+					 rp = r0 - zS / tanThetaX0;
+					 br0 =  bX * exp(- rp / rX) * (rp/r0) * cosThetaX0;
+					 bz0 =  bX * exp(- rp / rX) * (rp/r0) * sinThetaX0;
+					 
+				 }
+				 
+				 // compute factor F for solenoidality
+				 if (inner){
+					 f = 1. / ((1. - 1./( 2. + 2. * (rXc * tanThetaX0/ zS)) * (1. - (z / zS) * (z / zS))) * (1. - 1./( 2. + 2. * (rXc * tanThetaX0/ zS)) * (1. - (z / zS) * (z / zS))));
+				 }
+				 else{
+					 f = 1. + 1/ (2 * r * tanThetaX0/ zS) * (1. - (z / zS) * (z / zS)); 
+				 }
+				 
+				 double br = z / zS * f * br0;
+				 double bz = bz0 * f;
+				 
+				 b.x += br * cosPhi;
+				 b.y += br * sinPhi;
+				 b.z += bz;
+		}
+	}
+	return b;
+}
+
+double JF12FieldSolenoidal::p(const double r) const {
+	//transition polynomial p_delta(r)
+	
+	// 0 disk field outside
+	if ((r < r1) || (r > r2)) {
+		return 0.;
+	}	
+	// unchanged field
+	if ((r > r1s) && (r < r2s)) {
+		return r1/r;
+	}
+	
+	// transitions region parameters
+	double r_a = r1;
+	double r_b = r1s;
+	
+	if (r >= r2s) {
+		r_a = r2;
+		r_b = r2s;
+	}
+	
+	// differentiable transition at r_s, continous at r_a
+	double fakt = (r_a / r_b - 2.) / ((r_a - r_b) *  (r_a - r_b));
+	return (r1/r_b) * (2. - r / r_b + fakt * (r-r_b) * (r-r_b));
+}	
+
+double JF12FieldSolenoidal::q(const double r) const {
+	//transition polynomial derivative
+	
+	// 0 disk field outside
+	if ((r < r1) || (r > r2)) {
+		return 0.;
+	}	
+	// unchanged field
+	if ((r > r1s) && (r < r2s)) {
+		return 0.;
+	}
+	
+	// transitions region parameters
+	double r_a = r1;
+	double r_b = r1s;
+	
+	if (r >= r2s) {
+		r_a = r2;
+		r_b = r2s;
+	}
+	
+	// differentiable transition at r_s, continous at r_a
+	double fakt = (r_a / r_b - 2.) / ((r_a - r_b) * (r_a - r_b));
+	return (r1/r_b) * (2. - 2. * r/r_b + fakt * (3. * r * r - 4. * r * r_b + r_b * r_b));
+}
+
+double JF12FieldSolenoidal::PhiIntegralH(const double r, const double phi) const {
+	// evaluate BphiIntegral for solenodality/flux redistribution in ring-spiral transition region
+	double H_ret = 0.;
+	int idx = 1;
+	
+	if ((r1 < r) && (r < r2)){
+		double phi1 = phi - log(r/r1) * cotPitch;
+		phi1 = atan2(sin(phi1) , cos(phi1)); // map to [-pi,+pi]
+		while (phi1 < phi0Arms[idx]){
+			idx += 1;
+		}
+		H_ret = phi1 * bDisk[idx] + phiCoeff[idx];
+	}
+	
+	return H_ret;
+	
+}
+
+double JF12FieldSolenoidal::getSpiralStrength(const double r, const double phi) const {
+	// return field strength b_j for current spiral arm
+	double b_ret = 0.;
+	int idx = 1;
+	
+	if ((r1 < r) && (r < r2)){
+		double phi1 = phi - log(r/r1) * cotPitch;
+		phi1 = atan2(sin(phi1), cos(phi1)); // map to [-pi,+pi]
+		while (phi1 < phi0Arms[idx]){
+			idx += 1;
+		}
+		b_ret = bDisk[idx];
+	}
+	
+	return b_ret;
+}
+
+} // namespace crpropa


### PR DESCRIPTION
Add a modified JF12 Galactic Magnetic field model, which is detailed in Kleimann, Schorlepp, Merten and Becker Tjus, "Solenoidal improvements for the JF12 Galactic magnetic field model", [arXiv:1809.07528](https://arxiv.org/abs/1809.07528v1), as a new MagneticField called "JF12Solenoidal". This model includes both a smooth redistribution of magnetic flux of the spiral disk field (to avoid cut off fieldlines and thus violations of magnetic flux conservation), and a smooth X field with parabolic fieldlines near the z=0 plane. The current field implementation was used for the numerical tests in the article to investigate whether the smoothed field leads to an improved performance of the DiffusionSDE module.