### PR TITLE
custom photon fields / SOPHIA update

### DIFF
--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -1,7 +1,8 @@
 #ifndef CRPROPA_PHOTONBACKGROUND_H
 #define CRPROPA_PHOTONBACKGROUND_H
 
-#include <string>
+#include <crpropa/Vector3.h>
+#include <crpropa/Grid.h>
 
 namespace crpropa {
 
@@ -11,6 +12,7 @@ namespace crpropa {
  */
 // Photon fields
 // The default IRB model is that of Kneiske et al. 2004
+// The slots PF1 to PF8 may be used for custom photon fields
 enum PhotonField {
 	CMB,
 	IRB,  // same as IRB_Kneiske04
@@ -22,7 +24,9 @@ enum PhotonField {
 	IRB_Gilmore12,
 	IRB_Stecker16_upper,
 	IRB_Stecker16_lower,
-	URB_Protheroe96
+	URB_Protheroe96,
+	PF1, PF2, PF3, PF4,  // customizable
+	PF5, PF6, PF7, PF8,  // field slots
 };
 
 // Returns overall comoving scaling factor
@@ -30,6 +34,56 @@ double photonFieldScaling(PhotonField photonField, double z);
 
 // Returns a string representation of the field
 std::string photonFieldName(PhotonField photonField);
+
+/** 
+ @class CustomPhotonField
+ @brief Handler class for photon fields. Provides the sampleEps method.
+
+ sampleEps draws a photon from a given photon background. This method 
+ and all methods it depends on have been inspired by the SOPHIA code.
+ */
+class CustomPhotonField {
+public:
+	/** Constructor for photon field data
+	 @param fieldPath  path/to/photonField.txt
+	 */
+	explicit CustomPhotonField(std::string fieldPath);
+
+	/* Empty constructor to ease initialization in some modules
+	 */
+	CustomPhotonField();
+
+	/** Draws a photon from the photon background
+	 @param onProton  true=proton, false=neutron
+	 @param Ein       energy of primary
+	 @param zIn       redshift of primary
+	 */
+	double sampleEps(bool onProton, double Ein, double zIn) const;
+
+	/** Returns the photon field density in 1/(Jm³).
+		Multiply by h*nu for physical photon density.
+	 @param eps   photon energy in eV
+	 @param zIn   redshift
+	*/
+	double getPhotonDensity(double eps, double z) const;
+
+	/** Returns the crossection of p-gamma interaction
+	 @param eps       photon energy
+	 @param onProton  true=proton, false=neutron
+	*/
+	double SOPHIA_crossection(double eps, bool onProton) const;
+
+protected:
+	std::vector<double> photonEnergy;
+	std::vector<double> photonRedshift;
+	std::vector<double> photonDensity;
+	void init(std::string fieldPath);
+	double SOPHIA_probEps(double eps, bool onProton, double Ein, double zIn) const;
+	double SOPHIA_pl(double x, double xth, double xmax, double alpha) const;
+	double SOPHIA_ef(double x, double th, double w) const;
+	double SOPHIA_breitwigner(double sigma_0, double Gamma, double DMM, double epsPrime, bool onProton) const;
+	double SOPHIA_functs(double s, bool onProton) const;
+};
 
 /** @}*/
 } // namespace crpropa

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -1,11 +1,16 @@
 #include "crpropa/PhotonBackground.h"
 #include "crpropa/Common.h"
+#include "crpropa/Random.h"
+#include "crpropa/Units.h"
 
 #include <vector>
 #include <fstream>
 #include <stdexcept>
 #include <limits>
 #include <cmath>
+#include <sstream>
+#include <iostream>
+#include <string>
 
 namespace crpropa {
 
@@ -64,8 +69,10 @@ static PhotonFieldScaling scalingStecker16_lower("IRB_Stecker16_lower");
 
 double photonFieldScaling(PhotonField photonField, double z) {
 	switch (photonField) {
-	case CMB:
-		return 1;  // constant comoving photon number density
+	case CMB: // constant comoving photon number density
+	case PF1: case PF2: case PF3: case PF4:
+	case PF5: case PF6: case PF7: case PF8:
+		return 1;
 	case IRB:
 	case IRB_Kneiske04:
 		return scalingKneiske04.scalingFactor(z);
@@ -84,12 +91,9 @@ double photonFieldScaling(PhotonField photonField, double z) {
 	case IRB_Stecker16_lower:
 		return scalingStecker16_lower.scalingFactor(z);
 	case URB_Protheroe96:
-		if (z < 0.8)
-			return 1;
-		if (z < 6)
-			return pow((1 + 0.8) / (1 + z), 4);
-		else
-			return 0;
+		if (z < 0.8) { return 1; }
+		if (z < 6) { return pow((1 + 0.8) / (1 + z), 4); }
+		else { return 0; }
 	default:
 		throw std::runtime_error("PhotonField: unknown photon background");
 	}
@@ -97,30 +101,295 @@ double photonFieldScaling(PhotonField photonField, double z) {
 
 std::string photonFieldName(PhotonField photonField) {
 	switch (photonField) {
-	case CMB:
-		return "CMB";
-	case IRB:
-	case IRB_Kneiske04:
-		return "IRB_Kneiske04";
-	case IRB_Stecker05:
-		return "IRB_Stecker05";
-	case IRB_Franceschini08:
-		return "IRB_Franceschini08";
-	case IRB_Finke10:
-		return "IRB_Finke10";
-	case IRB_Dominguez11:
-		return "IRB_Dominguez11";
-	case IRB_Gilmore12:
-		return "IRB_Gilmore12";
-	case IRB_Stecker16_upper:
-		return "IRB_Stecker16_upper";
-	case IRB_Stecker16_lower:
-		return "IRB_Stecker16_lower";
-	case URB_Protheroe96:
-		return "URB_Protheroe96";
-	default:
-		throw std::runtime_error("PhotonField: unknown photon background");
+		case CMB: return "CMB";
+		case PF1: return "PF1";
+		case PF2: return "PF2";
+		case PF3: return "PF3";
+		case PF4: return "PF4";
+		case PF5: return "PF5";
+		case PF6: return "PF6";
+		case PF7: return "PF7";
+		case PF8: return "PF8";
+		case IRB:
+		case IRB_Kneiske04: return "IRB_Kneiske04";
+		case IRB_Stecker05: return "IRB_Stecker05";
+		case IRB_Franceschini08: return "IRB_Franceschini08";
+		case IRB_Finke10: return "IRB_Finke10";
+		case IRB_Dominguez11: return "IRB_Dominguez11";
+		case IRB_Gilmore12: return "IRB_Gilmore12";
+		case IRB_Stecker16_upper: return "IRB_Stecker16_upper";
+		case IRB_Stecker16_lower: return "IRB_Stecker16_lower";
+		case URB_Protheroe96: return "URB_Protheroe96";
+		default:
+			throw std::runtime_error("PhotonField: unknown photon background");
 	}
+}
+
+CustomPhotonField::CustomPhotonField(std::string fieldPath) {
+	init(fieldPath);
+}
+
+CustomPhotonField::CustomPhotonField() {
+	// empty constructor for initialization in some modules
+}
+
+void CustomPhotonField::init(std::string filename) {
+	std::vector< std::vector<double> > dndeps;
+	std::ifstream infile(filename.c_str());
+	if (!infile.good())
+		throw std::runtime_error("PhotoPionProduction @ CustomPhotonField::init : could not open file " + filename);
+	std::string line;
+	int i = 0;
+	while (std::getline(infile, line)) {
+		if (line.at(0) == '#')
+			continue;
+		std::istringstream ss(line);
+		std::vector<double> vec;
+		double n;
+		while (ss >> n)
+			vec.push_back(n);
+		if (i == 0) {
+			photonEnergy = vec;
+			i++;
+			continue;
+		}
+		if (i == 1) {
+			photonRedshift = vec;
+			i++;
+			continue;
+		}
+		dndeps.push_back(vec);
+	}
+	for (int i = 0; i < photonEnergy.size(); ++i) {
+		for (int j = 0; j < photonRedshift.size(); ++j) {
+			photonDensity.push_back(dndeps[i][j]);
+		}
+	}
+	infile.close();
+}
+
+double CustomPhotonField::sampleEps(bool onProton, double Ein, double zIn) const {
+/*
+	- input: particle type with energy Ein at redshift z
+	- output: photon energy [eV] of random photon of photon field
+	- samples distribution of n(epsilon)/epsilon^2
+*/
+	const double zMax = photonRedshift[photonRedshift.size() - 1];
+	if (zIn > zMax)
+		return 0.;
+
+	Ein /= GeV;  // SOPHIA standard unit
+	// calculate pMax and its norm factor via maximum such that peps <= 1
+	double cnorm = 0.;
+	double pMax = 0.;
+	for (int i = 0; i < photonEnergy.size(); ++i) {
+		double prob = SOPHIA_probEps(photonEnergy[i], onProton, Ein, zIn);
+		cnorm += prob;
+		if (prob > pMax)
+			pMax = prob;
+	}
+	pMax /= cnorm;
+
+	// sample eps between epsMin ... epsMax
+	const double epsMin = photonEnergy[0];
+	const double epsMax = photonEnergy[photonEnergy.size() - 1];
+	double eps;
+	double peps;
+	Random &random = Random::instance();
+	do {
+		eps = epsMin + random.rand() * (epsMax - epsMin);
+		peps = SOPHIA_probEps(eps, onProton, Ein, zIn) / cnorm;
+	} while (random.rand() * pMax > peps);
+	return eps;
+}
+
+double CustomPhotonField::SOPHIA_probEps(double eps, bool onProton, double Ein, double zIn) const {
+/*
+	- input: eps [eV]
+	- output: probability to encounter photon of energy eps
+	- called by: sampleEps, gaussInt
+*/
+	const double mass = onProton? 0.93827 : 0.93947;  // Gev/c^2
+	double gamma = Ein / mass;
+	double beta = std::sqrt(1. - 1. / gamma / gamma);
+	double photonDensity = getPhotonDensity(eps * eV, zIn) / 6.2415091e24;  // 1/(Jm³) -> 1/(eVcm³)
+	if (photonDensity == 0.) {
+		return 0.;
+	} else {
+		double sMin = 1.1646;  // head-on collision
+		double sMax = std::max(sMin, mass * mass + 2. * eps / 1.e9 * Ein * (1. + beta));
+		const double x[8] = {.0950125098, .2816035507, .4580167776, .6178762444,
+							 .7554044083, .8656312023, .9445750230, .9894009349};
+		const double w[8] = {.1894506104, .1826034150, .1691565193, .1495959888,
+							 .1246289712, .0951585116, .0622535239, .0271524594};
+		double xm = 0.5 * (sMax + sMin);
+		double xr = 0.5 * (sMax - sMin);
+		double ss = 0.;
+		for (int i = 0; i < 8; ++i) {
+			double dx = xr * x[i];
+			ss += w[i] * (SOPHIA_functs(xm + dx, onProton) + SOPHIA_functs(xm - dx, onProton));
+		}
+		double sIntegral = xr * ss;
+		return photonDensity / eps / eps * sIntegral / 8. / beta / Ein / Ein * 1.e24;
+	}
+}
+
+double CustomPhotonField::getPhotonDensity(double eps, double z) const {
+/*
+	- input: photon energy, redshift
+	- output: dndeps(e,z) [#/(eV cm^3)] from input file
+	- called by: sampleEps
+*/
+	return interpolate2d(eps / eV, z, photonEnergy, photonRedshift, photonDensity) * 6.2415091e24;  // 1/(eVcm³)->1/(Jm³)
+}
+
+double CustomPhotonField::SOPHIA_crossection(double x, bool onProton) const {
+/* 
+	- input: photon energy [eV], specifier: 0=neutron, 1=proton
+	- output: SOPHIA_crossection of nucleon-photon-interaction [area]
+	- called by: SOPHIA_functs
+*/  
+	const double mass = onProton? 0.93827 : 0.93947;  // Gev/c^2
+	double sth = 1.1646;
+	double s = mass * mass + 2. * mass * x;
+	if (s < sth)
+		return 0.;
+	// upper: proton resonance masses
+	// lower: neutron resonance masses
+	const double AMRES[18] = {1.231, 1.440, 1.515, 1.525, 1.675, 1.680, 1.690, 1.895, 1.950,
+							  1.231, 1.440, 1.515, 1.525, 1.675, 1.675, 1.690, 1.895, 1.950};
+	const double BGAMMA[18] = {5.6, 0.5, 4.6, 2.5, 1., 2.1, 2., 0.2, 1.,
+							   6.1, 0.3, 4.0, 2.5, 0., 0.2, 2., 0.2, 1.};
+	const double WIDTH[18] = {0.11, 0.35, 0.11, 0.1, 0.16, 0.125, 0.29, 0.35, 0.3,
+							  0.11, 0.35, 0.11, 0.1, 0.16, 0.150, 0.29, 0.35, 0.3};
+	const double RATIOJ[18] = {1., 0.5, 1., 0.5, 0.5, 1.5, 1., 1.5, 2.,
+							   1., 0.5, 1., 0.5, 0.5, 1.5, 1., 1.5, 2.};
+	const double AM2[2] = {0.882792, 0.880351};
+
+	int idx = onProton? 0 : 9;
+	double SIG0[9];
+	for (int i = 0; i < 9; ++i) {
+		SIG0[i] = 4.893089117 / AM2[int(onProton)] * RATIOJ[i + idx] * BGAMMA[i + idx];
+	}
+	double cross_dir = 0.;
+	double cross_res = 0.;
+	if (x <= 10.) {
+		cross_res = SOPHIA_breitwigner(SIG0[0], WIDTH[0 + idx], AMRES[0 + idx], x, onProton)
+				  * SOPHIA_ef(x, 0.152, 0.17);
+		for (int i = 1; i < 9; ++i) {
+			cross_res = SOPHIA_breitwigner(SIG0[i], WIDTH[i + idx], AMRES[i + idx], x, onProton)
+					   * SOPHIA_ef(x, 0.15, 0.38);
+		}
+		// direct channel
+		double cross_dir1 = 0.;
+		if ( (x > 0.1) && (x < 0.6) ) {
+			cross_dir1 = 92.7 * SOPHIA_pl(x, 0.152, 0.25, 2.)  // single pion production
+					   + 40.0 * std::exp(-(x - 0.29) * (x - 0.29) / 0.002)
+					   - 15.0 * std::exp(-(x - 0.37) * (x - 0.37) / 0.002);
+		} else {
+			cross_dir1 = 92.7 * SOPHIA_pl(x, 0.152, 0.25, 2.);  // single pion production
+		}
+		double cross_dir2 = 37.7 * SOPHIA_pl(x, 0.4, 0.6, 2.);  // double pion production
+		cross_dir = cross_dir1 + cross_dir2;
+	}
+	// fragmentation 2:
+	double cross_frag2;
+	if (onProton) {
+		cross_frag2 = 80.3 * SOPHIA_ef(x, 0.5, 0.1) * std::pow(s, -0.34);
+	} else {
+		cross_frag2 = 60.2 * SOPHIA_ef(x, 0.5, 0.1) * std::pow(s, -0.34);
+	}
+	// multipion production/fragmentation 1 cross section
+	double cs_multidiff = 0.;
+	if (x > 0.85) {
+		double ss1 = (x - 0.85) / 0.69;
+		double ss2;
+		if (onProton) {
+			ss2 = 29.3 * std::pow(s, -0.34) + 59.3 * std::pow(s, 0.095);
+		} else {
+			ss2 = 26.4 * std::pow(s, -0.34) + 59.3 * std::pow(s, 0.095);
+		}
+		cs_multidiff = (1. - std::exp(-ss1)) * ss2;
+		// diffractive scattering:
+		double cross_diffr = 0.11 * cs_multidiff;
+		// **************************************
+		ss1 = std::pow((x - 0.85), 0.75) / 0.64;
+		ss2 = 74.1 * std::pow(x, -0.44) + 62. * std::pow(s, 0.08);
+		double cs_tmp = 0.96 * (1. - std::exp(-ss1)) * ss2;
+		double cross_diffr1 = 0.14 * cs_tmp;
+		double cross_diffr2 = 0.013 * cs_tmp;
+		double cs_delta = cross_frag2
+						- (cross_diffr1+cross_diffr2-cross_diffr);
+		double cs_multi = 0.89 * cs_multidiff;
+		if (cs_delta < 0.) {
+			cross_frag2 = 0.;
+			cs_multi += cs_delta;
+		} else {
+			cross_frag2 = cs_delta;
+		}
+		cross_diffr = cross_diffr1 + cross_diffr2;
+		cs_multidiff = cs_multi + cross_diffr;
+	}
+	return (cross_res + cross_dir + cs_multidiff + cross_frag2) * 1.e-34;  // µbarn to m²
+}
+
+double CustomPhotonField::SOPHIA_pl(double x, double xth, double xmax, double alpha) const {
+/*
+	- input: photon energy [eV], threshold [eV], max [eV], unknown [no unit]
+	- output: unknown [no unit]
+	- called by: SOPHIA_crossection
+*/
+	if (xth > x)
+		return 0.;
+	double a = alpha * xmax / xth;
+	double prod1 = std::pow((x - xth) / (xmax - xth), (a - alpha));
+	double prod2 = std::pow(x / xmax, -a);
+	return prod1 * prod2;
+}
+
+double CustomPhotonField::SOPHIA_ef(double x, double th, double w) const {
+/*
+	- input: photon energy [eV], threshold [eV], unknown [eV]
+	- output: unknown [no unit]
+	- called by: SOPHIA_crossection
+*/
+	double wth = w + th;
+	if (x <= th) {
+		return 0.;
+	} else if ((x > th) && (x < wth)) {
+		return (x - th) / w;
+	} else if (x >= wth) {
+		return 1.;
+	} else {
+		throw std::runtime_error("error in function PhotonBackground::SOPHIA_ef");
+	}
+}
+
+double CustomPhotonField::SOPHIA_breitwigner(double sigma_0, double Gamma, double DMM,
+	double epsPrime, bool onProton) const {
+/*
+	- input: cross section [µbarn], width [GeV], mass [GeV/c^2]
+	- output: Breit-Wigner SOPHIA_crossection of a resonance widh width Gamma
+	- called by: SOPHIA_crossection
+*/
+	const double mass = onProton? 0.93827 : 0.93947;  // Gev/c^2
+	double s = mass * mass + 2. * mass * epsPrime;
+	double gam2s = Gamma * Gamma * s;
+	return sigma_0 * (s / epsPrime / epsPrime) * gam2s
+				   / ((s - DMM*DMM) * (s - DMM * DMM) + gam2s);
+}
+
+double CustomPhotonField::SOPHIA_functs(double s, bool onProton) const {
+/*
+	- input: s [GeV^2] 
+	- output: (s-p^2)*sigma_(nucleon/gamma) [GeV^2*area]
+	- called by: sampleEps
+*/  
+	const double mass = onProton? 0.93827 : 0.93947;  // Gev/c^2
+	double factor = s - mass * mass;
+	double epsPrime = factor / 2. / mass;
+	double sigma_pg = SOPHIA_crossection(epsPrime, onProton) / 1.e-34;  // m² to µbarn
+	return factor * sigma_pg;
 }
 
 } // namespace crpropa


### PR DESCRIPTION
Dear all,

with this pull request I want to provide the first of three parts that I wish to contribute to CRPropa. This approach follows the comments made in #218 


**Content:**


This extension is meant to introduce variable photon fields to CRPropa. Previously, there has only been the CMB and several IRB models. This photon field extension basically follows three concepts:

The photon field may

1) have any shape, i.e. any dependence of photon energy and field density
2) have any spacial and temporal behaviour (which is part of a future pull request)
3) be modified even after CRPropa has been installed


**Changelog (most severe changes):**


~/src/PhotonBackground.cpp
~/include/PhotonBackground.h

There are now eight new slots PF1..PF8 that may be included in the simulation. A class has been added to draw a random photon from the photon field that takes the primary, the nucleon/gamma crossection and the photon field's shape into account. This method and all those that it depends on have been inspired by SOPHIA.

Photon fields are now contained in photon field files in ~/share/crpropa/Scaling/ . For detailed information on the format and use of these fields, there is a [Wiki page](https://github.com/Froehliche-Kernschmelze/CRPropa3/wiki/How-to-create-and-use-custom-photon-fields) in my forked repository.

~/libs/sophia/sophia_interface.f

The main point of these changes to SOPHIA is to run the code on other photon fields than the CMB and IRB Kneiske (as only these two are implemented so far in SOPHIA). SOPHIA samples photons from these fields with its own photon sampling routine which in this version has been removed and replaced by the sampling method mentioned in the section above. For this, the input and output parameters of SOPHIA changed from
```
sophiaevent(nature, Ein, OutPart, OutPartType, NbOutPart, z_particle, bgFlag, Zmax_IRB, idatamax, en_data, flux_data)
```
to
```
sophiaevent(nature, Ein, OutPart, OutPartType, NbOut, eps).
```
Furthermore, SOPHIA has recieved:
- a removal of all parts of the program that are never used under any circumstances
- a removal of all GOTO pointers which have been replaced by safer control structures
- a unified indentation to ehance the readability of the code
- a re-naming of several variables and methods from cryptic abbreviations to full identifiers
- docstrings in most functions that as far as tracable describe their functions

~/src/module/PhotonPionProduction.cpp
~/include/module/PhotonPionProduction.h

The flag "haveRedshiftDependence" and all its associated functions have been removed as now all photon fields are represented on grids that are redshift-dependent. The signature of SOPHIA has been updated. The treatment of secondary particles being produced in SOPHIA has been rewritten in a more intuitively readable way. Also, this particle treatment did not allow for more than one hadron to be added among all secondaries produced by SOPHIA. This is valid for the CMB and IRB models as not eanough energy in the center of mass system would be present to produce nucleon/anti-nucleon pairs. However, with more energetic photon fields, these particles may occur. I would like to stress that no kind of anti-nucleon can be produced in the current implementation, even if it were produced.


**Tests**


As photon sampling is removed from SOPHIA and now provided within CRPropa, SOPHIA's sampling routines and its CRPropa counterparts are expected to produce similar results. Therefore, the following tests have been run according to their hierarchy in the procedure of sampling photons:

Hierarchy of sampling functions (highest to lowest):
```
sample_eps -> prob_eps -> get_photonDensity, gaussInt -> functs -> crossection
```
Reference simulation setup:
```
SimplePropagation(10 kpc, 100 kpc)
PhotoPionProduction(field=CMB, neutrinos=True)
Source @ (100 Mpc, 0, 0)										
Injected: 100.000 monoenergetic protons with 1e12 GeV
```
1) crossection is the deepest layer to be tested. Note that the SOPHIA function that returns the nucleon-gamma xsection does not depend on the nucleon's energy itself but rather on the fact whether or not it deals with a proton or a neutron. 
The reference simulation called the crossection function roughly 500.000 times. The sampled photon's energies have been injected into the newly written C++ version of crossection producing another set of ca 500.000 crossection values. These two samples have been inserted into the scipy.stats.ks_2samp Kolmogorov-Smirnov test. A result of D=0.0 and p=1.0 corresponds to total identity in this implementation of the Kolmogorov-Smirnov test. The test achieved a result of D=0.0011, p=0.9183. Note that the functions Ef, Pl and breitwigner are only used by crossection.

2) In an analogous way, the function gaussInt has been tested, which integrates the function functs over all center-of-mass energies. the function functs is only called by gaussint, whereas functs is the only function calling crossection. The KS test yielded a result of D=9.61e-5, p=0.9999999999 between the SOPHIA output and the C++ version.

3) prob_eps calculates the non-normalized probability to encounter a photon of the given photon field. Normalization is achieved by dividing the integral of prob_eps over its entire photon energy range. prob_eps is the only function calling gaussInt and get_photonDensity. For better comparison, get_photonDensity has been replaced by an analytical expression returning the photon density of the CMB, i.e. a blackbody with a temprature of 2.73 K. The results of SOPHIA vs C++ yield D=9.61e-5, p=0.9999999999. Results on grid data (and runtimes) are discussed in a later section.

4) Finally, sample_eps calls prob_eps to sample a photon. This happens in two steps: a) calculate the normalization and the photon energy with which one most likely gets an interaction. b) monte-carlo sample a photon from the field, use norm factor and max probability for this. For comparison, the SOPHIA output has been tested vs the C++ analytical expression for the photon density and vs the grid readout. The KS test yields:
```
SOPHIA vs C++ (analytic):     D=0.0224, p=0.0114
SOPHIA vs C++ (grid):         D=0.0225, p=0.0110
C++ (analytic) vs C++ (grid): D=0.0001, p=0.9999
```
Insights: the grid version and the analytic version are able to produce nearly identical outputs, however less similarity is achieved compared to SOPHIA. In return, SOPHIA operates a dedicated sampling routine that only works for the CMB this making several assumptions about the shape of the field in beforehand. The C++ version do not require any information that is not encoded in the photon field file. One might be interested in the fact that SOPHIA uses its own random number generator whereas the C++ routines have been run with std::srand().

5) Totally finally, the sampling method is implemented into CRPropa and tested on observables. For this, the neutrino output (energies) of the reference simulation has been chosen. The KS test result of a neutrino the neutrino outputs acquired by SOPHIA vs C++ sampling have been tested in three ways fore comparison: a) using no grid i.e. the analytical density readout b) density readout of a CMB grid with 101 points of resolution c) density readout of a CMB grid with 1001 points of resolution
```
SOPHIA vs C++ (analytic):  1:57 | 2:20 @ D=0.0035, p=0.3514
SOPHIA vs C++ (Grid_101):  1:57 | 2:20 @ D=0.0037, p=0.2716
SOPHIA vs C++ (Grid_1001): 1:57 | 5:58 @ D=0.0035, p=0.3514
```
Insights: The C++ small grid / analytic versions perform roughly 20% slower than SOPHIA. A larger grid may reach the analytic version at the expense of runtime. All C++ versions perform similarly but do not reach identity with the SOPHIA version. The two points coming to my mind are:
a) the C++ version of sampling has been done on CRPropa's random number generator, SOPHIA uses its own one
b) SOPHIA operates a dedicated sampling method that only works on the CMB (yet another one with IRB_Kneiske) making assumptions about the CMB shape in beforehand. The C++ version does not rely on such information.

Important notes: 
1) all the tests have been run on the CMB as this allows for tests against analytical expressions of the photon field and SOPHIA. The other only photon field implemented in SOPHIA is IRB_Kneiske. First tests did not yield a correlation between SOPHIA and C++. Before going deeper here, I would like to invoke your feedback on the current implementation.
2) The code does not tell CRPropa to build the photon field files stored in ~/share/crpropa/Scaling upon installation. Also, the tabulated files of the PhotoPionProduction have changed. Do you have any advice in how to include this?
3) The photon field URB_Protheroe96 could not be converted into a photon field file as there is no sufficient photon field data in the CRPropa-data repository for this. Hence, this field is currently unavailable.

Thanks in advance and best wishes,
Mario