### PR TITLE
Added analytic spherical point picking for randConeVector

### DIFF
--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -156,12 +156,9 @@ Vector3d Random::randFisherVector(const Vector3d &meanDirection, double kappa) {
 	return randVectorAroundMean(meanDirection, randFisher(kappa));
 }
 
-Vector3d Random::randConeVector(const Vector3d &meanDirection,
-		double angularRadius) {
-	double theta = 2 * M_PI;
-	while (theta > angularRadius)
-		theta = acos(2 * rand() - 1);
-	return randVectorAroundMean(meanDirection, theta);
+Vector3d Random::randConeVector(const Vector3d &meanDirection, double angularRadius) {
+        const double theta = acos(randUniform(1, cos(angularRadius)));
+        return randVectorAroundMean(meanDirection, theta);
 }
 
 Vector3d Random::randomInterpolatedPosition(const Vector3d &a, const Vector3d &b) {


### PR DESCRIPTION
During recent attempts to simulate ultra-narrow CR jets, I was stung by the computational cost of `randConeVector`. Since `randConeVector` uses rejection sampling across the entire unit sphere it is extremely inefficient with small angular sizes and made my studies of ~1 arcsecond jets completely intractable. 

Picking a polar angle on the surface of a unit sphere within some range is analytically calculable and this pull-request implements that solution. I also wrote a testbench (attached below) that shows that the two solutions agree to within one part in a million for my limited statistics run (this will improve with additional statistics).

For a ~1arcsecond half-width, the analytical solution is six orders of magnitude faster than rejection sampling (calculated by timing 10,000 iterations of both methods).

All included CRPropa3 test cases pass successfully. 

Let me know if I can provide any more information to validate this PR! 

<details>

```
#include <chrono>
#include <cstdlib>
#include <iostream>
#include <iomanip>
#include <crpropa/Random.h>
#include <boost/accumulators/accumulators.hpp>
#include <boost/accumulators/statistics.hpp>

// using namespace std;
using namespace boost::accumulators;
using namespace std::chrono; 

// create a CRPropa random object
static crpropa::Random rgen(3847537);

// current rejection sampling method
auto randConeVectorOld(const double radius) -> double {
    double theta = 2 * M_PI;
    while (theta > radius)
	theta = acos(2 * rgen.rand() - 1);
    return theta;
}

// explicit generation
auto randConeVectorNew(const double radius) -> double {
    return acos(rgen.randUniform(1, cos(radius)));
}


// a main function to compare the two implementations
auto main(const int argc, const char* argv[]) -> int {

    // the number of trials we make
    const int N{1000000};

    // check a bunch of different radii
    for (const double& radius : {M_PI/16., M_PI/8., M_PI/4., M_PI/2.}) {

	// print the radius
	std::cout << "Radius: " << radius << std::endl;

	// create accumulators for old and new
	accumulator_set<double, features<tag::mean, tag::variance>> oldm;
	accumulator_set<double, features<tag::mean, tag::variance>> newm;

	// measure the old
	const auto start_old = high_resolution_clock::now();
	for (int i = 0; i < N; i++) {
	    oldm(randConeVectorOld(radius));
	}
	// measure the old
	const auto stop_old = high_resolution_clock::now();

	// and compute the duration
	const auto duration_old = duration_cast<microseconds>(stop_old - start_old);
	std::cout << "Old: " << duration_old.count() << std::endl;

	// measure the old
	auto start_new = high_resolution_clock::now();
	for (int i = 0; i < N; i++) {
	    newm(randConeVectorNew(radius));
	}
	// measure the old
	auto stop_new = high_resolution_clock::now();

	// and compute the duration
	const auto duration_new = duration_cast<microseconds>(stop_new - start_new);
	std::cout << "New: " << duration_new.count() << std::endl;

	// relative performance
	std::cout << "Improvement: " << double(duration_old.count())/double(duration_new.count()) << std::endl;

	// print the mean and std.
	std::cout << "Old Mean: " << mean(oldm) << std::endl;
	std::cout << "New Mean: " << mean(newm) << std::endl;
	std::cout << "Old Std : " << sqrt(variance(oldm)) << std::endl;
	std::cout << "New Std : " << sqrt(variance(newm)) << std::endl;

	// compute the differences in the mean and std
	const double meand{fabs(mean(oldm) - mean(newm))};
	const double stdd{fabs(sqrt(variance(oldm)) - sqrt(variance(newm)))};

	// print the differences
	std::cout << "Mean Diff: " << std::setprecision(6) << meand << std::endl;
	std::cout << "std. Diff: " << std::setprecision(6) << stdd << std::endl;

	std::cout << "===================="  << std::endl;
		
	
    } // END: for (const auto& radius: ...

    return 0;

}
```
</details>