### PR TITLE
Implement Lamberts distributed vectors and an isotropic arrival scenario at the edge of the Galaxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *~
 
 doc/*
-build/*
+build*
 data/*
 data-tools/*
 data.tar.gz

--- a/include/crpropa/Random.h
+++ b/include/crpropa/Random.h
@@ -159,6 +159,10 @@ public:
 	Vector3d randFisherVector(const Vector3d &meanDirection, double kappa);
 	/// Uniform distributed random vector inside a cone
 	Vector3d randConeVector(const Vector3d &meanDirection, double angularRadius);
+	// Random lamberts distributed vector with theta distribution: sin(t) * cos(t)
+	Vector3d randVectorLamberts();
+	// Same as above but rotated to the respective normalVector of surface element
+	Vector3d randVectorLamberts(const Vector3d &normalVector);
 	///_Position vector uniformly distributed within propagation step size bin
 	Vector3d randomInterpolatedPosition(const Vector3d &a, const Vector3d &b);
 

--- a/include/crpropa/Random.h
+++ b/include/crpropa/Random.h
@@ -159,9 +159,11 @@ public:
 	Vector3d randFisherVector(const Vector3d &meanDirection, double kappa);
 	/// Uniform distributed random vector inside a cone
 	Vector3d randConeVector(const Vector3d &meanDirection, double angularRadius);
-	// Random lamberts distributed vector with theta distribution: sin(t) * cos(t)
+	/// Random lamberts distributed vector with theta distribution: sin(t) * cos(t),
+	/// aka cosine law (https://en.wikipedia.org/wiki/Lambert%27s_cosine_law),
+	/// for a surface element with normal vector pointing in positive z-axis (0, 0, 1)
 	Vector3d randVectorLamberts();
-	// Same as above but rotated to the respective normalVector of surface element
+	/// Same as above but rotated to the respective normalVector of surface element
 	Vector3d randVectorLamberts(const Vector3d &normalVector);
 	///_Position vector uniformly distributed within propagation step size bin
 	Vector3d randomInterpolatedPosition(const Vector3d &a, const Vector3d &b);

--- a/include/crpropa/Source.h
+++ b/include/crpropa/Source.h
@@ -301,8 +301,8 @@ class SourcePulsarDistribution: public SourceFeature {
 	double Zg; // exponential cut parameter in z direction
 	double frMax; // helper for efficient sampling
 	double fzMax; // helper for efficient sampling
-	double R_max;// maximum radial distance - default 22 kpc 
-	double Z_max; // maximum distance from galactic plane - default 5 kpc 
+	double R_max; // maximum radial distance - default 22 kpc 
+	double Z_max; // maximum distance from galactic plane - default 5 kpc
 	double r_blur; // relative smearing factor for the radius
 	double theta_blur; // smearing factor for the angle. Unit = [1/length]
 
@@ -406,7 +406,7 @@ class SourceLambertDistributionOnSphere: public SourceFeature {
 	double radius;
 	bool inward;
 public:
-	SourceLambertDistributionOnSphere(Vector3d center, double radius, bool inward);
+	SourceLambertDistributionOnSphere(const Vector3d &center, double radius, bool inward);
  void prepareParticle(ParticleState &particle) const;
  void setDescription();
 };

--- a/include/crpropa/Source.h
+++ b/include/crpropa/Source.h
@@ -393,6 +393,32 @@ public:
 };
 
 /**
+ @class SourceLambertsEmission
+ @brief Lamberts emission with normal vector equivalent to position vector
+ */
+class SourceLambertsEmission: public SourceFeature {
+public:
+	SourceLambertsEmission();
+	void prepareParticle(ParticleState &particle) const;
+	void setDescription();
+};
+
+/**
+
+@class SourceIsotropicGalacticArrival
+@brief Uniform random position at edge of Galaxy with isotropic Lamberts distributed emission
+*/
+class SourceIsotropicGalacticArrival: public SourceFeature {
+	Vector3d center;
+	double radius;
+public:
+	SourceIsotropicGalacticArrival(Vector3d center, double radius);
+ void prepareParticle(ParticleState &particle) const;
+ void setDescription();
+};
+
+/**
+
  @class SourceDirection
  @brief Emission in a discrete direction
  */

--- a/include/crpropa/Source.h
+++ b/include/crpropa/Source.h
@@ -393,20 +393,9 @@ public:
 };
 
 /**
- @class SourceLambertsEmission
- @brief Lamberts emission with normal vector equivalent to position vector
- */
-class SourceLambertsEmission: public SourceFeature {
-public:
-	SourceLambertsEmission();
-	void prepareParticle(ParticleState &particle) const;
-	void setDescription();
-};
-
-/**
 
 @class SourceIsotropicGalacticArrival
-@brief Uniform random position at edge of Galaxy with isotropic Lamberts distributed emission
+@brief Uniform random position at edge of Galaxy with inwards directed isotropic Lamberts distributed directions
 */
 class SourceIsotropicGalacticArrival: public SourceFeature {
 	Vector3d center;

--- a/include/crpropa/Source.h
+++ b/include/crpropa/Source.h
@@ -394,14 +394,19 @@ public:
 
 /**
 
-@class SourceIsotropicGalacticArrival
-@brief Uniform random position at edge of Galaxy with inwards directed isotropic Lamberts distributed directions
+@class SourceLambertDistributionOnSphere
+@brief Uniform random position on a sphere with isotropic Lamberts distributed directions.
+This function should be used for crosschecking the arrival distribution for a
+Galactic propagation with an isotropic arrival distribution at the Edge of our
+Galaxy. Note, that for simulation speed you should rather use the backtracking
+technique: see e.g. http://physik.rwth-aachen.de/parsec
 */
-class SourceIsotropicGalacticArrival: public SourceFeature {
+class SourceLambertDistributionOnSphere: public SourceFeature {
 	Vector3d center;
 	double radius;
+	bool inward;
 public:
-	SourceIsotropicGalacticArrival(Vector3d center, double radius);
+	SourceLambertDistributionOnSphere(Vector3d center, double radius, bool inward);
  void prepareParticle(ParticleState &particle) const;
  void setDescription();
 };

--- a/include/crpropa/Vector3.h
+++ b/include/crpropa/Vector3.h
@@ -185,7 +185,7 @@ public:
 
 	// rotate the vector around a given axis by a given angle
 	Vector3<T> getRotated(const Vector3<T> &axis, T angle) const {
-		Vector3<T> u = axis / axis.getR();
+		Vector3<T> u = axis;
 		T c = cos(angle);
 		T s = sin(angle);
 		Vector3<T> Rx(c + u.x * u.x * (1 - c), u.x * u.y * (1 - c) - u.z * s,

--- a/include/crpropa/Vector3.h
+++ b/include/crpropa/Vector3.h
@@ -183,9 +183,9 @@ public:
 		return (*this) - getParallelTo(v);
 	}
 
-	// rotate the vector around a given axis by a given a angle
+	// rotate the vector around a given axis by a given angle
 	Vector3<T> getRotated(const Vector3<T> &axis, T angle) const {
-		Vector3<T> u = axis;
+		Vector3<T> u = axis / axis.getR();
 		T c = cos(angle);
 		T s = sin(angle);
 		Vector3<T> Rx(c + u.x * u.x * (1 - c), u.x * u.y * (1 - c) - u.z * s,

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -162,19 +162,23 @@ Vector3d Random::randConeVector(const Vector3d &meanDirection, double angularRad
 }
 
 Vector3d Random::randVectorLamberts() {
+	// random vector following Lamberts cosine law (https://en.wikipedia.org/wiki/Lambert%27s_cosine_law)
+	// for a surface element with normal vector pointing in positive z-axis (0, 0, 1)
 	double phi = randUniform(-1.0 * M_PI, M_PI);
 	double theta = M_PI / 2.0 - acos(sqrt(randUniform(0, 1)));
 	return Vector3d(cos(phi) * cos(theta), sin(phi) * cos(theta), sin(theta));
 }
 
 Vector3d Random::randVectorLamberts(const Vector3d &normalVector) {
+	// random vector following Lamberts cosine law for a surface element described by normalVector
 	Vector3d vLambertz = randVectorLamberts();
-	// rotation axis by cross product with z-axis
+	// find rotation axis that rotates the z-axis to the normalVector of the surface element
 	Vector3d axis = normalVector.cross(Vector3d(0, 0, 1));
 	if (axis.getR() < std::numeric_limits<double>::epsilon()) {
 		axis = Vector3d(0, 0, 1);
 	}
 	double angle = normalVector.getAngleTo(Vector3d(0, 0, 1));
+	// rotate the random Lamberts vector from z-axis to respective surface element
 	return vLambertz.getRotated(axis / axis.getR(), -angle);
 }
 

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -161,6 +161,23 @@ Vector3d Random::randConeVector(const Vector3d &meanDirection, double angularRad
         return randVectorAroundMean(meanDirection, theta);
 }
 
+Vector3d Random::randVectorLamberts() {
+	double phi = randUniform(-1.0 * M_PI, M_PI);
+	double theta = M_PI / 2.0 - acos(sqrt(randUniform(0, 1)));
+	return Vector3d(cos(phi) * cos(theta), sin(phi) * cos(theta), sin(theta));
+}
+
+Vector3d Random::randVectorLamberts(const Vector3d &normalVector) {
+	Vector3d vLambertz = randVectorLamberts();
+	// rotation axis by cross product with z-axis
+	Vector3d axis = normalVector.cross(Vector3d(0, 0, 1));
+	if (axis.getR() < std::numeric_limits<double>::epsilon()) {
+		axis = Vector3d(0, 0, 1);
+	}
+	double angle = normalVector.getAngleTo(Vector3d(0, 0, 1));
+	return vLambertz.getRotated(axis / axis.getR(), -angle);
+}
+
 Vector3d Random::randomInterpolatedPosition(const Vector3d &a, const Vector3d &b) {
 	return a + rand() * (b - a);
 }

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -179,7 +179,7 @@ Vector3d Random::randVectorLamberts(const Vector3d &normalVector) {
 	}
 	double angle = normalVector.getAngleTo(Vector3d(0, 0, 1));
 	// rotate the random Lamberts vector from z-axis to respective surface element
-	return vLambertz.getRotated(axis, -angle);
+	return vLambertz.getRotated(axis / axis.getR(), -angle);
 }
 
 Vector3d Random::randomInterpolatedPosition(const Vector3d &a, const Vector3d &b) {

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -179,7 +179,7 @@ Vector3d Random::randVectorLamberts(const Vector3d &normalVector) {
 	}
 	double angle = normalVector.getAngleTo(Vector3d(0, 0, 1));
 	// rotate the random Lamberts vector from z-axis to respective surface element
-	return vLambertz.getRotated(axis / axis.getR(), -angle);
+	return vLambertz.getRotated(axis, -angle);
 }
 
 Vector3d Random::randomInterpolatedPosition(const Vector3d &a, const Vector3d &b) {

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -510,7 +510,7 @@ void SourcePulsarDistribution::prepareParticle(ParticleState& particle) const {
 	double RPos = blur_r(Rtilde);
 	double phi = blur_theta(theta_tilde, Rtilde);
 	Vector3d pos(cos(phi)*RPos, sin(phi)*RPos, ZPos);
-	
+
 	particle.setPosition(pos);
   }
 
@@ -732,6 +732,42 @@ void SourceIsotropicEmission::prepareParticle(ParticleState& particle) const {
 
 void SourceIsotropicEmission::setDescription() {
 	description = "SourceIsotropicEmission: Random isotropic direction\n";
+}
+
+// ----------------------------------------------------------------------------
+SourceLambertsEmission::SourceLambertsEmission() {
+	setDescription();
+}
+
+void SourceLambertsEmission::prepareParticle(ParticleState& particle) const {
+	Random &random = Random::instance();
+	Vector3d normalVector = particle.getPosition();
+	particle.setDirection(Vector3d(0, 0, 0) - random.randVectorLamberts(normalVector));
+}
+
+void SourceLambertsEmission::setDescription() {
+	description = "SourceLambertsEmission: Lamberts distributed direction relative to paricles position vector\n";
+}
+
+// ----------------------------------------------------------------------------
+SourceIsotropicGalacticArrival::SourceIsotropicGalacticArrival(Vector3d center, double radius) :
+		center(center), radius(radius) {
+	setDescription();
+}
+
+void SourceIsotropicGalacticArrival::prepareParticle(ParticleState& particle) const {
+	Random &random = Random::instance();
+	Vector3d normalVector = random.randVector();
+	particle.setPosition(center + normalVector * radius);
+	particle.setDirection(Vector3d(0, 0, 0) - random.randVectorLamberts(normalVector));
+}
+
+void SourceIsotropicGalacticArrival::setDescription() {
+	std::stringstream ss;
+	ss << "SourceIsotropicGalacticArrival: Random position and direction at edge of our Galaxy at center ";
+	ss << center / kpc << " kpc with ";
+	ss << radius / kpc << " kpc radius\n";
+	description = ss.str();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -735,21 +735,6 @@ void SourceIsotropicEmission::setDescription() {
 }
 
 // ----------------------------------------------------------------------------
-SourceLambertsEmission::SourceLambertsEmission() {
-	setDescription();
-}
-
-void SourceLambertsEmission::prepareParticle(ParticleState& particle) const {
-	Random &random = Random::instance();
-	Vector3d normalVector = particle.getPosition();
-	particle.setDirection(Vector3d(0, 0, 0) - random.randVectorLamberts(normalVector));
-}
-
-void SourceLambertsEmission::setDescription() {
-	description = "SourceLambertsEmission: Lamberts distributed direction relative to paricles position vector\n";
-}
-
-// ----------------------------------------------------------------------------
 SourceIsotropicGalacticArrival::SourceIsotropicGalacticArrival(Vector3d center, double radius) :
 		center(center), radius(radius) {
 	setDescription();

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -735,7 +735,7 @@ void SourceIsotropicEmission::setDescription() {
 }
 
 // ----------------------------------------------------------------------------
-SourceLambertDistributionOnSphere::SourceLambertDistributionOnSphere(Vector3d center, double radius, bool inward) :
+SourceLambertDistributionOnSphere::SourceLambertDistributionOnSphere(const Vector3d &center, double radius, bool inward) :
 		center(center), radius(radius) {
 	this->inward = inward;
 	setDescription();

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -744,6 +744,7 @@ void SourceIsotropicGalacticArrival::prepareParticle(ParticleState& particle) co
 	Random &random = Random::instance();
 	Vector3d normalVector = random.randVector();
 	particle.setPosition(center + normalVector * radius);
+	// negative Lamberts vector for inward directed emission
 	particle.setDirection(Vector3d(0, 0, 0) - random.randVectorLamberts(normalVector));
 }
 

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -735,23 +735,24 @@ void SourceIsotropicEmission::setDescription() {
 }
 
 // ----------------------------------------------------------------------------
-SourceIsotropicGalacticArrival::SourceIsotropicGalacticArrival(Vector3d center, double radius) :
+SourceLambertDistributionOnSphere::SourceLambertDistributionOnSphere(Vector3d center, double radius, bool inward) :
 		center(center), radius(radius) {
+	this->inward = inward;
 	setDescription();
 }
 
-void SourceIsotropicGalacticArrival::prepareParticle(ParticleState& particle) const {
+void SourceLambertDistributionOnSphere::prepareParticle(ParticleState& particle) const {
 	Random &random = Random::instance();
 	Vector3d normalVector = random.randVector();
 	particle.setPosition(center + normalVector * radius);
-	// negative Lamberts vector for inward directed emission
-	particle.setDirection(Vector3d(0, 0, 0) - random.randVectorLamberts(normalVector));
+	double sign = inward ? -1 : 1; // negative (positive) Lamberts vector for inward (outward) directed emission
+	particle.setDirection(Vector3d(0, 0, 0) + sign * random.randVectorLamberts(normalVector));
 }
 
-void SourceIsotropicGalacticArrival::setDescription() {
+void SourceLambertDistributionOnSphere::setDescription() {
 	std::stringstream ss;
-	ss << "SourceIsotropicGalacticArrival: Random position and direction at edge of our Galaxy at center ";
-	ss << center / kpc << " kpc with ";
+	ss << "SourceLambertDistributionOnSphere: Random position and direction on a Sphere with center ";
+	ss << center / kpc << " kpc and ";
 	ss << radius / kpc << " kpc radius\n";
 	description = ss.str();
 }


### PR DESCRIPTION
Addresses issue #246, the user is now able to setup an isotropic galactic arrival scenario:
```
source = crp.Source()
source.add(crp.SourceIsotropicGalacticArrival(crp.Vector3d(0, 0, 0) * crp.kpc, 20 * crp.kpc))
```
You can test it by run the provided script in issue #246 and replace the 

```
source = crp.Source()
source.add(crp.SourceUniformShell(crp.Vector3d(0, 0, 0) * crp.kpc, 20 * crp.kpc))
source.add(crp.SourceIsotropicEmission())
```
by the above code block. I put the observer more outside (15 kpc instead of 8.5 kpc) of the center to make the anisotropies visible also with lower statistics. You should be able to run it on your local PC within 2 minutes. 

I hope the new function will prevent more future publications about the violation of Liouville...