### PR TITLE
Break condition: charge number

### DIFF
--- a/include/crpropa/module/BreakCondition.h
+++ b/include/crpropa/module/BreakCondition.h
@@ -83,6 +83,25 @@ public:
 };
 
 /**
+ @class MinimumChargeNumber
+ @brief Deactivates the candidate below a minimum number
+
+ This modules deactivates the candidate below a given minimum charge number.
+ A minimum charge number of 26 deactivates all (anti-) isotopes which 
+ are ranked in the periodic table before iron (Fe). 
+ In that case the property ("Deactivated", module::description) is set.
+ */
+class MinimumChargeNumber: public AbstractCondition {
+	int minChargeNumber;
+public:
+	MinimumChargeNumber(int minChargeNumber = 0);
+	void setMinimumChargeNumber(int chargeNumber);
+	int getMinimumChargeNumber() const;
+	std::string getDescription() const;
+	void process(Candidate *candidate) const;
+};
+
+/**
  @class DetectionLength
  @brief Detects the candidate at a given trajectoryLength
  

--- a/src/module/BreakCondition.cpp
+++ b/src/module/BreakCondition.cpp
@@ -152,6 +152,36 @@ std::string MinimumRedshift::getDescription() const {
 }
 
 //*****************************************************************************
+MinimumChargeNumber::MinimumChargeNumber(int minChargeNumber) :
+		minChargeNumber(minChargeNumber) {
+}
+
+void MinimumChargeNumber::setMinimumChargeNumber(int chargeNumber) {
+	minChargeNumber = chargeNumber;
+}
+
+int MinimumChargeNumber::getMinimumChargeNumber() const {
+	return minChargeNumber;
+}
+
+void MinimumChargeNumber::process(Candidate *c) const {
+	if (chargeNumber(c->current.getId()) > minChargeNumber)
+		return;
+	else
+		reject(c);
+}
+
+std::string MinimumChargeNumber::getDescription() const {
+	std::stringstream s;
+	s << "Minimum charge number: " << minChargeNumber;
+	s << "Flag: '" << rejectFlagKey << "' -> '" << rejectFlagValue << "', ";
+	s << "MakeInactive: " << (makeRejectedInactive ? "yes" : "no");
+	if (rejectAction.valid())
+		s << ", Action: " << rejectAction->getDescription();
+	return s.str();
+}
+
+//*****************************************************************************
 DetectionLength::DetectionLength(double detLength) :
 		detLength(detLength) {
 }

--- a/test/testBreakCondition.cpp
+++ b/test/testBreakCondition.cpp
@@ -27,6 +27,32 @@ TEST(MinimumEnergy, test) {
 	EXPECT_TRUE(c.hasProperty("Rejected"));
 }
 
+TEST(MinimumChargeNumber, test) {
+	MinimumChargeNumber minChargeNumber(20);
+	Candidate c;
+
+	c.current.setId(nucleusId(56, 26));
+	minChargeNumber.process(&c);
+	EXPECT_TRUE(c.isActive());
+	
+	c.current.setId(-nucleusId(56, 26));
+	minChargeNumber.process(&c);
+	EXPECT_TRUE(c.isActive());
+
+	c.current.setId(nucleusId(4, 2));
+	minChargeNumber.process(&c);
+	EXPECT_FALSE(c.isActive());
+	EXPECT_TRUE(c.hasProperty("Rejected"));
+	
+	c.setActive(true);
+	c.removeProperty("Rejected");
+
+	c.current.setId(-nucleusId(4, 2));
+	minChargeNumber.process(&c);
+	EXPECT_FALSE(c.isActive());
+	EXPECT_TRUE(c.hasProperty("Rejected"));
+}
+
 TEST(MaximumTrajectoryLength, test) {
 	MaximumTrajectoryLength maxLength(10);
 	Candidate c;


### PR DESCRIPTION
**What's new?**

Adds a new break condition based on the charge number of the candidates.

**Use case**
I was using this feature for a study on the propagation distance of different elements. I did not want to use the minimum energy break condition. With this break condition I was able to get rid of low charge number candidates that I was not interested in.