### PR TITLE
Implementation of Terral and Ferrière 2017 Galactic magnetic field

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,7 @@ add_library(crpropa SHARED
 	src/magneticField/MagneticField.cpp
 	src/magneticField/MagneticFieldGrid.cpp
 	src/magneticField/PT11Field.cpp
+    src/magneticField/TF17Field.cpp
 	src/magneticField/ArchimedeanSpiralField.cpp
 	src/advectionField/AdvectionField.cpp
 	src/massDistribution/Nakanishi.cpp

--- a/include/CRPropa.h
+++ b/include/CRPropa.h
@@ -61,6 +61,7 @@
 #include "crpropa/magneticField/MagneticField.h"
 #include "crpropa/magneticField/MagneticFieldGrid.h"
 #include "crpropa/magneticField/PT11Field.h"
+#include "crpropa/magneticField/TF17Field.h"
 #include "crpropa/magneticField/QuimbyMagneticField.h"
 #include "crpropa/magneticField/ArchimedeanSpiralField.h"
 

--- a/include/crpropa/magneticField/TF17Field.h
+++ b/include/crpropa/magneticField/TF17Field.h
@@ -14,14 +14,14 @@ using namespace std;
 
  */
 
+enum class TF17DiskModel {Ad1, Bd1, Dd1};
+enum class TF17HaloModel {C0, C1};
+
+
 class TF17Field: public MagneticField {
 private:
-    // model definition
-    bool C0;
-    bool C1;
-    bool Ad1;
-    bool Bd1;
-    bool Dd1;
+    TF17DiskModel disk_model; 
+    TF17HaloModel halo_model;
 
 	// disk parameters
 	bool useDiskField;
@@ -53,7 +53,7 @@ private:
 	void SetParams();
 
 public:
-	TF17Field(string disk_model="Ad1", string halo_model="C1");
+	TF17Field(TF17DiskModel disk_model_=TF17DiskModel::Ad1, TF17HaloModel halo_model_=TF17HaloModel::C1);
 
 	void setUseDiskField(bool use);
 	void setUseHaloField(bool use);
@@ -77,6 +77,9 @@ public:
     void set_Hp(const double H);
     void set_Lp(const double L);
     void set_p0(const double p0);
+
+    string getDiskModel() const;
+    string getHaloModel() const;
 
 	Vector3d getField(const Vector3d& pos) const;
 	Vector3d getDiskField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const;

--- a/include/crpropa/magneticField/TF17Field.h
+++ b/include/crpropa/magneticField/TF17Field.h
@@ -7,6 +7,9 @@ namespace crpropa {
 using namespace std;
 
 /**
+ @class TF17Field
+ @brief TF17Field galactic magnetic field model
+ 
  Implements the TF2017 galactic magnetic field model, consisting of large-scale regular disk and halo fields.
  The field is defined in the usual galactocentric coordinate system with the Galactic center at the origin,
  the x-axis pointing in the opposite direction of  the Sun, and the z-axis pointing towards Galactic north.
@@ -53,6 +56,10 @@ private:
 	void SetParams();
 
 public:
+    /** Constructor
+        @param disk_model_     model to use for the disk (model are defined in enum class TF17DiskModel: Ad1, Bd1, Dd1)
+        @param halo_model_     model to use for the halo (model are defined in enum class TF17HaloModel: C0, C1)
+     */
 	TF17Field(TF17DiskModel disk_model_=TF17DiskModel::Ad1, TF17HaloModel halo_model_=TF17HaloModel::C1);
 
 	void setUseDiskField(bool use);
@@ -60,34 +67,129 @@ public:
 	bool isUsingDiskField();
 	bool isUsingHaloField();
 
+    /**@brief   set reference amplitude for the disk magnetic field
+     *          Automatically set at initialization
+     * @param B1    magnetic field amplitude in Gauss
+     */
     void set_B1_disk(const double B1);
+    /**@brief   set reference height for the disk magnetic field (model Dd1) 
+     *          Automatically set at initialization
+     * @param z1    height in kpc 
+     */
     void set_z1_disk(const double z1);
+    /**@brief   set reference radius for the disk magnetic field (models Ad1 and Bd1)
+     *          Automatically set at initialization
+     * @param r1    radius in kpc 
+     */
     void set_r1_disk(const double r1);
+    /**@brief   set scale height of Br for the disk magnetic field (models Ad1 and Bd1)
+     *          Automatically set at initialization
+     * @param H    height in kpc 
+     */
     void set_H_disk(const double H);
+    /**@brief   set scale length of Bz for the disk magnetic field (models Dd1)
+     *          Automatically set at initialization
+     * @param L    length in kpc 
+     */
     void set_L_disk(const double L);
+    /**@brief   set opening parameter for poloidal lines for the disk magnetic field (models Ad1)
+     *          Automatically set at initialization
+     * @param a     opening parameter in / kpc / kpc
+     */
     void set_a_disk(const double a);
+    /**@brief   set orientation angle of the azimuthal pattern for the disk magnetic field
+     *          Automatically set at initialization
+     * @param phi     opening parameter in rad
+     */
     void set_phi_star_disk(const double phi);
 
+    /**@brief   set reference amplitude for the halo magnetic field
+     *          Automatically set at initialization
+     * @param B1    magnetic field amplitude in Gauss
+     */
     void set_B1_halo(const double B1);
+    /**@brief   set reference height for the halo magnetic field
+     *          Automatically set at initialization
+     * @param z1    height in kpc 
+     */
     void set_z1_halo(const double z1);
+    /**@brief   set scale length of Bz for the halo magnetic field
+     *          Automatically set at initialization
+     * @param L    length in kpc 
+     */
     void set_L_halo(const double L);
+    /**@brief   set opening parameter for poloidal lines for the halo magnetic field
+     *          Automatically set at initialization
+     * @param a     opening parameter in / kpc / kpc
+     */
     void set_a_halo(const double a);
+    /**@brief   set orientation angle of the azimuthal pattern for the disk magnetic field
+     *          Automatically set at initialization
+     * @param phi     opening parameter in rad
+     */
     void set_phi_star_halo(const double phi);
 
-    void set_Hp(const double H);
-    void set_Lp(const double L);
+    /**@brief   set pitch angle origin (all models)
+     *          Automatically set at initialization
+     * @param p0    height in rad
+     */
     void set_p0(const double p0);
+    /**@brief   set scale height of winding function (all models)
+     *          Automatically set at initialization
+     * @param H    height in kpc 
+     */
+    void set_Hp(const double H);
+    /**@brief   set scale length of winding function (all models)
+     *          Automatically set at initialization
+     * @param L    length in kpc 
+     */
+    void set_Lp(const double L);
 
+    /**@brief   Get the disk model used as a string
+     * @return  disk model
+     */
     string getDiskModel() const;
+    /**@brief   Get the halo model used as a string
+     * @return  halo model
+     */
     string getHaloModel() const;
 
 	Vector3d getField(const Vector3d& pos) const;
 	Vector3d getDiskField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const;
 	Vector3d getHaloField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const;
 
+    /**@brief   Compute the azimuthal field component Bphi as define by equation 28 in TF17
+     * @param r     radius in cylindrical coordinates
+     * @param z     radius in cylindrical coordinates
+     * @param Br    radial component of the magnetic field at position (r,z)
+     * @param Bz    height component of the magnetic field at position (r,z)
+     * @return  the value of the azimuthal field component Bphi
+     */
 	double azimuthalFieldComponent(const double& r, const double& z, const double& B_r, const double& B_z) const;
+
+    /**@brief   Compute the scaling of the disk magnetic field amplitude (equation 30, models Ad1
+     * and Bd1)
+     * @param B1        magnetic field amplitude in Gauss
+     * @param phi_star  orientation angle of the azimuthal pattern in rad
+     * @param z1        scale height in kpc
+     * @param phi       cylindrical coordinates
+     * @param r         cylindrical coordinates
+     * @param z         cylindrical coordinates
+     * @return  the radial field component Br(r1, z1, phi1)
+     */
 	double radialFieldScale(const double& B1, const double& phi_star, const double& z1, const double& phi, const double& r, const double& z) const;
+
+    /**@brief   Compute the shifted winding function (equation 23)
+     * @param r         cylindrical coordinates
+     * @param z         cylindrical coordinates
+     * @return  g_phi, the shifted winding function
+     */
 	double shiftedWindingFunction(const double& r, const double& z) const;
+
+    /**@brief   Compute the height scaling appearing numerous times in the equations
+     * @param z         cylindrical coordinates
+     * @return  z_scale = 1 + (z/Hp)^2
+     */
 	double zscale(const double& z) const;
 };
 

--- a/include/crpropa/magneticField/TF17Field.h
+++ b/include/crpropa/magneticField/TF17Field.h
@@ -1,0 +1,93 @@
+#ifndef CRPROPA_TF17FIELD_H
+#define CRPROPA_TF17FIELD_H
+
+#include "crpropa/magneticField/MagneticField.h"
+
+namespace crpropa {
+using namespace std;
+
+/**
+ Implements the TF2017 galactic magnetic field model, consisting of large-scale regular disk and halo fields.
+ The field is defined in the usual galactocentric coordinate system with the Galactic center at the origin,
+ the x-axis pointing in the opposite direction of  the Sun, and the z-axis pointing towards Galactic north.
+ See: Terral, Ferriere 2017 - Constraints from Faraday rotation on the magnetic field structure in the galactic halo, DOI: 10.1051/0004-6361/201629572, arXiv:1611.10222
+
+ */
+
+class TF17Field: public MagneticField {
+private:
+    // model definition
+    bool C0;
+    bool C1;
+    bool Ad1;
+    bool Bd1;
+    bool Dd1;
+
+	// disk parameters
+	bool useDiskField;
+	double a_disk;
+	double z1_disk;
+	double r1_disk;
+	double B1_disk;
+	double L_disk;
+	double phi_star_disk;
+	double H_disk;
+
+	// halo parameters
+	bool useHaloField;
+	double a_halo;
+	double z1_halo;
+	double B1_halo;
+	double L_halo;
+	double phi_star_halo;
+
+	// universal parameters
+	double p_0;
+	double cot_p0;
+	double H_p;
+	double L_p;
+
+	// security to avoid 0 division
+	double epsilon;
+
+	void SetParams();
+
+public:
+	TF17Field(string disk_model="Ad1", string halo_model="C1");
+
+	void setUseDiskField(bool use);
+	void setUseHaloField(bool use);
+	bool isUsingDiskField();
+	bool isUsingHaloField();
+
+    void set_B1_disk(const double B1);
+    void set_z1_disk(const double z1);
+    void set_r1_disk(const double r1);
+    void set_H_disk(const double H);
+    void set_L_disk(const double L);
+    void set_a_disk(const double a);
+    void set_phi_star_disk(const double phi);
+
+    void set_B1_halo(const double B1);
+    void set_z1_halo(const double z1);
+    void set_L_halo(const double L);
+    void set_a_halo(const double a);
+    void set_phi_star_halo(const double phi);
+
+    void set_Hp(const double H);
+    void set_Lp(const double L);
+    void set_p0(const double p0);
+
+	Vector3d getField(const Vector3d& pos) const;
+	Vector3d getDiskField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const;
+	Vector3d getHaloField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const;
+
+	double azimuthalFieldComponent(const double& r, const double& z, const double& B_r, const double& B_z) const;
+	double radialFieldScale(const double& B1, const double& phi_star, const double& z1, const double& phi, const double& r, const double& z) const;
+	double shiftedWindingFunction(const double& r, const double& z) const;
+	double zscale(const double& z) const;
+};
+
+} // CRPROPA NAMESPACE
+
+#endif // CRPROPA_TF17FIELD_H

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -392,6 +392,7 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %include "crpropa/magneticField/JF12Field.h"
 %include "crpropa/magneticField/JF12FieldSolenoidal.h"
 %include "crpropa/magneticField/PT11Field.h"
+%include "crpropa/magneticField/TF17Field.h"
 %include "crpropa/magneticField/ArchimedeanSpiralField.h"
 %include "crpropa/module/BreakCondition.h"
 %include "crpropa/module/Boundary.h"

--- a/src/magneticField/TF17Field.cpp
+++ b/src/magneticField/TF17Field.cpp
@@ -7,146 +7,120 @@
 namespace crpropa {
 using namespace std;
 
-TF17Field::TF17Field(string disk_model, string halo_model){
+TF17Field::TF17Field(TF17DiskModel disk_model_, TF17HaloModel halo_model_) {
+    disk_model = disk_model_; 
+    halo_model = halo_model_;
+
     useHaloField = true;
     useDiskField = true;
-    C0 = false;
-    C1 = false;
-    Ad1 = false;
-    Bd1 = false;
-    Dd1 = false;
 
-    if (( halo_model == "C0" ) && ( disk_model == "Ad1" )){
-	    // disk parameters
-        Ad1 = true;
-	    set_r1_disk(3 * kpc);
-	    set_B1_disk(19.0 * muG);
-	    set_H_disk(0.055 * kpc);
-	    set_phi_star_disk(-54 * M_PI / 180);
-	    set_a_disk(0.9 / kpc / kpc);
+    switch (halo_model) {
+    case TF17HaloModel::C0:
+        switch (disk_model) {
+        case TF17DiskModel::Ad1:
+	        // disk parameters
+	        set_r1_disk(3 * kpc);
+	        set_B1_disk(19.0 * muG);
+	        set_H_disk(0.055 * kpc);
+	        set_phi_star_disk(-54 * M_PI / 180);
+	        set_a_disk(0.9 / kpc / kpc);
+	        // halo parameters
+	        set_z1_halo(0);
+	        set_B1_halo(0.36 * muG);
+	        set_L_halo(3.0 * kpc);
+	        set_a_halo(1.17 / kpc / kpc);
+	        // shared parameters
+	        set_p0(-7.9 * M_PI / 180);
+	        set_Hp(5 * kpc);
+	        set_Lp(50 * kpc); // > 18 kpc
 
-	    // halo parameters
-        C0 = true;
-	    set_z1_halo(0);
-	    set_B1_halo(0.36 * muG);
-	    set_L_halo(3.0 * kpc);
-	    set_a_halo(1.17 / kpc / kpc);
+        case TF17DiskModel::Bd1:
+	        // disk parameters
+	        set_r1_disk(3 * kpc);
+	        set_B1_disk(2.0 * muG);
+	        set_H_disk(0.32 * kpc);
+	        set_phi_star_disk(153 * M_PI / 180);
+	        // halo parameters
+	        set_z1_halo(0);
+	        set_B1_halo(0.29 * muG);
+	        set_L_halo(3.4 * kpc);
+	        set_a_halo(0.88 / kpc / kpc);
+	        // shared parameters
+	        set_p0(-7.2 * M_PI / 180);
+	        set_Hp(9 * kpc);
+	        set_Lp(50 * kpc); // > 16 kpc
 
-	    // shared parameters
-	    set_p0(-7.9 * M_PI / 180);
-	    set_Hp(5 * kpc);
-	    set_Lp(50 * kpc); // > 18 kpc
+        case TF17DiskModel::Dd1:
+	        // disk parameters
+	        set_z1_disk(1.5 * kpc);
+	        set_B1_disk(0.065 * muG);
+	        set_L_disk(9.8 * kpc);
+	        set_phi_star_disk(14 * M_PI / 180);
+	        // halo parameters
+	        set_z1_halo(0);
+	        set_B1_halo(0.18 * muG);
+	        set_L_halo(4.8 * kpc);
+	        set_a_halo(0.61 / kpc / kpc);
+	        // shared parameters
+	        set_p0(-7.4 * M_PI / 180);
+	        set_Hp(4.2 * kpc);
+	        set_Lp(50 * kpc); // > 22 kpc
+        }
 
-    } else if (( halo_model == "C0" ) && ( disk_model == "Bd1" )){
-	    // disk parameters
-        Bd1 = true;
-	    set_r1_disk(3 * kpc);
-	    set_B1_disk(2.0 * muG);
-	    set_H_disk(0.32 * kpc);
-	    set_phi_star_disk(153 * M_PI / 180);
+    case TF17HaloModel::C1:
+        switch (disk_model) {
+        case TF17DiskModel::Ad1:
+	        // disk parameters
+	        set_r1_disk(3 * kpc);
+	        set_B1_disk(32.0 * muG);
+	        set_H_disk(0.054 * kpc);
+	        set_phi_star_disk(-31 * M_PI / 180);
+	        set_a_disk(0.031 / kpc / kpc);
+	        // halo parameters
+	        set_z1_halo(0);
+	        set_B1_halo(9.0 * muG);
+	        set_L_halo(2.1 * kpc);
+	        set_phi_star_halo(198 * M_PI / 180);
+	        set_a_halo(0.33 / kpc / kpc);
+	        // shared parameters
+	        set_p0(-9.1 * M_PI / 180);
+	        set_Hp(1.2 * kpc);
+	        set_Lp(50 * kpc); // > 38 kpc
 
-	    // halo parameters
-        C0 = true;
-	    set_z1_halo(0);
-	    set_B1_halo(0.29 * muG);
-	    set_L_halo(3.4 * kpc);
-	    set_a_halo(0.88 / kpc / kpc);
+        case TF17DiskModel::Bd1:
+	        // disk parameters
+	        set_r1_disk(3 * kpc);
+	        set_B1_disk(24 * muG);
+	        set_H_disk(0.090 * kpc);
+	        set_phi_star_disk(-34 * M_PI / 180);
+	        // halo parameters
+	        set_z1_halo(0);
+	        set_B1_halo(8.2 * muG);
+	        set_L_halo(2.2 * kpc);
+	        set_phi_star_halo(197 * M_PI / 180);
+	        set_a_halo(0.38 / kpc / kpc);
+	        // shared parameters
+	        set_p0(-9.0 * M_PI / 180);
+	        set_Hp(1.2 * kpc);
+	        set_Lp(50 * kpc); // > 38 kpc
 
-	    // shared parameters
-	    set_p0(-7.2 * M_PI / 180);
-	    set_Hp(9 * kpc);
-	    set_Lp(50 * kpc); // > 16 kpc
-
-    } else if (( halo_model == "C0" ) && ( disk_model == "Dd1" )){
-	    // disk parameters
-        Dd1 = true;
-	    set_z1_disk(1.5 * kpc);
-	    set_B1_disk(0.065 * muG);
-	    set_L_disk(9.8 * kpc);
-	    set_phi_star_disk(14 * M_PI / 180);
-
-	    // halo parameters
-        C0 = true;
-	    set_z1_halo(0);
-	    set_B1_halo(0.18 * muG);
-	    set_L_halo(4.8 * kpc);
-	    set_a_halo(0.61 / kpc / kpc);
-
-	    // shared parameters
-	    set_p0(-7.4 * M_PI / 180);
-	    set_Hp(4.2 * kpc);
-	    set_Lp(50 * kpc); // > 22 kpc
-
-    } else if (( halo_model == "C1" ) && ( disk_model == "Ad1" )){
-	    // disk parameters
-        Ad1 = true;
-	    set_r1_disk(3 * kpc);
-	    set_B1_disk(32.0 * muG);
-	    set_H_disk(0.054 * kpc);
-	    set_phi_star_disk(-31 * M_PI / 180);
-	    set_a_disk(0.031 / kpc / kpc);
-
-	    // halo parameters
-        C1 = true;
-	    set_z1_halo(0);
-	    set_B1_halo(9.0 * muG);
-	    set_L_halo(2.1 * kpc);
-	    set_phi_star_halo(198 * M_PI / 180);
-	    set_a_halo(0.33 / kpc / kpc);
-
-	    // shared parameters
-	    set_p0(-9.1 * M_PI / 180);
-	    set_Hp(1.2 * kpc);
-	    set_Lp(50 * kpc); // > 38 kpc
-
-    } else if (( halo_model == "C1" ) && ( disk_model == "Bd1" )){
-	    // disk parameters
-        Bd1 = true;
-	    set_r1_disk(3 * kpc);
-	    set_B1_disk(24 * muG);
-	    set_H_disk(0.090 * kpc);
-	    set_phi_star_disk(-34 * M_PI / 180);
-
-	    // halo parameters
-        C1 = true;
-	    set_z1_halo(0);
-	    set_B1_halo(8.2 * muG);
-	    set_L_halo(2.2 * kpc);
-	    set_phi_star_halo(197 * M_PI / 180);
-	    set_a_halo(0.38 / kpc / kpc);
-
-	    // shared parameters
-	    set_p0(-9.0 * M_PI / 180);
-	    set_Hp(1.2 * kpc);
-	    set_Lp(50 * kpc); // > 38 kpc
-
-    } else if (( halo_model == "C1" ) && ( disk_model == "Dd1" )){
-	    // disk parameters
-        Dd1 = true;
-	    set_z1_disk(1.5 * kpc);
-	    set_B1_disk(0.40 * muG);
-	    set_L_disk(2.9 * kpc);
-	    set_phi_star_disk(120 * M_PI / 180);
-
-	    // halo parameters
-        C1 = true;
-	    set_z1_halo(0);
-	    set_B1_halo(9.5 * muG);
-	    set_L_halo(2.1 * kpc);
-	    set_phi_star_halo(179 * M_PI / 180);
-        set_a_halo(0.45 / kpc / kpc);
-
-	    // shared parameters
-	    set_p0(-8.4 * M_PI / 180);
-	    set_Hp(1.2 * kpc);
-	    set_Lp(50 * kpc); // > 30 kpc
-    
-    } else { // wrong model
-        cerr << "ERROR in TD17Field declaration:" << endl;
-        cerr << "   Disk model (" << disk_model << ") can only be : Ad1, Bd1 or Dd1" << endl;
-        cerr << "   Halo model (" << halo_model << ") can only be : C0 or C1" << endl;
-        exit(-1);
-
+        case TF17DiskModel::Dd1:
+	        // disk parameters
+	        set_z1_disk(1.5 * kpc);
+	        set_B1_disk(0.40 * muG);
+	        set_L_disk(2.9 * kpc);
+	        set_phi_star_disk(120 * M_PI / 180);
+	        // halo parameters
+	        set_z1_halo(0);
+	        set_B1_halo(9.5 * muG);
+	        set_L_halo(2.1 * kpc);
+	        set_phi_star_halo(179 * M_PI / 180);
+            set_a_halo(0.45 / kpc / kpc);
+	        // shared parameters
+	        set_p0(-8.4 * M_PI / 180);
+	        set_Hp(1.2 * kpc);
+	        set_Lp(50 * kpc); // > 30 kpc
+        }
     }
 
     epsilon = std::numeric_limits<double>::epsilon();
@@ -179,6 +153,24 @@ void TF17Field::set_p0(const double p0){
     cot_p0 = cos(p_0) / sin(p_0);
 }
 
+string TF17Field::getDiskModel() const {
+    string model_name;
+    switch (disk_model) {
+        case TF17DiskModel::Ad1 : model_name = "Ad1"; break;
+        case TF17DiskModel::Bd1 : model_name = "Bd1"; break;
+        case TF17DiskModel::Dd1 : model_name = "Dd1"; break;
+    }
+    return model_name;
+}
+string TF17Field::getHaloModel() const {
+    string model_name;
+    switch (halo_model) {
+        case TF17HaloModel::C0 : model_name = "C0"; break;
+        case TF17HaloModel::C1 : model_name = "C1"; break;
+    }
+    return model_name;
+}
+
 
 Vector3d TF17Field::getField(const Vector3d& pos) const {
 	double r = sqrt(pos.x * pos.x + pos.y * pos.y);  // in-plane radius
@@ -202,7 +194,8 @@ Vector3d TF17Field::getDiskField(const double& r, const double& z, const double&
     double B_phi = 0;
     double B_z = 0;
 
-    if ( Ad1 ){ // Model Ad1 ==========================================================
+    switch (disk_model) {
+    case TF17DiskModel::Ad1 : // ==========================================================
         if (r > r1_disk) {
             double z1_disk_z = (1. + a_disk * r1_disk * r1_disk) / (1. + a_disk * r * r); // z1_disk / z
             // B components in (r, phi, z)
@@ -218,8 +211,9 @@ Vector3d TF17Field::getDiskField(const double& r, const double& z, const double&
             B_r = cos(phi1_disk - phi) * B_amp;
             B_phi = sin(phi1_disk - phi) * B_amp;
         }
+        break;
 
-    } else if ( Bd1 ){ // Model Bd1 ===================================================
+    case TF17DiskModel::Bd1 : // ==========================================================
         // for model Bd1, best fit for n = 2 
         if ( r > epsilon ) {
             double r1_disk_r = r1_disk / r;	
@@ -234,8 +228,9 @@ Vector3d TF17Field::getDiskField(const double& r, const double& z, const double&
             B_z = -10. * z / r1_disk * B_r0;
         }
         B_phi = azimuthalFieldComponent(r, z, B_r, B_z);
+        break;
 
-    } else if ( Dd1 ){ // Model Dd1 ==================================================
+    case TF17DiskModel::Dd1 : // ==========================================================
         // for model Dd1, best fit for n = 0.5 
         double z_sign = z >= 0 ? 1. : -1.; 
         double z_abs = fabs(z); 
@@ -256,6 +251,7 @@ Vector3d TF17Field::getDiskField(const double& r, const double& z, const double&
             B_z = z_sign * r1_disk_r * r1_disk_r * B_z0;
         }
         B_phi = azimuthalFieldComponent(r, z, B_r, B_z);
+        break;
     }
 
     // Convert to (x, y, z) components
@@ -272,9 +268,11 @@ Vector3d TF17Field::getHaloField(const double& r, const double& z, const double&
 	double r1_halo_r =  (1. + a_halo * z1_halo * z1_halo) / (1. + a_halo * z * z);
 	// B components in (r, phi, z)
     double B_z0;
-    if ( C0 ){ // m = 0
+
+    switch (halo_model) {
+    case TF17HaloModel::C0: // m = 0
         B_z0 = B1_halo * exp(-r1_halo_r*r / L_halo); 
-    } else if ( C1 ){ // m = 1
+    case TF17HaloModel::C1: // m = 1
         // simplication of the equation in the cosinus
         double phi_prime = phi - shiftedWindingFunction(r, z) - phi_star_halo;
         B_z0 = B1_halo * exp(-r1_halo_r*r / L_halo) * cos(phi_prime); 

--- a/src/magneticField/TF17Field.cpp
+++ b/src/magneticField/TF17Field.cpp
@@ -1,0 +1,321 @@
+#include "crpropa/magneticField/TF17Field.h"
+#include "crpropa/Units.h"
+
+#include <algorithm>
+#include <string>
+
+namespace crpropa {
+using namespace std;
+
+TF17Field::TF17Field(string disk_model, string halo_model){
+    useHaloField = true;
+    useDiskField = true;
+    C0 = false;
+    C1 = false;
+    Ad1 = false;
+    Bd1 = false;
+    Dd1 = false;
+
+    if (( halo_model == "C0" ) && ( disk_model == "Ad1" )){
+	    // disk parameters
+        Ad1 = true;
+	    set_r1_disk(3 * kpc);
+	    set_B1_disk(19.0 * muG);
+	    set_H_disk(0.055 * kpc);
+	    set_phi_star_disk(-54 * M_PI / 180);
+	    set_a_disk(0.9 / kpc / kpc);
+
+	    // halo parameters
+        C0 = true;
+	    set_z1_halo(0);
+	    set_B1_halo(0.36 * muG);
+	    set_L_halo(3.0 * kpc);
+	    set_a_halo(1.17 / kpc / kpc);
+
+	    // shared parameters
+	    set_p0(-7.9 * M_PI / 180);
+	    set_Hp(5 * kpc);
+	    set_Lp(50 * kpc); // > 18 kpc
+
+    } else if (( halo_model == "C0" ) && ( disk_model == "Bd1" )){
+	    // disk parameters
+        Bd1 = true;
+	    set_r1_disk(3 * kpc);
+	    set_B1_disk(2.0 * muG);
+	    set_H_disk(0.32 * kpc);
+	    set_phi_star_disk(153 * M_PI / 180);
+
+	    // halo parameters
+        C0 = true;
+	    set_z1_halo(0);
+	    set_B1_halo(0.29 * muG);
+	    set_L_halo(3.4 * kpc);
+	    set_a_halo(0.88 / kpc / kpc);
+
+	    // shared parameters
+	    set_p0(-7.2 * M_PI / 180);
+	    set_Hp(9 * kpc);
+	    set_Lp(50 * kpc); // > 16 kpc
+
+    } else if (( halo_model == "C0" ) && ( disk_model == "Dd1" )){
+	    // disk parameters
+        Dd1 = true;
+	    set_z1_disk(1.5 * kpc);
+	    set_B1_disk(0.065 * muG);
+	    set_L_disk(9.8 * kpc);
+	    set_phi_star_disk(14 * M_PI / 180);
+
+	    // halo parameters
+        C0 = true;
+	    set_z1_halo(0);
+	    set_B1_halo(0.18 * muG);
+	    set_L_halo(4.8 * kpc);
+	    set_a_halo(0.61 / kpc / kpc);
+
+	    // shared parameters
+	    set_p0(-7.4 * M_PI / 180);
+	    set_Hp(4.2 * kpc);
+	    set_Lp(50 * kpc); // > 22 kpc
+
+    } else if (( halo_model == "C1" ) && ( disk_model == "Ad1" )){
+	    // disk parameters
+        Ad1 = true;
+	    set_r1_disk(3 * kpc);
+	    set_B1_disk(32.0 * muG);
+	    set_H_disk(0.054 * kpc);
+	    set_phi_star_disk(-31 * M_PI / 180);
+	    set_a_disk(0.031 / kpc / kpc);
+
+	    // halo parameters
+        C1 = true;
+	    set_z1_halo(0);
+	    set_B1_halo(9.0 * muG);
+	    set_L_halo(2.1 * kpc);
+	    set_phi_star_halo(198 * M_PI / 180);
+	    set_a_halo(0.33 / kpc / kpc);
+
+	    // shared parameters
+	    set_p0(-9.1 * M_PI / 180);
+	    set_Hp(1.2 * kpc);
+	    set_Lp(50 * kpc); // > 38 kpc
+
+    } else if (( halo_model == "C1" ) && ( disk_model == "Bd1" )){
+	    // disk parameters
+        Bd1 = true;
+	    set_r1_disk(3 * kpc);
+	    set_B1_disk(24 * muG);
+	    set_H_disk(0.090 * kpc);
+	    set_phi_star_disk(-34 * M_PI / 180);
+
+	    // halo parameters
+        C1 = true;
+	    set_z1_halo(0);
+	    set_B1_halo(8.2 * muG);
+	    set_L_halo(2.2 * kpc);
+	    set_phi_star_halo(197 * M_PI / 180);
+	    set_a_halo(0.38 / kpc / kpc);
+
+	    // shared parameters
+	    set_p0(-9.0 * M_PI / 180);
+	    set_Hp(1.2 * kpc);
+	    set_Lp(50 * kpc); // > 38 kpc
+
+    } else if (( halo_model == "C1" ) && ( disk_model == "Dd1" )){
+	    // disk parameters
+        Dd1 = true;
+	    set_z1_disk(1.5 * kpc);
+	    set_B1_disk(0.40 * muG);
+	    set_L_disk(2.9 * kpc);
+	    set_phi_star_disk(120 * M_PI / 180);
+
+	    // halo parameters
+        C1 = true;
+	    set_z1_halo(0);
+	    set_B1_halo(9.5 * muG);
+	    set_L_halo(2.1 * kpc);
+	    set_phi_star_halo(179 * M_PI / 180);
+        set_a_halo(0.45 / kpc / kpc);
+
+	    // shared parameters
+	    set_p0(-8.4 * M_PI / 180);
+	    set_Hp(1.2 * kpc);
+	    set_Lp(50 * kpc); // > 30 kpc
+    
+    } else { // wrong model
+        cerr << "ERROR in TD17Field declaration:" << endl;
+        cerr << "   Disk model (" << disk_model << ") can only be : Ad1, Bd1 or Dd1" << endl;
+        cerr << "   Halo model (" << halo_model << ") can only be : C0 or C1" << endl;
+        exit(-1);
+
+    }
+
+    epsilon = std::numeric_limits<double>::epsilon();
+}
+
+void TF17Field::setUseDiskField(bool use) {	useDiskField = use; }
+void TF17Field::setUseHaloField(bool use) { useHaloField = use; }
+
+bool TF17Field::isUsingDiskField() { return useDiskField; }
+bool TF17Field::isUsingHaloField() { return useHaloField; }
+
+void TF17Field::set_B1_disk(const double B1){ B1_disk = B1; }
+void TF17Field::set_z1_disk(const double z1){ z1_disk = z1; }
+void TF17Field::set_r1_disk(const double r1){ r1_disk = r1; }
+void TF17Field::set_H_disk(const double H){ H_disk = H; }
+void TF17Field::set_L_disk(const double L){ L_disk = L; }
+void TF17Field::set_a_disk(const double a){ a_disk = a; }
+void TF17Field::set_phi_star_disk(const double phi){ phi_star_disk = phi; }
+
+void TF17Field::set_B1_halo(const double B1){ B1_halo = B1; }
+void TF17Field::set_z1_halo(const double z1){ z1_halo = z1; }
+void TF17Field::set_L_halo(const double L){ L_halo = L; }
+void TF17Field::set_a_halo(const double a){ a_halo = a; }
+void TF17Field::set_phi_star_halo(const double phi){ phi_star_halo = phi; }
+
+void TF17Field::set_Hp(const double H){ H_p = H; }
+void TF17Field::set_Lp(const double L){ L_p = L; }
+void TF17Field::set_p0(const double p0){ 
+    p_0 = p0; 
+    cot_p0 = cos(p_0) / sin(p_0);
+}
+
+
+Vector3d TF17Field::getField(const Vector3d& pos) const {
+	double r = sqrt(pos.x * pos.x + pos.y * pos.y);  // in-plane radius
+	double phi = M_PI - pos.getPhi(); // azimuth in our convention
+	// double cosPhi = pos.x / r;
+	double cosPhi = cos(phi);
+	// double sinPhi = pos.y / r;
+	double sinPhi = sin(phi);
+
+	Vector3d b(0.);
+	if (useDiskField)
+		b += getDiskField(r, pos.z, phi, sinPhi, cosPhi);	// disk field
+	if (useHaloField)
+		b += getHaloField(r, pos.z, phi, sinPhi, cosPhi);	// halo field
+	return b;
+}
+
+Vector3d TF17Field::getDiskField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const {
+	Vector3d b(0.);
+    double B_r = 0;
+    double B_phi = 0;
+    double B_z = 0;
+
+    if ( Ad1 ){ // Model Ad1 ==========================================================
+        if (r > r1_disk) {
+            double z1_disk_z = (1. + a_disk * r1_disk * r1_disk) / (1. + a_disk * r * r); // z1_disk / z
+            // B components in (r, phi, z)
+            double B_r0 = radialFieldScale(B1_disk, phi_star_disk, z1_disk_z*z, phi, r, z);
+            B_r = (r1_disk / r) * z1_disk_z * B_r0;
+            B_z = 2 * a_disk * r1_disk * z1_disk_z*z / (1+ a_disk * r * r) * B_r0;
+            B_phi = azimuthalFieldComponent(r, z, B_r, B_z);
+        } else {
+            // within r = r1_disk, the field lines are straight in direction g_phi + phi_star_disk
+            // and thus z = z1
+            double phi1_disk = shiftedWindingFunction(r1_disk, z) + phi_star_disk;
+            double B_amp = B1_disk * exp(-fabs(z) / H_disk);
+            B_r = cos(phi1_disk - phi) * B_amp;
+            B_phi = sin(phi1_disk - phi) * B_amp;
+        }
+
+    } else if ( Bd1 ){ // Model Bd1 ===================================================
+        // for model Bd1, best fit for n = 2 
+        if ( r > epsilon ) {
+            double r1_disk_r = r1_disk / r;	
+            double z1_disk_z = 5. / (r1_disk_r*r1_disk_r + 4./sqrt(r1_disk_r)); // z1_disk / z -> remove z dependancy 
+            double B_r0 = radialFieldScale(B1_disk, phi_star_disk, z1_disk_z*z, phi, r, z);
+            B_r = r1_disk_r * z1_disk_z * B_r0;
+            B_z = -0.4 * r1_disk_r / r * z1_disk_z* z1_disk_z * z * (r1_disk_r*r1_disk_r - 1./sqrt(r1_disk_r)) * B_r0;
+        } else {
+            double z1_disk_z = 5. * r*r / (r1_disk*r1_disk); // z1_disk / z -> remove z dependancy 
+            double B_r0 = radialFieldScale(B1_disk, phi_star_disk, z1_disk_z*z, phi, r, z);
+            B_r = 5. * r / r1_disk * B_r0;
+            B_z = -10. * z / r1_disk * B_r0;
+        }
+        B_phi = azimuthalFieldComponent(r, z, B_r, B_z);
+
+    } else if ( Dd1 ){ // Model Dd1 ==================================================
+        // for model Dd1, best fit for n = 0.5 
+        double z_sign = z >= 0 ? 1. : -1.; 
+        double z_abs = fabs(z); 
+        if ( z_abs > epsilon ) {
+            double z1_disk_z = z1_disk / z_abs; 
+            double r1_disk_r = 1.5 / (sqrt(z1_disk_z) + 0.5/z1_disk_z); // r1_disk / r
+            double F_r = r1_disk_r*r  <= L_disk ? 1. : exp(1. - r1_disk_r*r/L_disk);
+        // simplication of the equation in the cosinus
+            double B_z0 = z_sign * B1_disk * F_r * cos(phi - shiftedWindingFunction(r, z) - phi_star_disk);
+            B_r = -0.5/1.5 * r1_disk_r * r1_disk_r * r1_disk_r * r / z_abs * (sqrt(z1_disk_z) - 1/z1_disk_z) * B_z0;
+            B_z = z_sign * r1_disk_r * r1_disk_r * B_z0;
+        } else {
+            double z_z1_disk = z_abs / z1_disk; 
+            double r1_disk_r = 1.5 * sqrt(z_abs / z1_disk); // r1_disk / r
+            double F_r = r1_disk_r*r  <= L_disk ? 1. : exp(1. - r1_disk_r*r/L_disk);
+            double B_z0 = z_sign * B1_disk * F_r * cos(phi - shiftedWindingFunction(r, z) - phi_star_disk);
+            B_r = -1.125 * r / z1_disk * (1 - 2.5 * z_z1_disk * sqrt(z_z1_disk)) * B_z0;
+            B_z = z_sign * r1_disk_r * r1_disk_r * B_z0;
+        }
+        B_phi = azimuthalFieldComponent(r, z, B_r, B_z);
+    }
+
+    // Convert to (x, y, z) components
+    b.x = - (B_r * cosPhi - B_phi * sinPhi); // flip x-component at the end
+    b.y = B_r * sinPhi + B_phi * cosPhi;
+    b.z = B_z;
+	return b;
+}
+
+Vector3d TF17Field::getHaloField(const double& r, const double& z, const double& phi, const double& sinPhi, const double& cosPhi) const {
+    int m;
+
+	Vector3d b(0.);
+	double r1_halo_r =  (1. + a_halo * z1_halo * z1_halo) / (1. + a_halo * z * z);
+	// B components in (r, phi, z)
+    double B_z0;
+    if ( C0 ){ // m = 0
+        B_z0 = B1_halo * exp(-r1_halo_r*r / L_halo); 
+    } else if ( C1 ){ // m = 1
+        // simplication of the equation in the cosinus
+        double phi_prime = phi - shiftedWindingFunction(r, z) - phi_star_halo;
+        B_z0 = B1_halo * exp(-r1_halo_r*r / L_halo) * cos(phi_prime); 
+    }
+
+    // Contrary to article, Br has been rewriten to a little bit by replacing
+    // (2 * a * r1**3 * z) / (r**2) by (2 * a * r1**2 * z) / (r * (1+a*z**2))
+    // but that is strictly equivalent except we can reintroduce the z1 in the expression via r1
+	double B_r = 2 * a_halo * r1_halo_r * r1_halo_r * r * z / (1. + a_halo * z * z) * B_z0;
+	double B_z = r1_halo_r * r1_halo_r * B_z0; 
+	double B_phi = azimuthalFieldComponent(r, z, B_r, B_z);
+
+	// Convert to (x, y, z) components
+	b.x = - (B_r * cosPhi - B_phi * sinPhi);	// flip x-component at the end
+	b.y = B_r * sinPhi + B_phi * cosPhi;
+	b.z = B_z;
+
+	return b;
+}
+
+double TF17Field::azimuthalFieldComponent(const double& r, const double& z, const double& B_r, const double& B_z) const {
+	double r_ = r / L_p;
+    double rscale = r > epsilon ? r_ * exp(-r_) / (1 - exp(-r_)) : 1 - r_/2. - r_*r_/12. ;
+	double B_phi = cot_p0 / zscale(z) * rscale * B_r;
+    B_phi = B_phi - 2 * z * r / (H_p * H_p) / zscale(z) * shiftedWindingFunction(r, z) * B_z;
+	return B_phi;
+}
+
+double TF17Field::radialFieldScale(const double& B1, const double& phi_star, const double& z1, const double& phi, const double& r, const double& z) const {
+    // simplication of the equation in the cosinus
+    double phi_prime = phi - shiftedWindingFunction(r, z) - phi_star;
+	// This term occures is parameterizations of models A and B always bisymmetric (m = 1)
+	return B1 * exp(-fabs(z1) / H_disk) * cos(phi_prime);
+}
+
+double TF17Field::shiftedWindingFunction(const double& r, const double& z) const {
+    return cot_p0 * log(1 - exp(-r / L_p) + epsilon) / zscale(z);
+}
+
+double TF17Field::zscale(const double& z) const {
+	return 1 + z * z / H_p / H_p;
+}
+
+} // namespace crpropa

--- a/src/magneticField/TF17Field.cpp
+++ b/src/magneticField/TF17Field.cpp
@@ -14,113 +14,106 @@ TF17Field::TF17Field(TF17DiskModel disk_model_, TF17HaloModel halo_model_) {
     useHaloField = true;
     useDiskField = true;
 
-    switch (halo_model) {
-    case TF17HaloModel::C0:
-        switch (disk_model) {
-        case TF17DiskModel::Ad1:
-	        // disk parameters
-	        set_r1_disk(3 * kpc);
-	        set_B1_disk(19.0 * muG);
-	        set_H_disk(0.055 * kpc);
-	        set_phi_star_disk(-54 * M_PI / 180);
-	        set_a_disk(0.9 / kpc / kpc);
-	        // halo parameters
-	        set_z1_halo(0);
-	        set_B1_halo(0.36 * muG);
-	        set_L_halo(3.0 * kpc);
-	        set_a_halo(1.17 / kpc / kpc);
-	        // shared parameters
-	        set_p0(-7.9 * M_PI / 180);
-	        set_Hp(5 * kpc);
-	        set_Lp(50 * kpc); // > 18 kpc
+    if ((halo_model == TF17HaloModel::C0) && (disk_model == TF17DiskModel::Ad1)) {
+        // disk parameters
+        set_r1_disk(3 * kpc);
+        set_B1_disk(19.0 * muG);
+        set_H_disk(0.055 * kpc);
+        set_phi_star_disk(-54 * M_PI / 180);
+        set_a_disk(0.9 / kpc / kpc);
+        // halo parameters
+        set_z1_halo(0);
+        set_B1_halo(0.36 * muG);
+        set_L_halo(3.0 * kpc);
+        set_a_halo(1.17 / kpc / kpc);
+        // shared parameters
+        set_p0(-7.9 * M_PI / 180);
+        set_Hp(5 * kpc);
+        set_Lp(50 * kpc); // > 18 kpc
+            
+    } else if ((halo_model == TF17HaloModel::C0) && (disk_model == TF17DiskModel::Bd1)) {
+        // disk parameters
+        set_r1_disk(3 * kpc);
+        set_B1_disk(2.0 * muG);
+        set_H_disk(0.32 * kpc);
+        set_phi_star_disk(153 * M_PI / 180);
+        // halo parameters
+        set_z1_halo(0);
+        set_B1_halo(0.29 * muG);
+        set_L_halo(3.4 * kpc);
+        set_a_halo(0.88 / kpc / kpc);
+        // shared parameters
+        set_p0(-7.2 * M_PI / 180);
+        set_Hp(9 * kpc);
+        set_Lp(50 * kpc); // > 16 kpc
 
-        case TF17DiskModel::Bd1:
-	        // disk parameters
-	        set_r1_disk(3 * kpc);
-	        set_B1_disk(2.0 * muG);
-	        set_H_disk(0.32 * kpc);
-	        set_phi_star_disk(153 * M_PI / 180);
-	        // halo parameters
-	        set_z1_halo(0);
-	        set_B1_halo(0.29 * muG);
-	        set_L_halo(3.4 * kpc);
-	        set_a_halo(0.88 / kpc / kpc);
-	        // shared parameters
-	        set_p0(-7.2 * M_PI / 180);
-	        set_Hp(9 * kpc);
-	        set_Lp(50 * kpc); // > 16 kpc
+    } else if ((halo_model == TF17HaloModel::C0) && (disk_model == TF17DiskModel::Dd1)) {
+        // disk parameters
+        set_z1_disk(1.5 * kpc);
+        set_B1_disk(0.065 * muG);
+        set_L_disk(9.8 * kpc);
+        set_phi_star_disk(14 * M_PI / 180);
+        // halo parameters
+        set_z1_halo(0);
+        set_B1_halo(0.18 * muG);
+        set_L_halo(4.8 * kpc);
+        set_a_halo(0.61 / kpc / kpc);
+        // shared parameters
+        set_p0(-7.4 * M_PI / 180);
+        set_Hp(4.2 * kpc);
+        set_Lp(50 * kpc); // > 22 kpc
 
-        case TF17DiskModel::Dd1:
-	        // disk parameters
-	        set_z1_disk(1.5 * kpc);
-	        set_B1_disk(0.065 * muG);
-	        set_L_disk(9.8 * kpc);
-	        set_phi_star_disk(14 * M_PI / 180);
-	        // halo parameters
-	        set_z1_halo(0);
-	        set_B1_halo(0.18 * muG);
-	        set_L_halo(4.8 * kpc);
-	        set_a_halo(0.61 / kpc / kpc);
-	        // shared parameters
-	        set_p0(-7.4 * M_PI / 180);
-	        set_Hp(4.2 * kpc);
-	        set_Lp(50 * kpc); // > 22 kpc
-        }
+    } else if ((halo_model == TF17HaloModel::C1) && (disk_model == TF17DiskModel::Ad1)) {
+        // disk parameters
+        set_r1_disk(3 * kpc);
+        set_B1_disk(32.0 * muG);
+        set_H_disk(0.054 * kpc);
+        set_phi_star_disk(-31 * M_PI / 180);
+        set_a_disk(0.031 / kpc / kpc);
+        // halo parameters
+        set_z1_halo(0);
+        set_B1_halo(9.0 * muG);
+        set_L_halo(2.1 * kpc);
+        set_phi_star_halo(198 * M_PI / 180);
+        set_a_halo(0.33 / kpc / kpc);
+        // shared parameters
+        set_p0(-9.1 * M_PI / 180);
+        set_Hp(1.2 * kpc);
+        set_Lp(50 * kpc); // > 38 kpc
 
-    case TF17HaloModel::C1:
-        switch (disk_model) {
-        case TF17DiskModel::Ad1:
-	        // disk parameters
-	        set_r1_disk(3 * kpc);
-	        set_B1_disk(32.0 * muG);
-	        set_H_disk(0.054 * kpc);
-	        set_phi_star_disk(-31 * M_PI / 180);
-	        set_a_disk(0.031 / kpc / kpc);
-	        // halo parameters
-	        set_z1_halo(0);
-	        set_B1_halo(9.0 * muG);
-	        set_L_halo(2.1 * kpc);
-	        set_phi_star_halo(198 * M_PI / 180);
-	        set_a_halo(0.33 / kpc / kpc);
-	        // shared parameters
-	        set_p0(-9.1 * M_PI / 180);
-	        set_Hp(1.2 * kpc);
-	        set_Lp(50 * kpc); // > 38 kpc
+    } else if ((halo_model == TF17HaloModel::C1) && (disk_model == TF17DiskModel::Bd1)) {
+        // disk parameters
+        set_r1_disk(3 * kpc);
+        set_B1_disk(24 * muG);
+        set_H_disk(0.090 * kpc);
+        set_phi_star_disk(-34 * M_PI / 180);
+        // halo parameters
+        set_z1_halo(0);
+        set_B1_halo(8.2 * muG);
+        set_L_halo(2.2 * kpc);
+        set_phi_star_halo(197 * M_PI / 180);
+        set_a_halo(0.38 / kpc / kpc);
+        // shared parameters
+        set_p0(-9.0 * M_PI / 180);
+        set_Hp(1.2 * kpc);
+        set_Lp(50 * kpc); // > 38 kpc
 
-        case TF17DiskModel::Bd1:
-	        // disk parameters
-	        set_r1_disk(3 * kpc);
-	        set_B1_disk(24 * muG);
-	        set_H_disk(0.090 * kpc);
-	        set_phi_star_disk(-34 * M_PI / 180);
-	        // halo parameters
-	        set_z1_halo(0);
-	        set_B1_halo(8.2 * muG);
-	        set_L_halo(2.2 * kpc);
-	        set_phi_star_halo(197 * M_PI / 180);
-	        set_a_halo(0.38 / kpc / kpc);
-	        // shared parameters
-	        set_p0(-9.0 * M_PI / 180);
-	        set_Hp(1.2 * kpc);
-	        set_Lp(50 * kpc); // > 38 kpc
-
-        case TF17DiskModel::Dd1:
-	        // disk parameters
-	        set_z1_disk(1.5 * kpc);
-	        set_B1_disk(0.40 * muG);
-	        set_L_disk(2.9 * kpc);
-	        set_phi_star_disk(120 * M_PI / 180);
-	        // halo parameters
-	        set_z1_halo(0);
-	        set_B1_halo(9.5 * muG);
-	        set_L_halo(2.1 * kpc);
-	        set_phi_star_halo(179 * M_PI / 180);
-            set_a_halo(0.45 / kpc / kpc);
-	        // shared parameters
-	        set_p0(-8.4 * M_PI / 180);
-	        set_Hp(1.2 * kpc);
-	        set_Lp(50 * kpc); // > 30 kpc
-        }
+    } else if ((halo_model == TF17HaloModel::C1) && (disk_model == TF17DiskModel::Dd1)) {
+        // disk parameters
+        set_z1_disk(1.5 * kpc);
+        set_B1_disk(0.40 * muG);
+        set_L_disk(2.9 * kpc);
+        set_phi_star_disk(120 * M_PI / 180);
+        // halo parameters
+        set_z1_halo(0);
+        set_B1_halo(9.5 * muG);
+        set_L_halo(2.1 * kpc);
+        set_phi_star_halo(179 * M_PI / 180);
+        set_a_halo(0.45 / kpc / kpc);
+        // shared parameters
+        set_p0(-8.4 * M_PI / 180);
+        set_Hp(1.2 * kpc);
+        set_Lp(50 * kpc); // > 30 kpc
     }
 
     epsilon = std::numeric_limits<double>::epsilon();
@@ -194,8 +187,7 @@ Vector3d TF17Field::getDiskField(const double& r, const double& z, const double&
     double B_phi = 0;
     double B_z = 0;
 
-    switch (disk_model) {
-    case TF17DiskModel::Ad1 : // ==========================================================
+    if (disk_model == TF17DiskModel::Ad1) { // ==========================================================
         if (r > r1_disk) {
             double z1_disk_z = (1. + a_disk * r1_disk * r1_disk) / (1. + a_disk * r * r); // z1_disk / z
             // B components in (r, phi, z)
@@ -211,9 +203,8 @@ Vector3d TF17Field::getDiskField(const double& r, const double& z, const double&
             B_r = cos(phi1_disk - phi) * B_amp;
             B_phi = sin(phi1_disk - phi) * B_amp;
         }
-        break;
 
-    case TF17DiskModel::Bd1 : // ==========================================================
+    } else if (disk_model == TF17DiskModel::Bd1) { // ===================================================
         // for model Bd1, best fit for n = 2 
         if ( r > epsilon ) {
             double r1_disk_r = r1_disk / r;	
@@ -228,9 +219,8 @@ Vector3d TF17Field::getDiskField(const double& r, const double& z, const double&
             B_z = -10. * z / r1_disk * B_r0;
         }
         B_phi = azimuthalFieldComponent(r, z, B_r, B_z);
-        break;
 
-    case TF17DiskModel::Dd1 : // ==========================================================
+    } else if (disk_model == TF17DiskModel::Dd1) { // ===================================================
         // for model Dd1, best fit for n = 0.5 
         double z_sign = z >= 0 ? 1. : -1.; 
         double z_abs = fabs(z); 
@@ -251,7 +241,6 @@ Vector3d TF17Field::getDiskField(const double& r, const double& z, const double&
             B_z = z_sign * r1_disk_r * r1_disk_r * B_z0;
         }
         B_phi = azimuthalFieldComponent(r, z, B_r, B_z);
-        break;
     }
 
     // Convert to (x, y, z) components
@@ -269,10 +258,9 @@ Vector3d TF17Field::getHaloField(const double& r, const double& z, const double&
 	// B components in (r, phi, z)
     double B_z0;
 
-    switch (halo_model) {
-    case TF17HaloModel::C0: // m = 0
+    if (halo_model == TF17HaloModel::C0) { // m = 0
         B_z0 = B1_halo * exp(-r1_halo_r*r / L_halo); 
-    case TF17HaloModel::C1: // m = 1
+    } else if (halo_model == TF17HaloModel::C1) { // m = 1
         // simplication of the equation in the cosinus
         double phi_prime = phi - shiftedWindingFunction(r, z) - phi_star_halo;
         B_z0 = B1_halo * exp(-r1_halo_r*r / L_halo) * cos(phi_prime); 


### PR DESCRIPTION
Dear all,

In this pull-request, I want to provide the implementation of the Galactic and halo magnetic field presented in [Terral & Ferrière 2017](https://ui.adsabs.harvard.edu/abs/2017A%26A...600A..29T/abstract).

I implemented all 6 models of the paper: disk (Ad1, Bd1, Dd1) + halo (C0, C1).

The models can be set as follow :
```python3
disk_model = "Ad1"
halo_model = "C0"
GMF = crpropa.TF17Field(disk_model,halo_model)
```
The field at a given position can be call as usual:
```python3
B = GMF.getField(crpropa.Vector3d(0,0,0))
```

All models have been checked by Katia Ferrière. As far as I know, the implementation is correct.

I would like to point out that from the few tests I made, the models have some problems. The Faraday rotation is indeed only fittted in the halo (excluding the Galactic plan). As a consequence, the Galactic models (Ad1, Bd1, Dd1) are poorly fitted. In particular really strong amplitudes of the magnetic field (higher than few hundreds microgauss) can appear locally.

Nevertheless, since it is implemented. I think it is worthy to include it in CRPropa.

Thank you for considering the pull-request,
Cheers,

Thomas F. 