### PR TITLE
Add JF12b variant of JF12 field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New features:
 
+* Planck JF12b variant of the JF12Field. See arXiv:1601.00546. Thanks to
+	Mikhail Zotov for contributing.
+
 ### Features that are deprecated and will be removed after this release:
 
 ### New plugins and resources linked on the webpages:
@@ -14,7 +17,7 @@
 
 * Fix of (#254): Redshift evolution in PhotoPionProduction
   The reshift evolution was always handled with simple scaling and never with
-  the more accurate 2 dimensional interpolation. 
+  the more accurate 2 dimensional interpolation.
 
 ### New features:
 
@@ -23,7 +26,7 @@
   distribution of cosmic rays on a sphere, e.g. for investigation of propagation
   of extagalactic cosmic rays in the Milky Way  (see issue #246 and pull
   request #247)
-* For PhotoPionProduction now a two dimensional interpolation of the redshift 
+* For PhotoPionProduction now a two dimensional interpolation of the redshift
   evolution is available (see pull request  #255)
 * A new break condition MinimumChargeNumber is added (see pull request #256)
 * Vector3 now has index based access to its components. This improves

--- a/include/crpropa/magneticField/JF12Field.h
+++ b/include/crpropa/magneticField/JF12Field.h
@@ -25,7 +25,7 @@ namespace crpropa {
  Galactic center at the origin, the x-axis pointing in the opposite direction of
  the Sun, and the z-axis pointing towards Galactic north.
 
- The regular field components (disk, toroidal halo and polodial halo field) 
+ The regular field components (disk, toroidal halo and polodial halo field)
  may be turned on and off individually.
  */
 class JF12Field: public MagneticField {
@@ -132,6 +132,23 @@ public:
 
 	// All set field components
 	Vector3d getField(const Vector3d& pos) const;
+};
+
+
+/**
+ @class JF12FieldPlanck
+ @brief JF12FieldPlanck: the JF12 galactic magnetic field model with corrections
+ suggested by the Planck Collaboration
+
+ See: Planck Collaboration, "Planck intermediate results. XLII.
+ Large-scale Galactic magnetic fields", A&A 596 (2016) A103;
+ arXiv:1601.00546
+
+ This variant of the JF12 field uses only different parameters compared to the standard JF12 implementation.
+  */
+class PlanckJF12bField: public JF12Field {
+	public:
+		PlanckJF12bField();
 };
 
 } // namespace crpropa

--- a/src/magneticField/JF12Field.cpp
+++ b/src/magneticField/JF12Field.cpp
@@ -341,4 +341,26 @@ Vector3d JF12Field::getField(const Vector3d& pos) const {
 	return b;
 }
 
+
+
+PlanckJF12bField::PlanckJF12bField() : JF12Field::JF12Field(){
+	// regular field parameters
+	bDisk[5] = -3.5 * muG;
+	bX = 1.8 * muG;
+
+	// turbulent field parameters;
+	bDiskTurb[0] = 3.12 * muG;
+	bDiskTurb[1] = 6.24 * muG;
+	bDiskTurb[2] = 3.12 * muG;
+	bDiskTurb[3] = 6.24 * muG;
+	bDiskTurb[4] = 3.12 * muG;
+	bDiskTurb[5] = 6.24 * muG;
+	bDiskTurb[6] = 3.12 * muG;
+	bDiskTurb[7] = 6.24 * muG;
+
+	bDiskTurb5 = 3.90 * muG;
+
+	bHaloTurb = 7.332 * muG;
+}
+
 } // namespace crpropa


### PR DESCRIPTION
Implements a variant of the JF12 field from the Planck collaboration following arXiv:1601.00546 with changed parameters only. Mikhail Zotov send me this parameters in a private mail. He used them for a recent publication. I verified that the parameters match with the values in arXiv:1601.00546 . 