### PR TITLE
Double precision grids

### DIFF
--- a/include/crpropa/Grid.h
+++ b/include/crpropa/Grid.h
@@ -240,9 +240,10 @@ public:
 	}
 };
 
-typedef float GridPrecision;
-typedef Grid<Vector3<GridPrecision> > VectorGrid;
-typedef Grid<GridPrecision> ScalarGrid;
+typedef Grid<Vector3f> VectorGrid;
+typedef Grid<Vector3d> VectorGridDouble;
+typedef Grid<float> ScalarGrid;
+typedef Grid<double> ScalarGridDouble;
 /** @}*/
 
 } // namespace crpropa

--- a/include/crpropa/Grid.h
+++ b/include/crpropa/Grid.h
@@ -3,6 +3,10 @@
 
 #include "crpropa/Referenced.h"
 #include "crpropa/Vector3.h"
+
+#include "kiss/string.h"
+#include "kiss/logger.h"
+
 #include <vector>
 
 namespace crpropa {
@@ -240,10 +244,49 @@ public:
 	}
 };
 
-typedef Grid<Vector3f> VectorGrid;
-typedef Grid<Vector3d> VectorGridDouble;
-typedef Grid<float> ScalarGrid;
-typedef Grid<double> ScalarGridDouble;
+typedef Grid<Vector3f> VectorGridf;
+typedef Grid<Vector3d> VectorGridd;
+typedef Grid<float> ScalarGridf;
+typedef Grid<double> ScalarGridd;
+
+// DEPRICATED: Will be removed in CRPropa v3.9
+class VectorGrid: public VectorGridf {
+	void printDeprication() const {
+		KISS_LOG_WARNING << "VectorGrid is deprecated and will be removed in the future. Replace it with VectorGridf (float) or VectorGridd (double).";
+	}
+public:
+	VectorGrid(Vector3d origin, size_t N, double spacing) : VectorGridf(origin, N, spacing) {
+		printDeprication();
+	}
+
+	VectorGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, double spacing) : VectorGridf(origin, Nx, Ny, Nz, spacing) {
+		printDeprication();
+	}
+
+	VectorGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, Vector3d spacing) : VectorGridf(origin, Nx, Ny, Nz, spacing) {
+		printDeprication();
+	}
+};
+
+// DEPRICATED: Will be removed in CRPropa v3.9
+class ScalarGrid: public ScalarGridf {
+	void printDeprication() const {
+		KISS_LOG_WARNING << "ScalarGrid is deprecated and will be removed in the future. Replace with ScalarGridf (float) or ScalarGridd (double).";
+	}
+public:
+	ScalarGrid(Vector3d origin, size_t N, double spacing) : ScalarGridf(origin, N, spacing) {
+		printDeprication();
+	}
+
+	ScalarGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, double spacing) : ScalarGridf(origin, Nx, Ny, Nz, spacing) {
+		printDeprication();
+	}
+
+	ScalarGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, Vector3d spacing) : ScalarGridf(origin, Nx, Ny, Nz, spacing) {
+		printDeprication();
+	}
+};
+
 /** @}*/
 
 } // namespace crpropa

--- a/include/crpropa/Grid.h
+++ b/include/crpropa/Grid.h
@@ -244,45 +244,45 @@ public:
 	}
 };
 
-typedef Grid<Vector3f> VectorGridf;
-typedef Grid<Vector3d> VectorGridd;
-typedef Grid<float> ScalarGridf;
-typedef Grid<double> ScalarGridd;
+typedef Grid<Vector3f> Grid3f;
+typedef Grid<Vector3d> Grid3d;
+typedef Grid<float> Grid1f;
+typedef Grid<double> Grid1d;
 
 // DEPRICATED: Will be removed in CRPropa v3.9
-class VectorGrid: public VectorGridf {
+class VectorGrid: public Grid3f {
 	void printDeprication() const {
-		KISS_LOG_WARNING << "VectorGrid is deprecated and will be removed in the future. Replace it with VectorGridf (float) or VectorGridd (double).";
+		KISS_LOG_WARNING << "VectorGrid is deprecated and will be removed in the future. Replace it with Grid3f (float) or Grid3d (double).";
 	}
 public:
-	VectorGrid(Vector3d origin, size_t N, double spacing) : VectorGridf(origin, N, spacing) {
+	VectorGrid(Vector3d origin, size_t N, double spacing) : Grid3f(origin, N, spacing) {
 		printDeprication();
 	}
 
-	VectorGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, double spacing) : VectorGridf(origin, Nx, Ny, Nz, spacing) {
+	VectorGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, double spacing) : Grid3f(origin, Nx, Ny, Nz, spacing) {
 		printDeprication();
 	}
 
-	VectorGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, Vector3d spacing) : VectorGridf(origin, Nx, Ny, Nz, spacing) {
+	VectorGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, Vector3d spacing) : Grid3f(origin, Nx, Ny, Nz, spacing) {
 		printDeprication();
 	}
 };
 
 // DEPRICATED: Will be removed in CRPropa v3.9
-class ScalarGrid: public ScalarGridf {
+class ScalarGrid: public Grid1f {
 	void printDeprication() const {
-		KISS_LOG_WARNING << "ScalarGrid is deprecated and will be removed in the future. Replace with ScalarGridf (float) or ScalarGridd (double).";
+		KISS_LOG_WARNING << "ScalarGrid is deprecated and will be removed in the future. Replace with Grid1f (float) or Grid1d (double).";
 	}
 public:
-	ScalarGrid(Vector3d origin, size_t N, double spacing) : ScalarGridf(origin, N, spacing) {
+	ScalarGrid(Vector3d origin, size_t N, double spacing) : Grid1f(origin, N, spacing) {
 		printDeprication();
 	}
 
-	ScalarGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, double spacing) : ScalarGridf(origin, Nx, Ny, Nz, spacing) {
+	ScalarGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, double spacing) : Grid1f(origin, Nx, Ny, Nz, spacing) {
 		printDeprication();
 	}
 
-	ScalarGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, Vector3d spacing) : ScalarGridf(origin, Nx, Ny, Nz, spacing) {
+	ScalarGrid(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, Vector3d spacing) : Grid1f(origin, Nx, Ny, Nz, spacing) {
 		printDeprication();
 	}
 };

--- a/include/crpropa/GridTools.h
+++ b/include/crpropa/GridTools.h
@@ -25,59 +25,59 @@ namespace crpropa {
  */
 
 /** Evaluate the mean vector of all grid points */
-Vector3f meanFieldVector(ref_ptr<VectorGridf> grid);
+Vector3f meanFieldVector(ref_ptr<Grid3f> grid);
 
 /** Evaluate the mean of all grid points */
-double meanFieldStrength(ref_ptr<ScalarGridf> grid);
+double meanFieldStrength(ref_ptr<Grid1f> grid);
 /** Evaluate the mean of all grid points */
-double meanFieldStrength(ref_ptr<VectorGridf> grid);
+double meanFieldStrength(ref_ptr<Grid3f> grid);
 
 /** Evaluate the RMS of all grid points */
-double rmsFieldStrength(ref_ptr<ScalarGridf> grid);
+double rmsFieldStrength(ref_ptr<Grid1f> grid);
 /** Evaluate the RMS of all grid points */
-double rmsFieldStrength(ref_ptr<VectorGridf> grid);
+double rmsFieldStrength(ref_ptr<Grid3f> grid);
 
 /** Multiply all grid values by a given factor */
-void scaleGrid(ref_ptr<ScalarGridf> grid, double a);
+void scaleGrid(ref_ptr<Grid1f> grid, double a);
 /** Multiply all grid values by a given factor */
-void scaleGrid(ref_ptr<VectorGridf> grid, double a);
+void scaleGrid(ref_ptr<Grid3f> grid, double a);
 
 /** Fill vector grid from provided magnetic field */
-void fromMagneticField(ref_ptr<VectorGridf> grid, ref_ptr<MagneticField> field);
+void fromMagneticField(ref_ptr<Grid3f> grid, ref_ptr<MagneticField> field);
 
 /** Fill scalar grid from provided magnetic field */
-void fromMagneticFieldStrength(ref_ptr<ScalarGridf> grid, ref_ptr<MagneticField> field);
+void fromMagneticFieldStrength(ref_ptr<Grid1f> grid, ref_ptr<MagneticField> field);
 
-/** Load a VectorGridf from a binary file with single precision */
-void loadGrid(ref_ptr<VectorGridf> grid, std::string filename,
+/** Load a Grid3f from a binary file with single precision */
+void loadGrid(ref_ptr<Grid3f> grid, std::string filename,
 		double conversion = 1);
 
-/** Load a ScalarGridf from a binary file with single precision */
-void loadGrid(ref_ptr<ScalarGridf> grid, std::string filename,
+/** Load a Grid1f from a binary file with single precision */
+void loadGrid(ref_ptr<Grid1f> grid, std::string filename,
 		double conversion = 1);
 
-/** Dump a VectorGridf to a binary file */
-void dumpGrid(ref_ptr<VectorGridf> grid, std::string filename,
+/** Dump a Grid3f to a binary file */
+void dumpGrid(ref_ptr<Grid3f> grid, std::string filename,
 		double conversion = 1);
 
-/** Dump a ScalarGridf to a binary file with single precision */
-void dumpGrid(ref_ptr<ScalarGridf> grid, std::string filename,
+/** Dump a Grid1f to a binary file with single precision */
+void dumpGrid(ref_ptr<Grid1f> grid, std::string filename,
 		double conversion = 1);
 
-/** Load a VectorGridf grid from a plain text file */
-void loadGridFromTxt(ref_ptr<VectorGridf> grid, std::string filename,
+/** Load a Grid3f grid from a plain text file */
+void loadGridFromTxt(ref_ptr<Grid3f> grid, std::string filename,
 		double conversion = 1);
 
-/** Load a ScalarGridf from a plain text file */
-void loadGridFromTxt(ref_ptr<ScalarGridf> grid, std::string filename,
+/** Load a Grid1f from a plain text file */
+void loadGridFromTxt(ref_ptr<Grid1f> grid, std::string filename,
 		double conversion = 1);
 
-/** Dump a VectorGridf to a plain text file */
-void dumpGridToTxt(ref_ptr<VectorGridf> grid, std::string filename,
+/** Dump a Grid3f to a plain text file */
+void dumpGridToTxt(ref_ptr<Grid3f> grid, std::string filename,
 		double conversion = 1);
 
-/** Dump a ScalarGridf to a plain text file */
-void dumpGridToTxt(ref_ptr<ScalarGridf> grid, std::string filename,
+/** Dump a Grid1f to a plain text file */
+void dumpGridToTxt(ref_ptr<Grid1f> grid, std::string filename,
 		double conversion = 1);
 
 /** @}*/

--- a/include/crpropa/GridTools.h
+++ b/include/crpropa/GridTools.h
@@ -25,59 +25,59 @@ namespace crpropa {
  */
 
 /** Evaluate the mean vector of all grid points */
-Vector3f meanFieldVector(ref_ptr<VectorGrid> grid);
+Vector3f meanFieldVector(ref_ptr<VectorGridf> grid);
 
 /** Evaluate the mean of all grid points */
-double meanFieldStrength(ref_ptr<ScalarGrid> grid);
+double meanFieldStrength(ref_ptr<ScalarGridf> grid);
 /** Evaluate the mean of all grid points */
-double meanFieldStrength(ref_ptr<VectorGrid> grid);
+double meanFieldStrength(ref_ptr<VectorGridf> grid);
 
 /** Evaluate the RMS of all grid points */
-double rmsFieldStrength(ref_ptr<ScalarGrid> grid);
+double rmsFieldStrength(ref_ptr<ScalarGridf> grid);
 /** Evaluate the RMS of all grid points */
-double rmsFieldStrength(ref_ptr<VectorGrid> grid);
+double rmsFieldStrength(ref_ptr<VectorGridf> grid);
 
 /** Multiply all grid values by a given factor */
-void scaleGrid(ref_ptr<ScalarGrid> grid, double a);
+void scaleGrid(ref_ptr<ScalarGridf> grid, double a);
 /** Multiply all grid values by a given factor */
-void scaleGrid(ref_ptr<VectorGrid> grid, double a);
+void scaleGrid(ref_ptr<VectorGridf> grid, double a);
 
 /** Fill vector grid from provided magnetic field */
-void fromMagneticField(ref_ptr<VectorGrid> grid, ref_ptr<MagneticField> field);
+void fromMagneticField(ref_ptr<VectorGridf> grid, ref_ptr<MagneticField> field);
 
 /** Fill scalar grid from provided magnetic field */
-void fromMagneticFieldStrength(ref_ptr<ScalarGrid> grid, ref_ptr<MagneticField> field);
+void fromMagneticFieldStrength(ref_ptr<ScalarGridf> grid, ref_ptr<MagneticField> field);
 
-/** Load a VectorGrid from a binary file with single precision */
-void loadGrid(ref_ptr<VectorGrid> grid, std::string filename,
+/** Load a VectorGridf from a binary file with single precision */
+void loadGrid(ref_ptr<VectorGridf> grid, std::string filename,
 		double conversion = 1);
 
-/** Load a ScalarGrid from a binary file with single precision */
-void loadGrid(ref_ptr<ScalarGrid> grid, std::string filename,
+/** Load a ScalarGridf from a binary file with single precision */
+void loadGrid(ref_ptr<ScalarGridf> grid, std::string filename,
 		double conversion = 1);
 
-/** Dump a VectorGrid to a binary file */
-void dumpGrid(ref_ptr<VectorGrid> grid, std::string filename,
+/** Dump a VectorGridf to a binary file */
+void dumpGrid(ref_ptr<VectorGridf> grid, std::string filename,
 		double conversion = 1);
 
-/** Dump a ScalarGrid to a binary file with single precision */
-void dumpGrid(ref_ptr<ScalarGrid> grid, std::string filename,
+/** Dump a ScalarGridf to a binary file with single precision */
+void dumpGrid(ref_ptr<ScalarGridf> grid, std::string filename,
 		double conversion = 1);
 
-/** Load a VectorGrid grid from a plain text file */
-void loadGridFromTxt(ref_ptr<VectorGrid> grid, std::string filename,
+/** Load a VectorGridf grid from a plain text file */
+void loadGridFromTxt(ref_ptr<VectorGridf> grid, std::string filename,
 		double conversion = 1);
 
-/** Load a ScalarGrid from a plain text file */
-void loadGridFromTxt(ref_ptr<ScalarGrid> grid, std::string filename,
+/** Load a ScalarGridf from a plain text file */
+void loadGridFromTxt(ref_ptr<ScalarGridf> grid, std::string filename,
 		double conversion = 1);
 
-/** Dump a VectorGrid to a plain text file */
-void dumpGridToTxt(ref_ptr<VectorGrid> grid, std::string filename,
+/** Dump a VectorGridf to a plain text file */
+void dumpGridToTxt(ref_ptr<VectorGridf> grid, std::string filename,
 		double conversion = 1);
 
-/** Dump a ScalarGrid to a plain text file */
-void dumpGridToTxt(ref_ptr<ScalarGrid> grid, std::string filename,
+/** Dump a ScalarGridf to a plain text file */
+void dumpGridToTxt(ref_ptr<ScalarGridf> grid, std::string filename,
 		double conversion = 1);
 
 /** @}*/

--- a/include/crpropa/GridTurbulence.h
+++ b/include/crpropa/GridTurbulence.h
@@ -26,7 +26,7 @@ double turbulentCorrelationLength(double lMin, double lMax,
  Calculate the omnidirectional power spectrum E(k) for a given turbulent field
  Returns a vector of pairs (k_i, E(k_i))
 */
-std::vector<std::pair<int, GridPrecision> > gridPowerSpectrum(ref_ptr<VectorGrid> grid); 
+std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGrid> grid); 
 
 /**
  Create a random initialization of a turbulent field.

--- a/include/crpropa/GridTurbulence.h
+++ b/include/crpropa/GridTurbulence.h
@@ -26,7 +26,7 @@ double turbulentCorrelationLength(double lMin, double lMax,
  Calculate the omnidirectional power spectrum E(k) for a given turbulent field
  Returns a vector of pairs (k_i, E(k_i))
 */
-std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGrid> grid); 
+std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGridf> grid); 
 
 /**
  Create a random initialization of a turbulent field.
@@ -36,21 +36,21 @@ std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGrid> grid);
  @param Brms	RMS field strength
  @param seed	Random seed
  */
-void initTurbulence(ref_ptr<VectorGrid> grid, double Brms, double lMin, double lMax, 
+void initTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, 
 	   double alpha = -11./3., int seed = 0);
 
 /**
  Same as the normal turbulent field but with helicity.
  @param H	Helicity
 */
-void initHelicalTurbulence(ref_ptr<VectorGrid> grid, double Brms, double lMin, double lMax, 
+void initHelicalTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, 
 	   double alpha = -11./3., int seed = 0, double H = 0);
 
 /**
  Same as the normal turbulent field but with the bendover.
  @param lambda	Bendover scale, usually defined as the grid total size divided by number (example: lambda = grid_size/10.)
 */
-void initTurbulenceWithBendover(ref_ptr<VectorGrid> grid, double Brms, double lMin, double lMax,
+void initTurbulenceWithBendover(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax,
 	   double alpha = -11./3., int seed = 0, double lambda = 1);
 
 #endif // CRPROPA_HAVE_FFTW3F

--- a/include/crpropa/GridTurbulence.h
+++ b/include/crpropa/GridTurbulence.h
@@ -26,7 +26,7 @@ double turbulentCorrelationLength(double lMin, double lMax,
  Calculate the omnidirectional power spectrum E(k) for a given turbulent field
  Returns a vector of pairs (k_i, E(k_i))
 */
-std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGridf> grid); 
+std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<Grid3f> grid); 
 
 /**
  Create a random initialization of a turbulent field.
@@ -36,21 +36,21 @@ std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGridf> grid)
  @param Brms	RMS field strength
  @param seed	Random seed
  */
-void initTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, 
+void initTurbulence(ref_ptr<Grid3f> grid, double Brms, double lMin, double lMax, 
 	   double alpha = -11./3., int seed = 0);
 
 /**
  Same as the normal turbulent field but with helicity.
  @param H	Helicity
 */
-void initHelicalTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, 
+void initHelicalTurbulence(ref_ptr<Grid3f> grid, double Brms, double lMin, double lMax, 
 	   double alpha = -11./3., int seed = 0, double H = 0);
 
 /**
  Same as the normal turbulent field but with the bendover.
  @param lambda	Bendover scale, usually defined as the grid total size divided by number (example: lambda = grid_size/10.)
 */
-void initTurbulenceWithBendover(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax,
+void initTurbulenceWithBendover(ref_ptr<Grid3f> grid, double Brms, double lMin, double lMax,
 	   double alpha = -11./3., int seed = 0, double lambda = 1);
 
 #endif // CRPROPA_HAVE_FFTW3F

--- a/include/crpropa/Source.h
+++ b/include/crpropa/Source.h
@@ -362,9 +362,9 @@ public:
  @brief Random source positions from a density grid
  */
 class SourceDensityGrid: public SourceFeature {
-	ref_ptr<ScalarGridf> grid;
+	ref_ptr<Grid1f> grid;
 public:
-	SourceDensityGrid(ref_ptr<ScalarGridf> densityGrid);
+	SourceDensityGrid(ref_ptr<Grid1f> densityGrid);
 	void prepareParticle(ParticleState &particle) const;
 	void setDescription();
 };
@@ -374,9 +374,9 @@ public:
  @brief Random source positions from a 1D density grid
  */
 class SourceDensityGrid1D: public SourceFeature {
-	ref_ptr<ScalarGridf> grid;
+	ref_ptr<Grid1f> grid;
 public:
-	SourceDensityGrid1D(ref_ptr<ScalarGridf> densityGrid);
+	SourceDensityGrid1D(ref_ptr<Grid1f> densityGrid);
 	void prepareParticle(ParticleState &particle) const;
 	void setDescription();
 };

--- a/include/crpropa/Source.h
+++ b/include/crpropa/Source.h
@@ -362,9 +362,9 @@ public:
  @brief Random source positions from a density grid
  */
 class SourceDensityGrid: public SourceFeature {
-	ref_ptr<ScalarGrid> grid;
+	ref_ptr<ScalarGridf> grid;
 public:
-	SourceDensityGrid(ref_ptr<ScalarGrid> densityGrid);
+	SourceDensityGrid(ref_ptr<ScalarGridf> densityGrid);
 	void prepareParticle(ParticleState &particle) const;
 	void setDescription();
 };
@@ -374,9 +374,9 @@ public:
  @brief Random source positions from a 1D density grid
  */
 class SourceDensityGrid1D: public SourceFeature {
-	ref_ptr<ScalarGrid> grid;
+	ref_ptr<ScalarGridf> grid;
 public:
-	SourceDensityGrid1D(ref_ptr<ScalarGrid> densityGrid);
+	SourceDensityGrid1D(ref_ptr<ScalarGridf> densityGrid);
 	void prepareParticle(ParticleState &particle) const;
 	void setDescription();
 };

--- a/include/crpropa/magneticField/JF12Field.h
+++ b/include/crpropa/magneticField/JF12Field.h
@@ -60,10 +60,10 @@ protected:
 
 	// Striated field ---------------------------------------------------------
 	double sqrtbeta;       // relative strength of striated field
-	ref_ptr<ScalarGrid> striatedGrid;
+	ref_ptr<ScalarGridf> striatedGrid;
 
 	// Turbulent field --------------------------------------------------------
-	ref_ptr<VectorGrid> turbulentGrid;
+	ref_ptr<VectorGridf> turbulentGrid;
 	// disk
 	double bDiskTurb[8]; // field strengths in arms at r=5 kpc
 	double bDiskTurb5;   // field strength at r<5kpc
@@ -88,16 +88,16 @@ public:
 	 * Set a striated grid and activate the striated field component
 	 * @param grid	scalar grid containing random +1/-1 values, 100 parsec grid spacing
 	 */
-	void setStriatedGrid(ref_ptr<ScalarGrid> grid);
+	void setStriatedGrid(ref_ptr<ScalarGridf> grid);
 
 	/**
 	 * Set a turbulent grid and activate the turbulent field component
 	 * @param grid	vector grid containing a random field of Brms = 1
 	 */
-	void setTurbulentGrid(ref_ptr<VectorGrid> grid);
+	void setTurbulentGrid(ref_ptr<VectorGridf> grid);
 
-	ref_ptr<ScalarGrid> getStriatedGrid();
-	ref_ptr<VectorGrid> getTurbulentGrid();
+	ref_ptr<ScalarGridf> getStriatedGrid();
+	ref_ptr<VectorGridf> getTurbulentGrid();
 
 	void setUseRegularField(bool use);
 	virtual void setUseStriatedField(bool use);

--- a/include/crpropa/magneticField/JF12Field.h
+++ b/include/crpropa/magneticField/JF12Field.h
@@ -60,10 +60,10 @@ protected:
 
 	// Striated field ---------------------------------------------------------
 	double sqrtbeta;       // relative strength of striated field
-	ref_ptr<ScalarGridf> striatedGrid;
+	ref_ptr<Grid1f> striatedGrid;
 
 	// Turbulent field --------------------------------------------------------
-	ref_ptr<VectorGridf> turbulentGrid;
+	ref_ptr<Grid3f> turbulentGrid;
 	// disk
 	double bDiskTurb[8]; // field strengths in arms at r=5 kpc
 	double bDiskTurb5;   // field strength at r<5kpc
@@ -88,16 +88,16 @@ public:
 	 * Set a striated grid and activate the striated field component
 	 * @param grid	scalar grid containing random +1/-1 values, 100 parsec grid spacing
 	 */
-	void setStriatedGrid(ref_ptr<ScalarGridf> grid);
+	void setStriatedGrid(ref_ptr<Grid1f> grid);
 
 	/**
 	 * Set a turbulent grid and activate the turbulent field component
 	 * @param grid	vector grid containing a random field of Brms = 1
 	 */
-	void setTurbulentGrid(ref_ptr<VectorGridf> grid);
+	void setTurbulentGrid(ref_ptr<Grid3f> grid);
 
-	ref_ptr<ScalarGridf> getStriatedGrid();
-	ref_ptr<VectorGridf> getTurbulentGrid();
+	ref_ptr<Grid1f> getStriatedGrid();
+	ref_ptr<Grid3f> getTurbulentGrid();
 
 	void setUseRegularField(bool use);
 	virtual void setUseStriatedField(bool use);

--- a/include/crpropa/magneticField/MagneticFieldGrid.h
+++ b/include/crpropa/magneticField/MagneticFieldGrid.h
@@ -14,14 +14,14 @@ namespace crpropa {
  @class MagneticFieldGrid
  @brief Magnetic field on a periodic (or reflective), cartesian grid with trilinear interpolation.
 
- This class wraps a VectorGrid to serve as a MagneticField.
+ This class wraps a VectorGridf to serve as a MagneticField.
  */
 class MagneticFieldGrid: public MagneticField {
-	ref_ptr<VectorGrid> grid;
+	ref_ptr<VectorGridf> grid;
 public:
-	MagneticFieldGrid(ref_ptr<VectorGrid> grid);
-	void setGrid(ref_ptr<VectorGrid> grid);
-	ref_ptr<VectorGrid> getGrid();
+	MagneticFieldGrid(ref_ptr<VectorGridf> grid);
+	void setGrid(ref_ptr<VectorGridf> grid);
+	ref_ptr<VectorGridf> getGrid();
 	Vector3d getField(const Vector3d &position) const;
 };
 
@@ -29,21 +29,21 @@ public:
  @class ModulatedMagneticFieldGrid
  @brief Modulated magnetic field on a periodic grid.
 
- This class wraps a VectorGrid to serve as a MagneticField.
- The field is modulated on-the-fly with a ScalarGrid.
- The VectorGrid and ScalarGrid do not need to share the same origin, spacing or size.
+ This class wraps a VectorGridf to serve as a MagneticField.
+ The field is modulated on-the-fly with a ScalarGridf.
+ The VectorGridf and ScalarGridf do not need to share the same origin, spacing or size.
  */
 class ModulatedMagneticFieldGrid: public MagneticField {
-	ref_ptr<VectorGrid> grid;
-	ref_ptr<ScalarGrid> modGrid;
+	ref_ptr<VectorGridf> grid;
+	ref_ptr<ScalarGridf> modGrid;
 public:
 	ModulatedMagneticFieldGrid() {
 	}
-	ModulatedMagneticFieldGrid(ref_ptr<VectorGrid> grid, ref_ptr<ScalarGrid> modGrid);
-	void setGrid(ref_ptr<VectorGrid> grid);
-	void setModulationGrid(ref_ptr<ScalarGrid> modGrid);
-	ref_ptr<VectorGrid> getGrid();
-	ref_ptr<ScalarGrid> getModulationGrid();
+	ModulatedMagneticFieldGrid(ref_ptr<VectorGridf> grid, ref_ptr<ScalarGridf> modGrid);
+	void setGrid(ref_ptr<VectorGridf> grid);
+	void setModulationGrid(ref_ptr<ScalarGridf> modGrid);
+	ref_ptr<VectorGridf> getGrid();
+	ref_ptr<ScalarGridf> getModulationGrid();
 	void setReflective(bool gridReflective, bool modGridReflective);
 	Vector3d getField(const Vector3d &position) const;
 };

--- a/include/crpropa/magneticField/MagneticFieldGrid.h
+++ b/include/crpropa/magneticField/MagneticFieldGrid.h
@@ -14,14 +14,14 @@ namespace crpropa {
  @class MagneticFieldGrid
  @brief Magnetic field on a periodic (or reflective), cartesian grid with trilinear interpolation.
 
- This class wraps a VectorGridf to serve as a MagneticField.
+ This class wraps a Grid3f to serve as a MagneticField.
  */
 class MagneticFieldGrid: public MagneticField {
-	ref_ptr<VectorGridf> grid;
+	ref_ptr<Grid3f> grid;
 public:
-	MagneticFieldGrid(ref_ptr<VectorGridf> grid);
-	void setGrid(ref_ptr<VectorGridf> grid);
-	ref_ptr<VectorGridf> getGrid();
+	MagneticFieldGrid(ref_ptr<Grid3f> grid);
+	void setGrid(ref_ptr<Grid3f> grid);
+	ref_ptr<Grid3f> getGrid();
 	Vector3d getField(const Vector3d &position) const;
 };
 
@@ -29,21 +29,21 @@ public:
  @class ModulatedMagneticFieldGrid
  @brief Modulated magnetic field on a periodic grid.
 
- This class wraps a VectorGridf to serve as a MagneticField.
- The field is modulated on-the-fly with a ScalarGridf.
- The VectorGridf and ScalarGridf do not need to share the same origin, spacing or size.
+ This class wraps a Grid3f to serve as a MagneticField.
+ The field is modulated on-the-fly with a Grid1f.
+ The Grid3f and Grid1f do not need to share the same origin, spacing or size.
  */
 class ModulatedMagneticFieldGrid: public MagneticField {
-	ref_ptr<VectorGridf> grid;
-	ref_ptr<ScalarGridf> modGrid;
+	ref_ptr<Grid3f> grid;
+	ref_ptr<Grid1f> modGrid;
 public:
 	ModulatedMagneticFieldGrid() {
 	}
-	ModulatedMagneticFieldGrid(ref_ptr<VectorGridf> grid, ref_ptr<ScalarGridf> modGrid);
-	void setGrid(ref_ptr<VectorGridf> grid);
-	void setModulationGrid(ref_ptr<ScalarGridf> modGrid);
-	ref_ptr<VectorGridf> getGrid();
-	ref_ptr<ScalarGridf> getModulationGrid();
+	ModulatedMagneticFieldGrid(ref_ptr<Grid3f> grid, ref_ptr<Grid1f> modGrid);
+	void setGrid(ref_ptr<Grid3f> grid);
+	void setModulationGrid(ref_ptr<Grid1f> modGrid);
+	ref_ptr<Grid3f> getGrid();
+	ref_ptr<Grid1f> getModulationGrid();
 	void setReflective(bool gridReflective, bool modGridReflective);
 	Vector3d getField(const Vector3d &position) const;
 };

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -368,20 +368,20 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %include "crpropa/GridTurbulence.h"
 
 %implicitconv crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<float> > >;
-%template(VectorGridRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<float> > >;
-%template(VectorGrid) crpropa::Grid<crpropa::Vector3<float> >;
+%template(VectorGridfRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<float> > >;
+%template(VectorGridf) crpropa::Grid<crpropa::Vector3<float> >;
 
 %implicitconv crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<double> > >;
-%template(VectorGridDoubleRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<double> > >;
-%template(VectorGridDouble) crpropa::Grid<crpropa::Vector3<double> >;
+%template(VectorGriddRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<double> > >;
+%template(VectorGridd) crpropa::Grid<crpropa::Vector3<double> >;
 
 %implicitconv crpropa::ref_ptr<crpropa::Grid<float> >;
-%template(ScalarGridRefPtr) crpropa::ref_ptr<crpropa::Grid<float> >;
-%template(ScalarGrid) crpropa::Grid<float>;
+%template(ScalarGridfRefPtr) crpropa::ref_ptr<crpropa::Grid<float> >;
+%template(ScalarGridf) crpropa::Grid<float>;
 
 %implicitconv crpropa::ref_ptr<crpropa::Grid<double> >;
-%template(ScalarGridDoubleRefPtr) crpropa::ref_ptr<crpropa::Grid<double> >;
-%template(ScalarGridDouble) crpropa::Grid<double>;
+%template(ScalarGriddRefPtr) crpropa::ref_ptr<crpropa::Grid<double> >;
+%template(ScalarGridd) crpropa::Grid<double>;
 
 %implicitconv std::pair<std::vector<int>, std::vector<float> >;
 %template(PairIntFloat) std::pair<int, float>;

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -371,9 +371,17 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %template(VectorGridRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<float> > >;
 %template(VectorGrid) crpropa::Grid<crpropa::Vector3<float> >;
 
+%implicitconv crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<double> > >;
+%template(VectorGridDoubleRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<double> > >;
+%template(VectorGridDouble) crpropa::Grid<crpropa::Vector3<double> >;
+
 %implicitconv crpropa::ref_ptr<crpropa::Grid<float> >;
 %template(ScalarGridRefPtr) crpropa::ref_ptr<crpropa::Grid<float> >;
 %template(ScalarGrid) crpropa::Grid<float>;
+
+%implicitconv crpropa::ref_ptr<crpropa::Grid<double> >;
+%template(ScalarGridDoubleRefPtr) crpropa::ref_ptr<crpropa::Grid<double> >;
+%template(ScalarGridDouble) crpropa::Grid<double>;
 
 %implicitconv std::pair<std::vector<int>, std::vector<float> >;
 %template(PairIntFloat) std::pair<int, float>;

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -49,6 +49,13 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %ignore operator crpropa::MagneticField*;
 %ignore operator crpropa::AdvectionField*;
 %ignore operator crpropa::ParticleCollector*;
+%ignore operator crpropa::Density*;
+%ignore operator crpropa::CylindricalProjectionMap*;
+%ignore operator crpropa::EmissionMap*;
+%ignore operator crpropa::Grid< crpropa::Vector3< float > >*;
+%ignore operator crpropa::Grid< crpropa::Vector3< double > >*;
+%ignore operator crpropa::Grid< float >*;
+%ignore operator crpropa::Grid< double >*;
 %ignore crpropa::TextOutput::load;
 
 %feature("ref")   crpropa::Referenced "$this->addReference();"
@@ -368,20 +375,20 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %include "crpropa/GridTurbulence.h"
 
 %implicitconv crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<float> > >;
-%template(VectorGridfRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<float> > >;
-%template(VectorGridf) crpropa::Grid<crpropa::Vector3<float> >;
+%template(Grid3fRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<float> > >;
+%template(Grid3f) crpropa::Grid<crpropa::Vector3<float> >;
 
 %implicitconv crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<double> > >;
-%template(VectorGriddRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<double> > >;
-%template(VectorGridd) crpropa::Grid<crpropa::Vector3<double> >;
+%template(Grid3dRefPtr) crpropa::ref_ptr<crpropa::Grid<crpropa::Vector3<double> > >;
+%template(Grid3d) crpropa::Grid<crpropa::Vector3<double> >;
 
 %implicitconv crpropa::ref_ptr<crpropa::Grid<float> >;
-%template(ScalarGridfRefPtr) crpropa::ref_ptr<crpropa::Grid<float> >;
-%template(ScalarGridf) crpropa::Grid<float>;
+%template(Grid1fRefPtr) crpropa::ref_ptr<crpropa::Grid<float> >;
+%template(Grid1f) crpropa::Grid<float>;
 
 %implicitconv crpropa::ref_ptr<crpropa::Grid<double> >;
-%template(ScalarGriddRefPtr) crpropa::ref_ptr<crpropa::Grid<double> >;
-%template(ScalarGridd) crpropa::Grid<double>;
+%template(Grid1dRefPtr) crpropa::ref_ptr<crpropa::Grid<double> >;
+%template(Grid1d) crpropa::Grid<double>;
 
 %implicitconv std::pair<std::vector<int>, std::vector<float> >;
 %template(PairIntFloat) std::pair<int, float>;

--- a/src/GridTools.cpp
+++ b/src/GridTools.cpp
@@ -6,21 +6,21 @@
 
 namespace crpropa {
 
-void scaleGrid(ref_ptr<ScalarGrid> grid, double a) {
+void scaleGrid(ref_ptr<ScalarGridf> grid, double a) {
 	for (int ix = 0; ix < grid->getNx(); ix++)
 		for (int iy = 0; iy < grid->getNy(); iy++)
 			for (int iz = 0; iz < grid->getNz(); iz++)
 				grid->get(ix, iy, iz) *= a;
 }
 
-void scaleGrid(ref_ptr<VectorGrid> grid, double a) {
+void scaleGrid(ref_ptr<VectorGridf> grid, double a) {
 	for (int ix = 0; ix < grid->getNx(); ix++)
 		for (int iy = 0; iy < grid->getNy(); iy++)
 			for (int iz = 0; iz < grid->getNz(); iz++)
 				grid->get(ix, iy, iz) *= a;
 }
 
-Vector3f meanFieldVector(ref_ptr<VectorGrid> grid) {
+Vector3f meanFieldVector(ref_ptr<VectorGridf> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -32,7 +32,7 @@ Vector3f meanFieldVector(ref_ptr<VectorGrid> grid) {
 	return mean / Nx / Ny / Nz;
 }
 
-double meanFieldStrength(ref_ptr<VectorGrid> grid) {
+double meanFieldStrength(ref_ptr<VectorGridf> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -44,7 +44,7 @@ double meanFieldStrength(ref_ptr<VectorGrid> grid) {
 	return mean / Nx / Ny / Nz;
 }
 
-double meanFieldStrength(ref_ptr<ScalarGrid> grid) {
+double meanFieldStrength(ref_ptr<ScalarGridf> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -56,7 +56,7 @@ double meanFieldStrength(ref_ptr<ScalarGrid> grid) {
 	return mean / Nx / Ny / Nz;
 }
 
-double rmsFieldStrength(ref_ptr<VectorGrid> grid) {
+double rmsFieldStrength(ref_ptr<VectorGridf> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -68,7 +68,7 @@ double rmsFieldStrength(ref_ptr<VectorGrid> grid) {
 	return std::sqrt(sumV2 / Nx / Ny / Nz);
 }
 
-double rmsFieldStrength(ref_ptr<ScalarGrid> grid) {
+double rmsFieldStrength(ref_ptr<ScalarGridf> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -80,7 +80,7 @@ double rmsFieldStrength(ref_ptr<ScalarGrid> grid) {
 	return std::sqrt(sumV2 / Nx / Ny / Nz);
 }
 
-void fromMagneticField(ref_ptr<VectorGrid> grid, ref_ptr<MagneticField> field) {
+void fromMagneticField(ref_ptr<VectorGridf> grid, ref_ptr<MagneticField> field) {
 	Vector3d origin = grid->getOrigin();
 	Vector3d spacing = grid->getSpacing();
 	size_t Nx = grid->getNx();
@@ -95,7 +95,7 @@ void fromMagneticField(ref_ptr<VectorGrid> grid, ref_ptr<MagneticField> field) {
 	}
 }
 
-void fromMagneticFieldStrength(ref_ptr<ScalarGrid> grid, ref_ptr<MagneticField> field) {
+void fromMagneticFieldStrength(ref_ptr<ScalarGridf> grid, ref_ptr<MagneticField> field) {
 	Vector3d origin = grid->getOrigin();
 	Vector3d spacing = grid->getSpacing();
 	size_t Nx = grid->getNx();
@@ -110,11 +110,11 @@ void fromMagneticFieldStrength(ref_ptr<ScalarGrid> grid, ref_ptr<MagneticField> 
 	}
 }
 
-void loadGrid(ref_ptr<VectorGrid> grid, std::string filename, double c) {
+void loadGrid(ref_ptr<VectorGridf> grid, std::string filename, double c) {
 	std::ifstream fin(filename.c_str(), std::ios::binary);
 	if (!fin) {
 		std::stringstream ss;
-		ss << "load VectorGrid: " << filename << " not found";
+		ss << "load VectorGridf: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 
@@ -144,11 +144,11 @@ void loadGrid(ref_ptr<VectorGrid> grid, std::string filename, double c) {
 	fin.close();
 }
 
-void loadGrid(ref_ptr<ScalarGrid> grid, std::string filename, double c) {
+void loadGrid(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
 	std::ifstream fin(filename.c_str(), std::ios::binary);
 	if (!fin) {
 		std::stringstream ss;
-		ss << "load ScalarGrid: " << filename << " not found";
+		ss << "load ScalarGridf: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 
@@ -176,11 +176,11 @@ void loadGrid(ref_ptr<ScalarGrid> grid, std::string filename, double c) {
 	fin.close();
 }
 
-void dumpGrid(ref_ptr<VectorGrid> grid, std::string filename, double c) {
+void dumpGrid(ref_ptr<VectorGridf> grid, std::string filename, double c) {
 	std::ofstream fout(filename.c_str(), std::ios::binary);
 	if (!fout) {
 		std::stringstream ss;
-		ss << "dump VectorGrid: " << filename << " not found";
+		ss << "dump VectorGridf: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	for (int ix = 0; ix < grid->getNx(); ix++) {
@@ -196,11 +196,11 @@ void dumpGrid(ref_ptr<VectorGrid> grid, std::string filename, double c) {
 	fout.close();
 }
 
-void dumpGrid(ref_ptr<ScalarGrid> grid, std::string filename, double c) {
+void dumpGrid(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
 	std::ofstream fout(filename.c_str(), std::ios::binary);
 	if (!fout) {
 		std::stringstream ss;
-		ss << "dump ScalarGrid: " << filename << " not found";
+		ss << "dump ScalarGridf: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	for (int ix = 0; ix < grid->getNx(); ix++) {
@@ -214,11 +214,11 @@ void dumpGrid(ref_ptr<ScalarGrid> grid, std::string filename, double c) {
 	fout.close();
 }
 
-void loadGridFromTxt(ref_ptr<VectorGrid> grid, std::string filename, double c) {
+void loadGridFromTxt(ref_ptr<VectorGridf> grid, std::string filename, double c) {
 	std::ifstream fin(filename.c_str());
 	if (!fin) {
 		std::stringstream ss;
-		ss << "load VectorGrid: " << filename << " not found";
+		ss << "load VectorGridf: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	// skip header lines
@@ -232,18 +232,18 @@ void loadGridFromTxt(ref_ptr<VectorGrid> grid, std::string filename, double c) {
 				fin >> b.x >> b.y >> b.z;
 				b *= c;
 				if (fin.eof())
-					throw std::runtime_error("load VectorGrid: file too short");
+					throw std::runtime_error("load VectorGridf: file too short");
 			}
 		}
 	}
 	fin.close();
 }
 
-void loadGridFromTxt(ref_ptr<ScalarGrid> grid, std::string filename, double c) {
+void loadGridFromTxt(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
 	std::ifstream fin(filename.c_str());
 	if (!fin) {
 		std::stringstream ss;
-		ss << "load ScalarGrid: " << filename << " not found";
+		ss << "load ScalarGridf: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	// skip header lines
@@ -257,18 +257,18 @@ void loadGridFromTxt(ref_ptr<ScalarGrid> grid, std::string filename, double c) {
 				fin >> b;
 				b *= c;
 				if (fin.eof())
-					throw std::runtime_error("load ScalarGrid: file too short");
+					throw std::runtime_error("load ScalarGridf: file too short");
 			}
 		}
 	}
 	fin.close();
 }
 
-void dumpGridToTxt(ref_ptr<VectorGrid> grid, std::string filename, double c) {
+void dumpGridToTxt(ref_ptr<VectorGridf> grid, std::string filename, double c) {
 	std::ofstream fout(filename.c_str());
 	if (!fout) {
 		std::stringstream ss;
-		ss << "dump VectorGrid: " << filename << " not found";
+		ss << "dump VectorGridf: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	for (int ix = 0; ix < grid->getNx(); ix++) {
@@ -282,11 +282,11 @@ void dumpGridToTxt(ref_ptr<VectorGrid> grid, std::string filename, double c) {
 	fout.close();
 }
 
-void dumpGridToTxt(ref_ptr<ScalarGrid> grid, std::string filename, double c) {
+void dumpGridToTxt(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
 	std::ofstream fout(filename.c_str());
 	if (!fout) {
 		std::stringstream ss;
-		ss << "dump ScalarGrid: " << filename << " not found";
+		ss << "dump ScalarGridf: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	for (int ix = 0; ix < grid->getNx(); ix++) {

--- a/src/GridTools.cpp
+++ b/src/GridTools.cpp
@@ -6,21 +6,21 @@
 
 namespace crpropa {
 
-void scaleGrid(ref_ptr<ScalarGridf> grid, double a) {
+void scaleGrid(ref_ptr<Grid1f> grid, double a) {
 	for (int ix = 0; ix < grid->getNx(); ix++)
 		for (int iy = 0; iy < grid->getNy(); iy++)
 			for (int iz = 0; iz < grid->getNz(); iz++)
 				grid->get(ix, iy, iz) *= a;
 }
 
-void scaleGrid(ref_ptr<VectorGridf> grid, double a) {
+void scaleGrid(ref_ptr<Grid3f> grid, double a) {
 	for (int ix = 0; ix < grid->getNx(); ix++)
 		for (int iy = 0; iy < grid->getNy(); iy++)
 			for (int iz = 0; iz < grid->getNz(); iz++)
 				grid->get(ix, iy, iz) *= a;
 }
 
-Vector3f meanFieldVector(ref_ptr<VectorGridf> grid) {
+Vector3f meanFieldVector(ref_ptr<Grid3f> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -32,7 +32,7 @@ Vector3f meanFieldVector(ref_ptr<VectorGridf> grid) {
 	return mean / Nx / Ny / Nz;
 }
 
-double meanFieldStrength(ref_ptr<VectorGridf> grid) {
+double meanFieldStrength(ref_ptr<Grid3f> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -44,7 +44,7 @@ double meanFieldStrength(ref_ptr<VectorGridf> grid) {
 	return mean / Nx / Ny / Nz;
 }
 
-double meanFieldStrength(ref_ptr<ScalarGridf> grid) {
+double meanFieldStrength(ref_ptr<Grid1f> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -56,7 +56,7 @@ double meanFieldStrength(ref_ptr<ScalarGridf> grid) {
 	return mean / Nx / Ny / Nz;
 }
 
-double rmsFieldStrength(ref_ptr<VectorGridf> grid) {
+double rmsFieldStrength(ref_ptr<Grid3f> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -68,7 +68,7 @@ double rmsFieldStrength(ref_ptr<VectorGridf> grid) {
 	return std::sqrt(sumV2 / Nx / Ny / Nz);
 }
 
-double rmsFieldStrength(ref_ptr<ScalarGridf> grid) {
+double rmsFieldStrength(ref_ptr<Grid1f> grid) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -80,7 +80,7 @@ double rmsFieldStrength(ref_ptr<ScalarGridf> grid) {
 	return std::sqrt(sumV2 / Nx / Ny / Nz);
 }
 
-void fromMagneticField(ref_ptr<VectorGridf> grid, ref_ptr<MagneticField> field) {
+void fromMagneticField(ref_ptr<Grid3f> grid, ref_ptr<MagneticField> field) {
 	Vector3d origin = grid->getOrigin();
 	Vector3d spacing = grid->getSpacing();
 	size_t Nx = grid->getNx();
@@ -95,7 +95,7 @@ void fromMagneticField(ref_ptr<VectorGridf> grid, ref_ptr<MagneticField> field) 
 	}
 }
 
-void fromMagneticFieldStrength(ref_ptr<ScalarGridf> grid, ref_ptr<MagneticField> field) {
+void fromMagneticFieldStrength(ref_ptr<Grid1f> grid, ref_ptr<MagneticField> field) {
 	Vector3d origin = grid->getOrigin();
 	Vector3d spacing = grid->getSpacing();
 	size_t Nx = grid->getNx();
@@ -110,11 +110,11 @@ void fromMagneticFieldStrength(ref_ptr<ScalarGridf> grid, ref_ptr<MagneticField>
 	}
 }
 
-void loadGrid(ref_ptr<VectorGridf> grid, std::string filename, double c) {
+void loadGrid(ref_ptr<Grid3f> grid, std::string filename, double c) {
 	std::ifstream fin(filename.c_str(), std::ios::binary);
 	if (!fin) {
 		std::stringstream ss;
-		ss << "load VectorGridf: " << filename << " not found";
+		ss << "load Grid3f: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 
@@ -144,11 +144,11 @@ void loadGrid(ref_ptr<VectorGridf> grid, std::string filename, double c) {
 	fin.close();
 }
 
-void loadGrid(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
+void loadGrid(ref_ptr<Grid1f> grid, std::string filename, double c) {
 	std::ifstream fin(filename.c_str(), std::ios::binary);
 	if (!fin) {
 		std::stringstream ss;
-		ss << "load ScalarGridf: " << filename << " not found";
+		ss << "load Grid1f: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 
@@ -176,11 +176,11 @@ void loadGrid(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
 	fin.close();
 }
 
-void dumpGrid(ref_ptr<VectorGridf> grid, std::string filename, double c) {
+void dumpGrid(ref_ptr<Grid3f> grid, std::string filename, double c) {
 	std::ofstream fout(filename.c_str(), std::ios::binary);
 	if (!fout) {
 		std::stringstream ss;
-		ss << "dump VectorGridf: " << filename << " not found";
+		ss << "dump Grid3f: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	for (int ix = 0; ix < grid->getNx(); ix++) {
@@ -196,11 +196,11 @@ void dumpGrid(ref_ptr<VectorGridf> grid, std::string filename, double c) {
 	fout.close();
 }
 
-void dumpGrid(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
+void dumpGrid(ref_ptr<Grid1f> grid, std::string filename, double c) {
 	std::ofstream fout(filename.c_str(), std::ios::binary);
 	if (!fout) {
 		std::stringstream ss;
-		ss << "dump ScalarGridf: " << filename << " not found";
+		ss << "dump Grid1f: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	for (int ix = 0; ix < grid->getNx(); ix++) {
@@ -214,11 +214,11 @@ void dumpGrid(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
 	fout.close();
 }
 
-void loadGridFromTxt(ref_ptr<VectorGridf> grid, std::string filename, double c) {
+void loadGridFromTxt(ref_ptr<Grid3f> grid, std::string filename, double c) {
 	std::ifstream fin(filename.c_str());
 	if (!fin) {
 		std::stringstream ss;
-		ss << "load VectorGridf: " << filename << " not found";
+		ss << "load Grid3f: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	// skip header lines
@@ -232,18 +232,18 @@ void loadGridFromTxt(ref_ptr<VectorGridf> grid, std::string filename, double c) 
 				fin >> b.x >> b.y >> b.z;
 				b *= c;
 				if (fin.eof())
-					throw std::runtime_error("load VectorGridf: file too short");
+					throw std::runtime_error("load Grid3f: file too short");
 			}
 		}
 	}
 	fin.close();
 }
 
-void loadGridFromTxt(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
+void loadGridFromTxt(ref_ptr<Grid1f> grid, std::string filename, double c) {
 	std::ifstream fin(filename.c_str());
 	if (!fin) {
 		std::stringstream ss;
-		ss << "load ScalarGridf: " << filename << " not found";
+		ss << "load Grid1f: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	// skip header lines
@@ -257,18 +257,18 @@ void loadGridFromTxt(ref_ptr<ScalarGridf> grid, std::string filename, double c) 
 				fin >> b;
 				b *= c;
 				if (fin.eof())
-					throw std::runtime_error("load ScalarGridf: file too short");
+					throw std::runtime_error("load Grid1f: file too short");
 			}
 		}
 	}
 	fin.close();
 }
 
-void dumpGridToTxt(ref_ptr<VectorGridf> grid, std::string filename, double c) {
+void dumpGridToTxt(ref_ptr<Grid3f> grid, std::string filename, double c) {
 	std::ofstream fout(filename.c_str());
 	if (!fout) {
 		std::stringstream ss;
-		ss << "dump VectorGridf: " << filename << " not found";
+		ss << "dump Grid3f: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	for (int ix = 0; ix < grid->getNx(); ix++) {
@@ -282,11 +282,11 @@ void dumpGridToTxt(ref_ptr<VectorGridf> grid, std::string filename, double c) {
 	fout.close();
 }
 
-void dumpGridToTxt(ref_ptr<ScalarGridf> grid, std::string filename, double c) {
+void dumpGridToTxt(ref_ptr<Grid1f> grid, std::string filename, double c) {
 	std::ofstream fout(filename.c_str());
 	if (!fout) {
 		std::stringstream ss;
-		ss << "dump ScalarGridf: " << filename << " not found";
+		ss << "dump Grid1f: " << filename << " not found";
 		throw std::runtime_error(ss.str());
 	}
 	for (int ix = 0; ix < grid->getNx(); ix++) {

--- a/src/GridTurbulence.cpp
+++ b/src/GridTurbulence.cpp
@@ -20,7 +20,7 @@ double turbulentCorrelationLength(double lMin, double lMax, double alpha) {
 
 #ifdef CRPROPA_HAVE_FFTW3F
 
-std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGrid> grid) {
+std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGridf> grid) {
 	
 	double rms = rmsFieldStrength(grid);
 	size_t n = grid->getNx(); // size of array
@@ -106,7 +106,7 @@ std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGrid> grid) 
 /* Helper functions for synthetic turbulent field models */
 
 // Check the grid properties before the FFT procedure
-void checkGridRequirements(ref_ptr<VectorGrid> grid, double lMin, double lMax) {
+void checkGridRequirements(ref_ptr<VectorGridf> grid, double lMin, double lMax) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -125,7 +125,7 @@ void checkGridRequirements(ref_ptr<VectorGrid> grid, double lMin, double lMax) {
 }
 
 // Execute inverse discrete FFT in-place for a 3D grid, from complex to real space
-void executeInverseFFTInplace(ref_ptr<VectorGrid> grid, fftwf_complex* Bkx, fftwf_complex* Bky, fftwf_complex* Bkz) {
+void executeInverseFFTInplace(ref_ptr<VectorGridf> grid, fftwf_complex* Bkx, fftwf_complex* Bky, fftwf_complex* Bkz) {
 
 	size_t n = grid->getNx(); // size of array
 	size_t n2 = (size_t) floor(n / 2) + 1; // size array in z-direction in configuration space
@@ -162,7 +162,7 @@ void executeInverseFFTInplace(ref_ptr<VectorGrid> grid, fftwf_complex* Bkx, fftw
 	}
 }
 
-void initTurbulence(ref_ptr<VectorGrid> grid, double Brms, double lMin, double lMax, double alpha, int seed) {
+void initTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, double alpha, int seed) {
 
 	checkGridRequirements(grid, lMin, lMax);
 
@@ -261,7 +261,7 @@ void initTurbulence(ref_ptr<VectorGrid> grid, double Brms, double lMin, double l
 	scaleGrid(grid, Brms / rmsFieldStrength(grid)); // normalize to Brms
 }
 
-void initHelicalTurbulence(ref_ptr<VectorGrid> grid, double Brms, double lMin, double lMax, double alpha, int seed, double H) {
+void initHelicalTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, double alpha, int seed, double H) {
 
 	checkGridRequirements(grid, lMin, lMax);
 
@@ -359,7 +359,7 @@ void initHelicalTurbulence(ref_ptr<VectorGrid> grid, double Brms, double lMin, d
 	scaleGrid(grid, Brms / rmsFieldStrength(grid)); // normalize to Brms
 }
 
-void initTurbulenceWithBendover(ref_ptr<VectorGrid> grid, double Brms, double lMin, double lMax, double alpha, int seed, double lambda) {
+void initTurbulenceWithBendover(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, double alpha, int seed, double lambda) {
 
 	checkGridRequirements(grid, lMin, lMax);
 

--- a/src/GridTurbulence.cpp
+++ b/src/GridTurbulence.cpp
@@ -20,7 +20,7 @@ double turbulentCorrelationLength(double lMin, double lMax, double alpha) {
 
 #ifdef CRPROPA_HAVE_FFTW3F
 
-std::vector<std::pair<int, GridPrecision> > gridPowerSpectrum(ref_ptr<VectorGrid> grid) {
+std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGrid> grid) {
 	
 	double rms = rmsFieldStrength(grid);
 	size_t n = grid->getNx(); // size of array
@@ -41,7 +41,7 @@ std::vector<std::pair<int, GridPrecision> > gridPowerSpectrum(ref_ptr<VectorGrid
 		for (size_t iy = 0; iy < n; iy++) {
 			for (size_t iz = 0; iz < n; iz++) {
 				i = ix * n * n + iy * n + iz;
-				Vector3<GridPrecision> &b = grid->get(ix, iy, iz);
+				Vector3<float> &b = grid->get(ix, iy, iz);
 				Bx[i][0] = b.x / rms;
 				By[i][0] = b.y / rms;
 				Bz[i][0] = b.z / rms;
@@ -63,8 +63,8 @@ std::vector<std::pair<int, GridPrecision> > gridPowerSpectrum(ref_ptr<VectorGrid
 	fftwf_execute(plan_z);
 	fftwf_destroy_plan(plan_z);
 
-	GridPrecision power;
-	std::map<size_t, std::pair<GridPrecision, int> > spectrum;
+	float power;
+	std::map<size_t, std::pair<float, int> > spectrum;
 	int k;
 
 	for (size_t ix = 0; ix < n; ix++) {
@@ -93,8 +93,8 @@ std::vector<std::pair<int, GridPrecision> > gridPowerSpectrum(ref_ptr<VectorGrid
 	fftwf_free(Bky);
 	fftwf_free(Bkz);
 
-	std::vector<std::pair<int, GridPrecision> > points;
-	for(std::map<size_t, std::pair<GridPrecision, int> >::iterator it = spectrum.begin(); it != spectrum.end(); ++it) {
+	std::vector<std::pair<int, float> > points;
+	for(std::map<size_t, std::pair<float, int> >::iterator it = spectrum.begin(); it != spectrum.end(); ++it) {
         	points.push_back(std::make_pair(
 					it->first,
 					(it->second).first/(it->second).second));

--- a/src/GridTurbulence.cpp
+++ b/src/GridTurbulence.cpp
@@ -20,7 +20,7 @@ double turbulentCorrelationLength(double lMin, double lMax, double alpha) {
 
 #ifdef CRPROPA_HAVE_FFTW3F
 
-std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGridf> grid) {
+std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<Grid3f> grid) {
 	
 	double rms = rmsFieldStrength(grid);
 	size_t n = grid->getNx(); // size of array
@@ -106,7 +106,7 @@ std::vector<std::pair<int, float> > gridPowerSpectrum(ref_ptr<VectorGridf> grid)
 /* Helper functions for synthetic turbulent field models */
 
 // Check the grid properties before the FFT procedure
-void checkGridRequirements(ref_ptr<VectorGridf> grid, double lMin, double lMax) {
+void checkGridRequirements(ref_ptr<Grid3f> grid, double lMin, double lMax) {
 	size_t Nx = grid->getNx();
 	size_t Ny = grid->getNy();
 	size_t Nz = grid->getNz();
@@ -125,7 +125,7 @@ void checkGridRequirements(ref_ptr<VectorGridf> grid, double lMin, double lMax) 
 }
 
 // Execute inverse discrete FFT in-place for a 3D grid, from complex to real space
-void executeInverseFFTInplace(ref_ptr<VectorGridf> grid, fftwf_complex* Bkx, fftwf_complex* Bky, fftwf_complex* Bkz) {
+void executeInverseFFTInplace(ref_ptr<Grid3f> grid, fftwf_complex* Bkx, fftwf_complex* Bky, fftwf_complex* Bkz) {
 
 	size_t n = grid->getNx(); // size of array
 	size_t n2 = (size_t) floor(n / 2) + 1; // size array in z-direction in configuration space
@@ -162,7 +162,7 @@ void executeInverseFFTInplace(ref_ptr<VectorGridf> grid, fftwf_complex* Bkx, fft
 	}
 }
 
-void initTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, double alpha, int seed) {
+void initTurbulence(ref_ptr<Grid3f> grid, double Brms, double lMin, double lMax, double alpha, int seed) {
 
 	checkGridRequirements(grid, lMin, lMax);
 
@@ -261,7 +261,7 @@ void initTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double 
 	scaleGrid(grid, Brms / rmsFieldStrength(grid)); // normalize to Brms
 }
 
-void initHelicalTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, double alpha, int seed, double H) {
+void initHelicalTurbulence(ref_ptr<Grid3f> grid, double Brms, double lMin, double lMax, double alpha, int seed, double H) {
 
 	checkGridRequirements(grid, lMin, lMax);
 
@@ -359,7 +359,7 @@ void initHelicalTurbulence(ref_ptr<VectorGridf> grid, double Brms, double lMin, 
 	scaleGrid(grid, Brms / rmsFieldStrength(grid)); // normalize to Brms
 }
 
-void initTurbulenceWithBendover(ref_ptr<VectorGridf> grid, double Brms, double lMin, double lMax, double alpha, int seed, double lambda) {
+void initTurbulenceWithBendover(ref_ptr<Grid3f> grid, double Brms, double lMin, double lMax, double alpha, int seed, double lambda) {
 
 	checkGridRequirements(grid, lMin, lMax);
 

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -652,7 +652,7 @@ void SourceUniform1D::setDescription() {
 }
 
 // ----------------------------------------------------------------------------
-SourceDensityGrid::SourceDensityGrid(ref_ptr<ScalarGrid> grid) :
+SourceDensityGrid::SourceDensityGrid(ref_ptr<ScalarGridf> grid) :
 		grid(grid) {
 	float sum = 0;
 	for (int ix = 0; ix < grid->getNx(); ix++) {
@@ -687,7 +687,7 @@ void SourceDensityGrid::setDescription() {
 }
 
 // ----------------------------------------------------------------------------
-SourceDensityGrid1D::SourceDensityGrid1D(ref_ptr<ScalarGrid> grid) :
+SourceDensityGrid1D::SourceDensityGrid1D(ref_ptr<ScalarGridf> grid) :
 		grid(grid) {
 	if (grid->getNy() != 1)
 		throw std::runtime_error("SourceDensityGrid1D: Ny != 1");

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -652,7 +652,7 @@ void SourceUniform1D::setDescription() {
 }
 
 // ----------------------------------------------------------------------------
-SourceDensityGrid::SourceDensityGrid(ref_ptr<ScalarGridf> grid) :
+SourceDensityGrid::SourceDensityGrid(ref_ptr<Grid1f> grid) :
 		grid(grid) {
 	float sum = 0;
 	for (int ix = 0; ix < grid->getNx(); ix++) {
@@ -687,7 +687,7 @@ void SourceDensityGrid::setDescription() {
 }
 
 // ----------------------------------------------------------------------------
-SourceDensityGrid1D::SourceDensityGrid1D(ref_ptr<ScalarGridf> grid) :
+SourceDensityGrid1D::SourceDensityGrid1D(ref_ptr<Grid1f> grid) :
 		grid(grid) {
 	if (grid->getNy() != 1)
 		throw std::runtime_error("SourceDensityGrid1D: Ny != 1");

--- a/src/magneticField/JF12Field.cpp
+++ b/src/magneticField/JF12Field.cpp
@@ -84,7 +84,7 @@ JF12Field::JF12Field() {
 void JF12Field::randomStriated(int seed) {
 	useStriatedField = true;
 	int N = 100;
-	striatedGrid = new ScalarGridf(Vector3d(0.), N, 0.1 * kpc);
+	striatedGrid = new Grid1f(Vector3d(0.), N, 0.1 * kpc);
 
 	Random random;
 	if (seed != 0)
@@ -102,26 +102,26 @@ void JF12Field::randomStriated(int seed) {
 void JF12Field::randomTurbulent(int seed) {
 	useTurbulentField = true;
 	// turbulent field with Kolmogorov spectrum, B_rms = 1 and Lc = 60 parsec
-	turbulentGrid = new VectorGridf(Vector3d(0.), 256, 4 * parsec);
+	turbulentGrid = new Grid3f(Vector3d(0.), 256, 4 * parsec);
 	initTurbulence(turbulentGrid, 1, 8 * parsec, 272 * parsec, -11./3., seed);
 }
 #endif
 
-void JF12Field::setStriatedGrid(ref_ptr<ScalarGridf> grid) {
+void JF12Field::setStriatedGrid(ref_ptr<Grid1f> grid) {
 	useStriatedField = true;
 	striatedGrid = grid;
 }
 
-void JF12Field::setTurbulentGrid(ref_ptr<VectorGridf> grid) {
+void JF12Field::setTurbulentGrid(ref_ptr<Grid3f> grid) {
 	useTurbulentField = true;
 	turbulentGrid = grid;
 }
 
-ref_ptr<ScalarGridf> JF12Field::getStriatedGrid() {
+ref_ptr<Grid1f> JF12Field::getStriatedGrid() {
 	return striatedGrid;
 }
 
-ref_ptr<VectorGridf> JF12Field::getTurbulentGrid() {
+ref_ptr<Grid3f> JF12Field::getTurbulentGrid() {
 	return turbulentGrid;
 }
 

--- a/src/magneticField/JF12Field.cpp
+++ b/src/magneticField/JF12Field.cpp
@@ -84,7 +84,7 @@ JF12Field::JF12Field() {
 void JF12Field::randomStriated(int seed) {
 	useStriatedField = true;
 	int N = 100;
-	striatedGrid = new ScalarGrid(Vector3d(0.), N, 0.1 * kpc);
+	striatedGrid = new ScalarGridf(Vector3d(0.), N, 0.1 * kpc);
 
 	Random random;
 	if (seed != 0)
@@ -102,26 +102,26 @@ void JF12Field::randomStriated(int seed) {
 void JF12Field::randomTurbulent(int seed) {
 	useTurbulentField = true;
 	// turbulent field with Kolmogorov spectrum, B_rms = 1 and Lc = 60 parsec
-	turbulentGrid = new VectorGrid(Vector3d(0.), 256, 4 * parsec);
+	turbulentGrid = new VectorGridf(Vector3d(0.), 256, 4 * parsec);
 	initTurbulence(turbulentGrid, 1, 8 * parsec, 272 * parsec, -11./3., seed);
 }
 #endif
 
-void JF12Field::setStriatedGrid(ref_ptr<ScalarGrid> grid) {
+void JF12Field::setStriatedGrid(ref_ptr<ScalarGridf> grid) {
 	useStriatedField = true;
 	striatedGrid = grid;
 }
 
-void JF12Field::setTurbulentGrid(ref_ptr<VectorGrid> grid) {
+void JF12Field::setTurbulentGrid(ref_ptr<VectorGridf> grid) {
 	useTurbulentField = true;
 	turbulentGrid = grid;
 }
 
-ref_ptr<ScalarGrid> JF12Field::getStriatedGrid() {
+ref_ptr<ScalarGridf> JF12Field::getStriatedGrid() {
 	return striatedGrid;
 }
 
-ref_ptr<VectorGrid> JF12Field::getTurbulentGrid() {
+ref_ptr<VectorGridf> JF12Field::getTurbulentGrid() {
 	return turbulentGrid;
 }
 

--- a/src/magneticField/MagneticFieldGrid.cpp
+++ b/src/magneticField/MagneticFieldGrid.cpp
@@ -2,15 +2,15 @@
 
 namespace crpropa {
 
-MagneticFieldGrid::MagneticFieldGrid(ref_ptr<VectorGridf> grid) {
+MagneticFieldGrid::MagneticFieldGrid(ref_ptr<Grid3f> grid) {
 	setGrid(grid);
 }
 
-void MagneticFieldGrid::setGrid(ref_ptr<VectorGridf> grid) {
+void MagneticFieldGrid::setGrid(ref_ptr<Grid3f> grid) {
 	this->grid = grid;
 }
 
-ref_ptr<VectorGridf> MagneticFieldGrid::getGrid() {
+ref_ptr<Grid3f> MagneticFieldGrid::getGrid() {
 	return grid;
 }
 
@@ -18,27 +18,27 @@ Vector3d MagneticFieldGrid::getField(const Vector3d &pos) const {
 	return grid->interpolate(pos);
 }
 
-ModulatedMagneticFieldGrid::ModulatedMagneticFieldGrid(ref_ptr<VectorGridf> grid,
-		ref_ptr<ScalarGridf> modGrid) {
+ModulatedMagneticFieldGrid::ModulatedMagneticFieldGrid(ref_ptr<Grid3f> grid,
+		ref_ptr<Grid1f> modGrid) {
 	grid->setReflective(false);
 	modGrid->setReflective(true);
 	setGrid(grid);
 	setModulationGrid(modGrid);
 }
 
-void ModulatedMagneticFieldGrid::setGrid(ref_ptr<VectorGridf> g) {
+void ModulatedMagneticFieldGrid::setGrid(ref_ptr<Grid3f> g) {
 	grid = g;
 }
 
-ref_ptr<VectorGridf> ModulatedMagneticFieldGrid::getGrid() {
+ref_ptr<Grid3f> ModulatedMagneticFieldGrid::getGrid() {
 	return grid;
 }
 
-void ModulatedMagneticFieldGrid::setModulationGrid(ref_ptr<ScalarGridf> g) {
+void ModulatedMagneticFieldGrid::setModulationGrid(ref_ptr<Grid1f> g) {
 	modGrid = g;
 }
 
-ref_ptr<ScalarGridf> ModulatedMagneticFieldGrid::getModulationGrid() {
+ref_ptr<Grid1f> ModulatedMagneticFieldGrid::getModulationGrid() {
 	return modGrid;
 }
 

--- a/src/magneticField/MagneticFieldGrid.cpp
+++ b/src/magneticField/MagneticFieldGrid.cpp
@@ -2,15 +2,15 @@
 
 namespace crpropa {
 
-MagneticFieldGrid::MagneticFieldGrid(ref_ptr<VectorGrid> grid) {
+MagneticFieldGrid::MagneticFieldGrid(ref_ptr<VectorGridf> grid) {
 	setGrid(grid);
 }
 
-void MagneticFieldGrid::setGrid(ref_ptr<VectorGrid> grid) {
+void MagneticFieldGrid::setGrid(ref_ptr<VectorGridf> grid) {
 	this->grid = grid;
 }
 
-ref_ptr<VectorGrid> MagneticFieldGrid::getGrid() {
+ref_ptr<VectorGridf> MagneticFieldGrid::getGrid() {
 	return grid;
 }
 
@@ -18,27 +18,27 @@ Vector3d MagneticFieldGrid::getField(const Vector3d &pos) const {
 	return grid->interpolate(pos);
 }
 
-ModulatedMagneticFieldGrid::ModulatedMagneticFieldGrid(ref_ptr<VectorGrid> grid,
-		ref_ptr<ScalarGrid> modGrid) {
+ModulatedMagneticFieldGrid::ModulatedMagneticFieldGrid(ref_ptr<VectorGridf> grid,
+		ref_ptr<ScalarGridf> modGrid) {
 	grid->setReflective(false);
 	modGrid->setReflective(true);
 	setGrid(grid);
 	setModulationGrid(modGrid);
 }
 
-void ModulatedMagneticFieldGrid::setGrid(ref_ptr<VectorGrid> g) {
+void ModulatedMagneticFieldGrid::setGrid(ref_ptr<VectorGridf> g) {
 	grid = g;
 }
 
-ref_ptr<VectorGrid> ModulatedMagneticFieldGrid::getGrid() {
+ref_ptr<VectorGridf> ModulatedMagneticFieldGrid::getGrid() {
 	return grid;
 }
 
-void ModulatedMagneticFieldGrid::setModulationGrid(ref_ptr<ScalarGrid> g) {
+void ModulatedMagneticFieldGrid::setModulationGrid(ref_ptr<ScalarGridf> g) {
 	modGrid = g;
 }
 
-ref_ptr<ScalarGrid> ModulatedMagneticFieldGrid::getModulationGrid() {
+ref_ptr<ScalarGridf> ModulatedMagneticFieldGrid::getModulationGrid() {
 	return modGrid;
 }
 

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -408,7 +408,7 @@ TEST(Grid, PeriodicClamp) {
 	EXPECT_EQ(1, hi);
 }
 
-TEST(ScalarGrid, SimpleTest) {
+TEST(ScalarGridf, SimpleTest) {
 	// Test construction and parameters
 	size_t Nx = 5;
 	size_t Ny = 8;
@@ -416,7 +416,7 @@ TEST(ScalarGrid, SimpleTest) {
 	double spacing = 2.0;
 	Vector3d origin(1., 2., 3.);
 
-	ScalarGrid grid(origin, Nx, Ny, Nz, spacing);
+	ScalarGridf grid(origin, Nx, Ny, Nz, spacing);
 
 	EXPECT_TRUE(origin == grid.getOrigin());
 	EXPECT_EQ(Nx, grid.getNx());
@@ -435,7 +435,7 @@ TEST(ScalarGrid, SimpleTest) {
 	EXPECT_FLOAT_EQ(7., grid.interpolate(some_grid_point));
 }
 
-TEST(ScalarGrid, TestVectorSpacing) {
+TEST(ScalarGridf, TestVectorSpacing) {
 	// Test constructor for vector spacing
 	size_t Nx = 5;
 	size_t Ny = 8;
@@ -443,7 +443,7 @@ TEST(ScalarGrid, TestVectorSpacing) {
 	Vector3d origin = Vector3d(1., 2., 3.);
 	Vector3d spacing = Vector3d(1., 5., 3.);
 
-	ScalarGrid grid(origin, Nx, Ny, Nz, spacing);
+	ScalarGridf grid(origin, Nx, Ny, Nz, spacing);
 
 	EXPECT_EQ(spacing, grid.getSpacing());
 
@@ -456,9 +456,9 @@ TEST(ScalarGrid, TestVectorSpacing) {
 	EXPECT_FLOAT_EQ(12., grid.interpolate(some_grid_point));
 }
 
-TEST(ScalarGrid, ClosestValue) {
+TEST(ScalarGridf, ClosestValue) {
 	// Check some closest values
-	ScalarGrid grid(Vector3d(0.), 2, 2, 2, 1.);
+	ScalarGridf grid(Vector3d(0.), 2, 2, 2, 1.);
 	grid.get(0, 0, 0) = 1;
 	grid.get(0, 0, 1) = 2;
 	grid.get(0, 1, 0) = 3;
@@ -475,11 +475,11 @@ TEST(ScalarGrid, ClosestValue) {
 	EXPECT_FLOAT_EQ(7, grid.closestValue(Vector3d(1.7, 1.8, 0.4)));
 }
 
-TEST(VectorGrid, Interpolation) {
+TEST(VectorGridf, Interpolation) {
 	// Explicitly test trilinear interpolation
 	double spacing = 2.793;
 	int n = 3;
-	VectorGrid grid(Vector3d(0.), n, n, n, spacing);
+	VectorGridf grid(Vector3d(0.), n, n, n, spacing);
 	grid.get(0, 0, 1) = Vector3f(1.7, 0., 0.); // set one value
 
 	Vector3d b;
@@ -503,7 +503,7 @@ TEST(VectorGrid, Interpolation) {
 
 TEST(VectordGrid, Scale) {
 	// Test scaling a field
-	ref_ptr<VectorGrid> grid = new VectorGrid(Vector3d(0.), 3, 1);
+	ref_ptr<VectorGridf> grid = new VectorGridf(Vector3d(0.), 3, 1);
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
 			for (int iz = 0; iz < 3; iz++)
@@ -516,12 +516,12 @@ TEST(VectordGrid, Scale) {
 				EXPECT_FLOAT_EQ(5, grid->interpolate(Vector3d(0.7, 0, 0.1)).x);
 }
 
-TEST(VectorGrid, Periodicity) {
+TEST(VectorGridf, Periodicity) {
 	// Test for periodic boundaries: grid(x+a*n) = grid(x)
 	size_t n = 3;
 	double spacing = 3;
 	double size = n * spacing;
-	VectorGrid grid(Vector3d(0.), n, spacing);
+	VectorGridf grid(Vector3d(0.), n, spacing);
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
 			for (int iz = 0; iz < 3; iz++)
@@ -545,10 +545,10 @@ TEST(VectorGrid, Periodicity) {
 	EXPECT_FLOAT_EQ(b.z, b2.z);
 }
 
-TEST(VectorGrid, DumpLoad) {
+TEST(VectorGridf, DumpLoad) {
 	// Dump and load a field grid
-	ref_ptr<VectorGrid> grid1 = new VectorGrid(Vector3d(0.), 3, 1);
-	ref_ptr<VectorGrid> grid2 = new VectorGrid(Vector3d(0.), 3, 1);
+	ref_ptr<VectorGridf> grid1 = new VectorGridf(Vector3d(0.), 3, 1);
+	ref_ptr<VectorGridf> grid2 = new VectorGridf(Vector3d(0.), 3, 1);
 
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
@@ -571,10 +571,10 @@ TEST(VectorGrid, DumpLoad) {
 	}
 }
 
-TEST(VectorGrid, DumpLoadTxt) {
+TEST(VectorGridf, DumpLoadTxt) {
 	// Dump and load a field grid
-	ref_ptr<VectorGrid> grid1 = new VectorGrid(Vector3d(0.), 3, 1);
-	ref_ptr<VectorGrid> grid2 = new VectorGrid(Vector3d(0.), 3, 1);
+	ref_ptr<VectorGridf> grid1 = new VectorGridf(Vector3d(0.), 3, 1);
+	ref_ptr<VectorGridf> grid2 = new VectorGridf(Vector3d(0.), 3, 1);
 
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
@@ -597,9 +597,9 @@ TEST(VectorGrid, DumpLoadTxt) {
 	}
 }
 
-TEST(VectorGrid, Speed) {
+TEST(VectorGridf, Speed) {
 	// Dump and load a field grid
-	VectorGrid grid(Vector3d(0.), 3, 3);
+	VectorGridf grid(Vector3d(0.), 3, 3);
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
 			for (int iz = 0; iz < 3; iz++)

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -408,7 +408,7 @@ TEST(Grid, PeriodicClamp) {
 	EXPECT_EQ(1, hi);
 }
 
-TEST(ScalarGridf, SimpleTest) {
+TEST(ScalarGrid, SimpleTest) {
 	// Test construction and parameters
 	size_t Nx = 5;
 	size_t Ny = 8;
@@ -416,7 +416,7 @@ TEST(ScalarGridf, SimpleTest) {
 	double spacing = 2.0;
 	Vector3d origin(1., 2., 3.);
 
-	ScalarGridf grid(origin, Nx, Ny, Nz, spacing);
+	ScalarGrid grid(origin, Nx, Ny, Nz, spacing);
 
 	EXPECT_TRUE(origin == grid.getOrigin());
 	EXPECT_EQ(Nx, grid.getNx());
@@ -435,7 +435,7 @@ TEST(ScalarGridf, SimpleTest) {
 	EXPECT_FLOAT_EQ(7., grid.interpolate(some_grid_point));
 }
 
-TEST(ScalarGridf, TestVectorSpacing) {
+TEST(ScalarGrid, TestVectorSpacing) {
 	// Test constructor for vector spacing
 	size_t Nx = 5;
 	size_t Ny = 8;
@@ -443,7 +443,7 @@ TEST(ScalarGridf, TestVectorSpacing) {
 	Vector3d origin = Vector3d(1., 2., 3.);
 	Vector3d spacing = Vector3d(1., 5., 3.);
 
-	ScalarGridf grid(origin, Nx, Ny, Nz, spacing);
+	ScalarGrid grid(origin, Nx, Ny, Nz, spacing);
 
 	EXPECT_EQ(spacing, grid.getSpacing());
 
@@ -456,9 +456,9 @@ TEST(ScalarGridf, TestVectorSpacing) {
 	EXPECT_FLOAT_EQ(12., grid.interpolate(some_grid_point));
 }
 
-TEST(ScalarGridf, ClosestValue) {
+TEST(ScalarGrid, ClosestValue) {
 	// Check some closest values
-	ScalarGridf grid(Vector3d(0.), 2, 2, 2, 1.);
+	ScalarGrid grid(Vector3d(0.), 2, 2, 2, 1.);
 	grid.get(0, 0, 0) = 1;
 	grid.get(0, 0, 1) = 2;
 	grid.get(0, 1, 0) = 3;
@@ -475,11 +475,11 @@ TEST(ScalarGridf, ClosestValue) {
 	EXPECT_FLOAT_EQ(7, grid.closestValue(Vector3d(1.7, 1.8, 0.4)));
 }
 
-TEST(VectorGridf, Interpolation) {
+TEST(Grid3f, Interpolation) {
 	// Explicitly test trilinear interpolation
 	double spacing = 2.793;
 	int n = 3;
-	VectorGridf grid(Vector3d(0.), n, n, n, spacing);
+	Grid3f grid(Vector3d(0.), n, n, n, spacing);
 	grid.get(0, 0, 1) = Vector3f(1.7, 0., 0.); // set one value
 
 	Vector3d b;
@@ -503,7 +503,7 @@ TEST(VectorGridf, Interpolation) {
 
 TEST(VectordGrid, Scale) {
 	// Test scaling a field
-	ref_ptr<VectorGridf> grid = new VectorGridf(Vector3d(0.), 3, 1);
+	ref_ptr<Grid3f> grid = new Grid3f(Vector3d(0.), 3, 1);
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
 			for (int iz = 0; iz < 3; iz++)
@@ -516,12 +516,12 @@ TEST(VectordGrid, Scale) {
 				EXPECT_FLOAT_EQ(5, grid->interpolate(Vector3d(0.7, 0, 0.1)).x);
 }
 
-TEST(VectorGridf, Periodicity) {
+TEST(Grid3f, Periodicity) {
 	// Test for periodic boundaries: grid(x+a*n) = grid(x)
 	size_t n = 3;
 	double spacing = 3;
 	double size = n * spacing;
-	VectorGridf grid(Vector3d(0.), n, spacing);
+	Grid3f grid(Vector3d(0.), n, spacing);
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
 			for (int iz = 0; iz < 3; iz++)
@@ -545,10 +545,10 @@ TEST(VectorGridf, Periodicity) {
 	EXPECT_FLOAT_EQ(b.z, b2.z);
 }
 
-TEST(VectorGridf, DumpLoad) {
+TEST(Grid3f, DumpLoad) {
 	// Dump and load a field grid
-	ref_ptr<VectorGridf> grid1 = new VectorGridf(Vector3d(0.), 3, 1);
-	ref_ptr<VectorGridf> grid2 = new VectorGridf(Vector3d(0.), 3, 1);
+	ref_ptr<Grid3f> grid1 = new Grid3f(Vector3d(0.), 3, 1);
+	ref_ptr<Grid3f> grid2 = new Grid3f(Vector3d(0.), 3, 1);
 
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
@@ -571,10 +571,10 @@ TEST(VectorGridf, DumpLoad) {
 	}
 }
 
-TEST(VectorGridf, DumpLoadTxt) {
+TEST(Grid3f, DumpLoadTxt) {
 	// Dump and load a field grid
-	ref_ptr<VectorGridf> grid1 = new VectorGridf(Vector3d(0.), 3, 1);
-	ref_ptr<VectorGridf> grid2 = new VectorGridf(Vector3d(0.), 3, 1);
+	ref_ptr<Grid3f> grid1 = new Grid3f(Vector3d(0.), 3, 1);
+	ref_ptr<Grid3f> grid2 = new Grid3f(Vector3d(0.), 3, 1);
 
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
@@ -597,9 +597,9 @@ TEST(VectorGridf, DumpLoadTxt) {
 	}
 }
 
-TEST(VectorGridf, Speed) {
+TEST(Grid3f, Speed) {
 	// Dump and load a field grid
-	VectorGridf grid(Vector3d(0.), 3, 3);
+	Grid3f grid(Vector3d(0.), 3, 3);
 	for (int ix = 0; ix < 3; ix++)
 		for (int iy = 0; iy < 3; iy++)
 			for (int iz = 0; iz < 3; iz++)

--- a/test/testMagneticField.cpp
+++ b/test/testMagneticField.cpp
@@ -78,7 +78,7 @@ TEST(testVectorFieldGrid, Turbulence_bmean_brms) {
 	double lMin = 2 * spacing;
 	double lMax = 8 * spacing;
 
-	ref_ptr<VectorGrid> grid = new VectorGrid(Vector3d(0, 0, 0), n, spacing);
+	ref_ptr<VectorGridf> grid = new VectorGridf(Vector3d(0, 0, 0), n, spacing);
 	initTurbulence(grid, Brms, lMin, lMax);
 
 	double precision = 1e-7;
@@ -99,10 +99,10 @@ TEST(testVectorFieldGrid, Turbulence_seed) {
 	double index = -11. / 3.;
 	int seed = 753;
 
-	ref_ptr<VectorGrid> grid1 = new VectorGrid(Vector3d(0, 0, 0), n, spacing);
+	ref_ptr<VectorGridf> grid1 = new VectorGridf(Vector3d(0, 0, 0), n, spacing);
 	initTurbulence(grid1, Brms, lMin, lMax, index, seed);
 
-	ref_ptr<VectorGrid> grid2 = new VectorGrid(Vector3d(0, 0, 0), n, spacing);
+	ref_ptr<VectorGridf> grid2 = new VectorGridf(Vector3d(0, 0, 0), n, spacing);
 	initTurbulence(grid2, Brms, lMin, lMax, index, seed);
 
 	Vector3d pos(22 * Mpc);
@@ -114,7 +114,7 @@ TEST(testVectorFieldGrid, turbulence_Exceptions) {
 	size_t n = 64;
 	double spacing = 10 * Mpc / n;
 	double brms = 1;
-	ref_ptr<VectorGrid> grid = new VectorGrid(Vector3d(0, 0, 0), n, spacing);
+	ref_ptr<VectorGridf> grid = new VectorGridf(Vector3d(0, 0, 0), n, spacing);
 
 	// should be fine
 	EXPECT_NO_THROW(initTurbulence(grid, brms, 2 * spacing, 8 * spacing));

--- a/test/testMagneticField.cpp
+++ b/test/testMagneticField.cpp
@@ -78,7 +78,7 @@ TEST(testVectorFieldGrid, Turbulence_bmean_brms) {
 	double lMin = 2 * spacing;
 	double lMax = 8 * spacing;
 
-	ref_ptr<VectorGridf> grid = new VectorGridf(Vector3d(0, 0, 0), n, spacing);
+	ref_ptr<Grid3f> grid = new Grid3f(Vector3d(0, 0, 0), n, spacing);
 	initTurbulence(grid, Brms, lMin, lMax);
 
 	double precision = 1e-7;
@@ -99,10 +99,10 @@ TEST(testVectorFieldGrid, Turbulence_seed) {
 	double index = -11. / 3.;
 	int seed = 753;
 
-	ref_ptr<VectorGridf> grid1 = new VectorGridf(Vector3d(0, 0, 0), n, spacing);
+	ref_ptr<Grid3f> grid1 = new Grid3f(Vector3d(0, 0, 0), n, spacing);
 	initTurbulence(grid1, Brms, lMin, lMax, index, seed);
 
-	ref_ptr<VectorGridf> grid2 = new VectorGridf(Vector3d(0, 0, 0), n, spacing);
+	ref_ptr<Grid3f> grid2 = new Grid3f(Vector3d(0, 0, 0), n, spacing);
 	initTurbulence(grid2, Brms, lMin, lMax, index, seed);
 
 	Vector3d pos(22 * Mpc);
@@ -114,7 +114,7 @@ TEST(testVectorFieldGrid, turbulence_Exceptions) {
 	size_t n = 64;
 	double spacing = 10 * Mpc / n;
 	double brms = 1;
-	ref_ptr<VectorGridf> grid = new VectorGridf(Vector3d(0, 0, 0), n, spacing);
+	ref_ptr<Grid3f> grid = new Grid3f(Vector3d(0, 0, 0), n, spacing);
 
 	// should be fine
 	EXPECT_NO_THROW(initTurbulence(grid, brms, 2 * spacing, 8 * spacing));


### PR DESCRIPTION
I want to introduce double-precision grids in CRPropa as an option. Corner cases do exist where single-precision is not enough (especially in simulations where coupling between magnetic fields and particles are "strong", i.e., in the diffusive regime) and that can affect physical results. Before, I did this as a special CMake option with which one can recompile the source and make all grids in double-precision. Now I think it is a wrong approach, on the top of the fact that it is ugly too (I let CMake to change source files, i.e., Grid.h, which makes the whole process of compiling more complex and harder to debug).

This PR removes the changes of the previous approach and introduces single- and double-precision grids that can be used in parallel. Moreover, no new options in CMake neither preprocessing source files by CMake are required. In later PR I'll present changes to GridTools and GridTurbulence which would operate on both types of grids.

The only doubt I have is in the naming: should we change VectorGrid (ScalarGrid) to VectorGridf (ScalarGridf) analogously to Vector3f and Vector3d, but what would, however, break users python scripts? Or should I just add VectorGridDouble next to VectorGrid (like in this PR)? This is inconsistent with the previous naming, yet, it doesn't break the interface, only extends it.