### PR TITLE
introduce proper photon field class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@
 * ParticleCollector can provide Candidates directly to ModuleList::run
 * Basic file versioning of the data archive in CMakeLists.txt
 * Python docstrings are generated automatically from doxygen documentation
+* Photon field classes replaced the photon field enumerator,
+  consequently, the new photon fields implementation follows the same logic as
+  of the other modules making it is easier to introduce custom ones
 
 ### Interface change:
 
 * ParticleCollector::getAll() -> ParticleCollector::getContainer()
+* Photon fields are no longer items of the PhotonField enumerator but independent
+  classes that shares the same interface, so instead of `CMB` one should use `CMB()`,
+  instead of `IRB_Kneiske04` - `IRB_Kneiske04()`, etc.
 
 ### Features that are deprecated and will be removed after this release:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,7 +313,7 @@ endif(APPLE)
 # Download data files (interaction data, masses, decay data ...)
 # ----------------------------------------------------------------------------
 OPTION(DOWNLOAD_DATA "Download CRProap Data files" ON)
-set(CRPROPA_DATAFILE_VER "2017-11-09")
+set(CRPROPA_DATAFILE_VER "2020-05-25")
 if(DOWNLOAD_DATA)
   message("-- Downloading data file from crpropa.desy.de ~ 50 MB")
   file(DOWNLOAD

--- a/doc/building_blocks.rst
+++ b/doc/building_blocks.rst
@@ -14,6 +14,6 @@ Building Blocks
   buildingblocks/Output.rst
   buildingblocks/MagneticLens.rst
   buildingblocks/Tools.rst
-
+  buildingblocks/PhotonFields.rst
 
 

--- a/doc/buildingblocks/PhotonFields.rst
+++ b/doc/buildingblocks/PhotonFields.rst
@@ -1,0 +1,3 @@
+Photon Fields
+================
+.. doxygengroup:: PhotonFields

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -1,6 +1,7 @@
 #ifndef CRPROPA_PHOTONBACKGROUND_H
 #define CRPROPA_PHOTONBACKGROUND_H
 
+#include "crpropa/Common.h"
 #include "crpropa/Referenced.h"
 
 #include <vector>
@@ -58,29 +59,106 @@ protected:
  @brief Photon field decorator for tabulated photon fields.
 
  This class reads photon field data from files;
- the data files to be read are inferred from the field name.
- The first file must be a list of photon energies [J], named photonEnergy_fieldName.txt
- The second file must be a list of comoving photon field densities [1/m^3], named photonDensity_fieldName.txt
- Optionally, a third file contains redshifts, named redshift_fieldName.txt
+ The first file must be a list of photon energies [J], named fieldName_photonEnergy.txt
+ The second file must be a list of comoving photon field densities [1/m^3], named fieldName_photonDensity.txt
+ Optionally, a third file contains redshifts, named fieldName_redshift.txt
  */
 class TabularPhotonField: public PhotonField {
 public:
-	TabularPhotonField(const std::string fieldName);
-	// TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent);
+	TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent = true);
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 	double getRedshiftScaling(double z) const;
 
-protected:
-	void initPhotonEnergy(std::string fieldName);
-	void initPhotonDensity(std::string fieldName);
-	void initRedshift(std::string fieldName);
+	void initPhotonEnergy(std::string filePath);
+	void initPhotonDensity(std::string filePath);
+	void initRedshift(std::string filePath);
 	void initRedshiftScaling();
-	void checkInputData() const;
 
+protected:
 	std::vector<double> photonEnergies;
 	std::vector<double> photonDensity;
 	std::vector<double> redshifts;
 	std::vector<double> redshiftScalings;
+};
+
+class IRB_Kneiske04: public TabularPhotonField {
+public:
+	IRB_Kneiske04() : TabularPhotonField("IRB_Kneiske04", true) {
+		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+		initRedshiftScaling();
+	}
+};
+
+class IRB_Stecker05: public TabularPhotonField {
+public:
+	IRB_Stecker05() : TabularPhotonField("IRB_Stecker05", true) {
+		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+		initRedshiftScaling();
+	}
+};
+
+class IRB_Franceschini08: public TabularPhotonField {
+public:
+	IRB_Franceschini08() : TabularPhotonField("IRB_Franceschini08", true) {
+		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+		initRedshiftScaling();
+	}
+};
+
+class IRB_Finke10: public TabularPhotonField {
+public:
+	IRB_Finke10() : TabularPhotonField("IRB_Finke10", true) {
+		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+		initRedshiftScaling();
+	}
+};
+
+class IRB_Dominguez11: public TabularPhotonField {
+public:
+	IRB_Dominguez11() : TabularPhotonField("IRB_Dominguez11", true) {
+		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+		initRedshiftScaling();
+	}
+};
+
+class IRB_Gilmore12: public TabularPhotonField {
+public:
+	IRB_Gilmore12() : TabularPhotonField("IRB_Gilmore12", true) {
+		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+		initRedshiftScaling();
+	}
+};
+
+class IRB_Stecker16_upper: public TabularPhotonField {
+public:
+	IRB_Stecker16_upper() : TabularPhotonField("IRB_Stecker16_upper", true) {
+		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+		initRedshiftScaling();
+	}
+};
+
+class IRB_Stecker16_lower: public TabularPhotonField {
+public:
+	IRB_Stecker16_lower() : TabularPhotonField("IRB_Stecker16_lower", true) {
+		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+		initRedshiftScaling();
+	}
 };
 
 /**

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -65,16 +65,17 @@ protected:
  */
 class TabularPhotonField: public PhotonField {
 public:
-	TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent = true);
+	TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent);
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 	double getRedshiftScaling(double z) const;
 
-	void initPhotonEnergy(std::string filePath);
-	void initPhotonDensity(std::string filePath);
-	void initRedshift(std::string filePath);
-	void initRedshiftScaling();
-
 protected:
+	void readPhotonEnergy(std::string filePath);
+	void readPhotonDensity(std::string filePath);
+	void readRedshift(std::string filePath);
+	void initRedshiftScaling();
+	void checkInputData() const;
+
 	std::vector<double> photonEnergies;
 	std::vector<double> photonDensity;
 	std::vector<double> redshifts;
@@ -91,12 +92,7 @@ protected:
  */
 class IRB_Kneiske04: public TabularPhotonField {
 public:
-	IRB_Kneiske04() : TabularPhotonField("IRB_Kneiske04", true) {
-		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
-		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
-		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
-		initRedshiftScaling();
-	}
+	IRB_Kneiske04() : TabularPhotonField("IRB_Kneiske04", true) {}
 };
 
 /**
@@ -109,12 +105,7 @@ public:
  */
 class IRB_Stecker05: public TabularPhotonField {
 public:
-	IRB_Stecker05() : TabularPhotonField("IRB_Stecker05", true) {
-		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
-		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
-		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
-		initRedshiftScaling();
-	}
+	IRB_Stecker05() : TabularPhotonField("IRB_Stecker05", true) {}
 };
 
 /**
@@ -127,12 +118,7 @@ public:
  */
 class IRB_Franceschini08: public TabularPhotonField {
 public:
-	IRB_Franceschini08() : TabularPhotonField("IRB_Franceschini08", true) {
-		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
-		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
-		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
-		initRedshiftScaling();
-	}
+	IRB_Franceschini08() : TabularPhotonField("IRB_Franceschini08", true) {}
 };
 
 /**
@@ -145,12 +131,7 @@ public:
  */
 class IRB_Finke10: public TabularPhotonField {
 public:
-	IRB_Finke10() : TabularPhotonField("IRB_Finke10", true) {
-		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
-		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
-		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
-		initRedshiftScaling();
-	}
+	IRB_Finke10() : TabularPhotonField("IRB_Finke10", true) {}
 };
 
 /**
@@ -163,12 +144,7 @@ public:
  */
 class IRB_Dominguez11: public TabularPhotonField {
 public:
-	IRB_Dominguez11() : TabularPhotonField("IRB_Dominguez11", true) {
-		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
-		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
-		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
-		initRedshiftScaling();
-	}
+	IRB_Dominguez11() : TabularPhotonField("IRB_Dominguez11", true) {}
 };
 
 /**
@@ -181,12 +157,7 @@ public:
  */
 class IRB_Gilmore12: public TabularPhotonField {
 public:
-	IRB_Gilmore12() : TabularPhotonField("IRB_Gilmore12", true) {
-		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
-		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
-		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
-		initRedshiftScaling();
-	}
+	IRB_Gilmore12() : TabularPhotonField("IRB_Gilmore12", true) {}
 };
 
 /**
@@ -199,12 +170,7 @@ public:
  */
 class IRB_Stecker16_upper: public TabularPhotonField {
 public:
-	IRB_Stecker16_upper() : TabularPhotonField("IRB_Stecker16_upper", true) {
-		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
-		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
-		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
-		initRedshiftScaling();
-	}
+	IRB_Stecker16_upper() : TabularPhotonField("IRB_Stecker16_upper", true) {}
 };
 
 /**
@@ -217,12 +183,7 @@ public:
  */
 class IRB_Stecker16_lower: public TabularPhotonField {
 public:
-	IRB_Stecker16_lower() : TabularPhotonField("IRB_Stecker16_lower", true) {
-		initPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
-		initPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
-		initRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
-		initRedshiftScaling();
-	}
+	IRB_Stecker16_lower() : TabularPhotonField("IRB_Stecker16_lower", true) {}
 };
 
 /**

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -24,7 +24,7 @@ public:
 
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 	double getRedshiftScaling(double z) const;  // returns overall comoving scaling factor (cf. CRPropa3-data/calc_scaling.py)
-	bool getHasRedshiftDependence() const;
+	bool hasRedshiftDependence() const;
 	std::string getFieldName() const;
 
 protected:
@@ -38,7 +38,7 @@ protected:
 	std::vector<double> photonDensity;
 	std::vector<double> redshifts;
 	std::vector<double> redshiftScalings;
-	bool hasRedshiftDependence;
+	bool isRedshiftDependent;
 	std::string fieldName;
 };
 

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -96,6 +96,30 @@ protected:
 };
 
 /**
+ @class PowerLawPhotonField
+ @brief Photon field decorator for power law photon fields.
+
+ This photon field is defined from eMin to eMax with a power law index < 0.
+ The norm factor should be equal to the maximal photon number density in [1/m^3] of this field, i.e. at eMin.
+ */
+class PowerLawPhotonField: public PhotonField {
+public:	
+	PowerLawPhotonField(
+		const std::string fieldName,
+		const double eMin,
+		const double eMax,
+		const double powerLawIndex,
+		const double normFactor);
+	double getPhotonDensity(double ePhoton, double z = 0.) const;
+
+protected:
+	double eMin;
+	double eMax;
+	double powerLawIndex;
+	double normFactor;
+};
+
+/**
  @class PhotonFieldSampling
  @brief Reimplementation of SOPHIA photon sampling. Naming and unit conventions are taken from SOPHIA to ease comparisions.
  */

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -11,28 +11,36 @@ namespace crpropa {
  * \addtogroup EnergyLosses
  * @{
  */
-// Photon fields
-// The default IRB model is that of Kneiske et al. 2004
-enum PhotonField {
-	CMB,
-	IRB,  // same as IRB_Kneiske04
-	IRB_Kneiske04,
-	IRB_Stecker05,
-	IRB_Franceschini08,
-	IRB_Finke10,
-	IRB_Dominguez11,
-	IRB_Gilmore12,
-	IRB_Stecker16_upper,
-	IRB_Stecker16_lower,
-	URB_Protheroe96
+
+
+/**
+ @class PhotonField
+ @brief photon field class fully defined with a range of photon energies, redshift and the field's density
+ */
+class PhotonField {
+public:
+	PhotonField(std::string fieldName, bool hasRedshiftDependence = true);
+	PhotonField() : PhotonField("CMB", false) {};
+
+	double getPhotonDensity(double ePhoton, double z = 0.) const;
+	double getRedshiftScaling(double z) const;  // returns overall comoving scaling factor (cf. CRPropa3-data/calc_scaling.py)
+	bool getHasRedshiftDependence() const;
+	std::string getFieldName() const;
+
+protected:
+	void initPhotonEnergy(std::string fieldName);
+	void initPhotonDensity(std::string fieldName);
+	void initRedshift(std::string fieldName);
+	void initRedshiftScaling();
+	void checkInputData() const;
+
+	std::vector<double> photonEnergies;
+	std::vector<double> photonDensity;
+	std::vector<double> redshifts;
+	std::vector<double> redshiftScalings;
+	bool hasRedshiftDependence;
+	std::string fieldName;
 };
-
-// Returns overall comoving scaling factor
-double photonFieldScaling(PhotonField photonField, double z);
-
-// Returns a string representation of the field
-std::string photonFieldName(PhotonField photonField);
-
 
 /**
  @class PhotonFieldSampling

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -88,7 +88,7 @@ protected:
 
  Source info:
  DOI:10.1051/0004-6361:20031542,
- https://www.aanda.org/articles/aa/pdf/2004/03/aa3848.pdf, figure 1 (”Best-fit” model)
+ https://www.aanda.org/articles/aa/pdf/2004/03/aa3848.pdf, figure 1 ("Best-fit" model)
  */
 class IRB_Kneiske04: public TabularPhotonField {
 public:

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -18,15 +18,29 @@ namespace crpropa {
  */
 class PhotonField: public Referenced {
 public:
+	/**
+	 returns comoving photon density [1/m^3].
+	 multiply with (1+z^3) for physical number density.
+	 @param ePhoton		photon energy [J]
+	 @param z			redshift
+	 */
 	virtual double getPhotonDensity(double ePhoton, double z = 0.) const {
 		return 0.;
 	};
-	virtual double getRedshiftScaling(double z) const {  // returns overall comoving scaling factor (cf. CRPropa3-data/calc_scaling.py)
+
+	/**
+	 returns overall comoving scaling factor
+	 (cf. CRPropa3-data/calc_scaling.py)
+	 @param z		redshift
+	 */
+	virtual double getRedshiftScaling(double z) const {
 		return 1.;
 	};
+
 	bool hasRedshiftDependence() const {
 		return this->isRedshiftDependent;
 	}
+
 	std::string getFieldName() const {
 		return this->fieldName;
 	}

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -65,7 +65,8 @@ protected:
  */
 class TabularPhotonField: public PhotonField {
 public:
-	TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent = true);
+	TabularPhotonField(const std::string fieldName);
+	// TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent);
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 	double getRedshiftScaling(double z) const;
 
@@ -93,6 +94,11 @@ public:
 
 protected:
 	double blackbodyTemperature;
+};
+
+class CMB: public BlackbodyPhotonField {
+public:
+	CMB() : BlackbodyPhotonField("CMB", 2.73) {}
 };
 
 /**

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -211,29 +211,6 @@ public:
 	CMB() : BlackbodyPhotonField("CMB", 2.73) {}
 };
 
-/**
- @class PowerLawPhotonField
- @brief Photon field decorator for power law photon fields.
-
- This photon field is defined from eMin to eMax with a power law index < 0.
- The norm factor should be equal to the maximal photon number density in [1/m^3] of this field, i.e. at eMin.
- */
-class PowerLawPhotonField: public PhotonField {
-public:	
-	PowerLawPhotonField(
-		const std::string fieldName,
-		const double eMin,
-		const double eMax,
-		const double powerLawIndex,
-		const double normFactor);
-	double getPhotonDensity(double ePhoton, double z = 0.) const;
-
-protected:
-	double eMin;
-	double eMax;
-	double powerLawIndex;
-	double normFactor;
-};
 
 /**
  @class PhotonFieldSampling

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -65,7 +65,7 @@ protected:
  */
 class TabularPhotonField: public PhotonField {
 public:
-	TabularPhotonField(std::string fieldName, bool isRedshiftDependent = true);
+	TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent = true);
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 	double getRedshiftScaling(double z) const;
 
@@ -88,7 +88,7 @@ protected:
  */
 class BlackbodyPhotonField: public PhotonField {
 public:
-	BlackbodyPhotonField(std::string fieldName, double blackbodyTemperature);
+	BlackbodyPhotonField(const std::string fieldName, const double blackbodyTemperature);
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 
 protected:

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -2,22 +2,21 @@
 #define CRPROPA_PHOTONBACKGROUND_H
 
 #include "crpropa/Common.h"
+#include "crpropa/Referenced.h"
 
 #include <string>
 
 namespace crpropa {
-
 /**
  * \addtogroup PhotonFields
  * @{
  */
 
-
 /**
  @class PhotonField
- @brief photon field class fully defined with a range of photon energies, redshift and the field's density
+ @brief Abstract base class for photon fields.
  */
-class PhotonField {
+class PhotonField: public Referenced {
 public:
 	PhotonField(std::string fieldName, bool hasRedshiftDependence = true);
 	PhotonField() : PhotonField("CMB", false) {};

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -1,9 +1,9 @@
 #ifndef CRPROPA_PHOTONBACKGROUND_H
 #define CRPROPA_PHOTONBACKGROUND_H
 
-#include "crpropa/Common.h"
 #include "crpropa/Referenced.h"
 
+#include <vector>
 #include <string>
 
 namespace crpropa {

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -81,6 +81,14 @@ protected:
 	std::vector<double> redshiftScalings;
 };
 
+/**
+ @class IRB_Kneiske04
+ @brief Extragalactic background light model from Kneiske et al. 2004
+
+ Source info:
+ DOI:10.1051/0004-6361:20031542,
+ https://www.aanda.org/articles/aa/pdf/2004/03/aa3848.pdf, figure 1 (”Best-fit” model)
+ */
 class IRB_Kneiske04: public TabularPhotonField {
 public:
 	IRB_Kneiske04() : TabularPhotonField("IRB_Kneiske04", true) {
@@ -91,6 +99,14 @@ public:
 	}
 };
 
+/**
+ @class IRB_Stecker05
+ @brief Extragalactic background light model by Stecker at al. 2005
+
+ Source info:
+ DOI:10.1086/506188, astro-ph/0510449
+ https://iopscience.iop.org/article/10.1086/506188/pdf
+ */
 class IRB_Stecker05: public TabularPhotonField {
 public:
 	IRB_Stecker05() : TabularPhotonField("IRB_Stecker05", true) {
@@ -101,6 +117,14 @@ public:
 	}
 };
 
+/**
+ @class IRB_Franceschini08
+ @brief Extragalactic background light model from Franceschini et al. 2008
+
+ Source info:
+ DOI:10.1051/0004-6361:200809691
+ https://arxiv.org/pdf/0805.1841.pdf, tables 1 and 2
+ */
 class IRB_Franceschini08: public TabularPhotonField {
 public:
 	IRB_Franceschini08() : TabularPhotonField("IRB_Franceschini08", true) {
@@ -111,6 +135,14 @@ public:
 	}
 };
 
+/**
+ @class IRB_Finke10
+ @brief Extragalactic background light model from Finke et al. 2010
+
+ Source info:
+ DOI:10.1088/0004-637X/712/1/238
+ https://iopscience.iop.org/article/10.1088/0004-637X/712/1/238/pdf
+ */
 class IRB_Finke10: public TabularPhotonField {
 public:
 	IRB_Finke10() : TabularPhotonField("IRB_Finke10", true) {
@@ -121,6 +153,14 @@ public:
 	}
 };
 
+/**
+ @class IRB_Dominguez11
+ @brief Extragalactic background light model from Dominguez et al. 2011
+
+ Source info:
+ DOI:10.1111/j.1365-2966.2010.17631.x
+ https://academic.oup.com/mnras/article/410/4/2556/1008012
+ */
 class IRB_Dominguez11: public TabularPhotonField {
 public:
 	IRB_Dominguez11() : TabularPhotonField("IRB_Dominguez11", true) {
@@ -131,6 +171,14 @@ public:
 	}
 };
 
+/**
+ @class IRB_Gilmore12
+ @brief Extragalactic background light model from Gilmore et al. 2012
+
+ Source info:
+ DOI:10.1111/j.1365-2966.2012.20841.x
+ https://academic.oup.com/mnras/article/422/4/3189/1050758
+ */
 class IRB_Gilmore12: public TabularPhotonField {
 public:
 	IRB_Gilmore12() : TabularPhotonField("IRB_Gilmore12", true) {
@@ -141,6 +189,14 @@ public:
 	}
 };
 
+/**
+ @class IRB_Stecker16_upper
+ @brief Extragalactic background light model from Stecker et al. 2016 (upper-bound model)
+
+ Source info:
+ DOI:10.3847/0004-637X/827/1/6
+ https://iopscience.iop.org/article/10.3847/0004-637X/827/1/6
+ */
 class IRB_Stecker16_upper: public TabularPhotonField {
 public:
 	IRB_Stecker16_upper() : TabularPhotonField("IRB_Stecker16_upper", true) {
@@ -151,6 +207,14 @@ public:
 	}
 };
 
+/**
+ @class IRB_Stecker16_lower
+ @brief Extragalactic background light model from Stecker et al. 2016 (lower-bound model)
+
+ Source info:
+ DOI:10.3847/0004-637X/827/1/6
+ https://iopscience.iop.org/article/10.3847/0004-637X/827/1/6
+ */
 class IRB_Stecker16_lower: public TabularPhotonField {
 public:
 	IRB_Stecker16_lower() : TabularPhotonField("IRB_Stecker16_lower", true) {
@@ -174,6 +238,13 @@ protected:
 	double blackbodyTemperature;
 };
 
+/**
+ @class CMB
+ @brief Cosmic mircowave background photon field
+
+ Source info:
+ This field is an isotropic blackbody photon field with temperature T = 2.73 K
+ */
 class CMB: public BlackbodyPhotonField {
 public:
 	CMB() : BlackbodyPhotonField("CMB", 2.73) {}

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -65,7 +65,7 @@ protected:
  */
 class TabularPhotonField: public PhotonField {
 public:
-	TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent);
+	TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent = true);
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 	double getRedshiftScaling(double z) const;
 

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -18,13 +18,34 @@ namespace crpropa {
  */
 class PhotonField: public Referenced {
 public:
-	PhotonField(std::string fieldName, bool hasRedshiftDependence = true);
-	PhotonField() : PhotonField("CMB", false) {};
+	virtual double getPhotonDensity(double ePhoton, double z = 0.) const {
+		return 0.;
+	};
+	virtual double getRedshiftScaling(double z) const {  // returns overall comoving scaling factor (cf. CRPropa3-data/calc_scaling.py)
+		return 1.;
+	};
+	bool hasRedshiftDependence() const {
+		return this->isRedshiftDependent;
+	}
+	std::string getFieldName() const {
+		return this->fieldName;
+	}
 
+protected:
+	std::string fieldName = "AbstractPhotonField";
+	bool isRedshiftDependent = false;
+};
+
+/**
+ @class TabularPhotonField
+ @brief Photon field decorator for tabulated photon fields.
+ */
+class TabularPhotonField: public PhotonField {
+public:
+	TabularPhotonField(std::string fieldName, bool hasRedshiftDependence = true);
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
-	double getRedshiftScaling(double z) const;  // returns overall comoving scaling factor (cf. CRPropa3-data/calc_scaling.py)
+	double getRedshiftScaling(double z) const;
 	bool hasRedshiftDependence() const;
-	std::string getFieldName() const;
 
 protected:
 	void initPhotonEnergy(std::string fieldName);
@@ -37,8 +58,19 @@ protected:
 	std::vector<double> photonDensity;
 	std::vector<double> redshifts;
 	std::vector<double> redshiftScalings;
-	bool isRedshiftDependent;
-	std::string fieldName;
+};
+
+/**
+ @class BlackbodyPhotonField
+ @brief Photon field decorator for black body photon fields.
+ */
+class BlackbodyPhotonField: public PhotonField {
+public:
+	BlackbodyPhotonField(std::string fieldName, double blackbodyTemperature);
+	double getPhotonDensity(double ePhoton) const;
+
+protected:
+	double blackbodyTemperature;
 };
 
 /**

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -58,6 +58,12 @@ protected:
 /**
  @class TabularPhotonField
  @brief Photon field decorator for tabulated photon fields.
+
+ This class reads photon field data from files;
+ the data files to be read are inferred from the field name.
+ The first file must be a list of photon energies [J], named photonEnergy_fieldName.txt
+ The second file must be a list of comoving photon field densities [1/m^3], named photonDensity_fieldName.txt
+ Optionally, a third file contains redshifts, named redshift_fieldName.txt
  */
 class TabularPhotonField: public PhotonField {
 public:

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -8,7 +8,7 @@
 namespace crpropa {
 
 /**
- * \addtogroup EnergyLosses
+ * \addtogroup PhotonFields
  * @{
  */
 

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -27,11 +27,9 @@ public:
 	 returns comoving photon density [1/m^3].
 	 multiply with (1+z^3) for physical number density.
 	 @param ePhoton		photon energy [J]
-	 @param z			redshift
+	 @param z			redshift (if redshift dependent, default = 0.)
 	 */
-	virtual double getPhotonDensity(double ePhoton, double z = 0.) const {
-		return 0.;
-	};
+	virtual double getPhotonDensity(double ePhoton, double z = 0.) const = 0;
 
 	/**
 	 returns overall comoving scaling factor
@@ -91,7 +89,7 @@ protected:
 class BlackbodyPhotonField: public PhotonField {
 public:
 	BlackbodyPhotonField(std::string fieldName, double blackbodyTemperature);
-	double getPhotonDensity(double ePhoton) const;
+	double getPhotonDensity(double ePhoton, double z = 0.) const;
 
 protected:
 	double blackbodyTemperature;

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -61,10 +61,9 @@ protected:
  */
 class TabularPhotonField: public PhotonField {
 public:
-	TabularPhotonField(std::string fieldName, bool hasRedshiftDependence = true);
+	TabularPhotonField(std::string fieldName, bool isRedshiftDependent = true);
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 	double getRedshiftScaling(double z) const;
-	bool hasRedshiftDependence() const;
 
 protected:
 	void initPhotonEnergy(std::string fieldName);

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -18,6 +18,11 @@ namespace crpropa {
  */
 class PhotonField: public Referenced {
 public:
+	PhotonField() {
+		this->fieldName = "AbstractPhotonField";
+		this->isRedshiftDependent = false;
+	}
+
 	/**
 	 returns comoving photon density [1/m^3].
 	 multiply with (1+z^3) for physical number density.
@@ -46,8 +51,8 @@ public:
 	}
 
 protected:
-	std::string fieldName = "AbstractPhotonField";
-	bool isRedshiftDependent = false;
+	std::string fieldName;
+	bool isRedshiftDependent;
 };
 
 /**

--- a/include/crpropa/module/EMDoublePairProduction.h
+++ b/include/crpropa/module/EMDoublePairProduction.h
@@ -17,7 +17,7 @@ namespace crpropa {
  */
 class EMDoublePairProduction: public Module {
 private:
-	PhotonField photonField;
+	ref_ptr<PhotonField> photonField;
 	bool haveElectrons;
 	double limit;
 
@@ -27,12 +27,12 @@ private:
 
 public:
 	EMDoublePairProduction(
-		PhotonField photonField, 	   //!< target photon background
+		ref_ptr<PhotonField> photonField, 	   //!< target photon background
 		bool haveElectrons = false,    //!< switch to create the secondary electron pair
 		double limit = 0.1             //!< step size limit as fraction of mean free path
 		);
 
-	void setPhotonField(PhotonField photonField);
+	void setPhotonField(ref_ptr<PhotonField> photonField);
 	void setHaveElectrons(bool haveElectrons);
 	void setLimit(double limit);
 

--- a/include/crpropa/module/EMDoublePairProduction.h
+++ b/include/crpropa/module/EMDoublePairProduction.h
@@ -27,7 +27,7 @@ private:
 
 public:
 	EMDoublePairProduction(
-		PhotonField photonField = CMB, //!< target photon background
+		PhotonField photonField, 	   //!< target photon background
 		bool haveElectrons = false,    //!< switch to create the secondary electron pair
 		double limit = 0.1             //!< step size limit as fraction of mean free path
 		);

--- a/include/crpropa/module/EMInverseComptonScattering.h
+++ b/include/crpropa/module/EMInverseComptonScattering.h
@@ -32,7 +32,7 @@ private:
 
 public:
 	EMInverseComptonScattering(
-		PhotonField photonField = CMB, //!< target photon background
+		PhotonField photonField, //!< target photon background
 		bool havePhotons = false,      //!< switch to create secondary photon
 		double limit = 0.1             //!< step size limit as fraction of mean free path
 		);

--- a/include/crpropa/module/EMInverseComptonScattering.h
+++ b/include/crpropa/module/EMInverseComptonScattering.h
@@ -17,7 +17,7 @@ namespace crpropa {
 */
 class EMInverseComptonScattering: public Module {
 private:
-	PhotonField photonField;
+	ref_ptr<PhotonField> photonField;
 	bool havePhotons;
 	double limit;
 
@@ -32,12 +32,12 @@ private:
 
 public:
 	EMInverseComptonScattering(
-		PhotonField photonField, //!< target photon background
+		ref_ptr<PhotonField> photonField, //!< target photon background
 		bool havePhotons = false,      //!< switch to create secondary photon
 		double limit = 0.1             //!< step size limit as fraction of mean free path
 		);
 
-	void setPhotonField(PhotonField photonField);
+	void setPhotonField(ref_ptr<PhotonField> photonField);
 	void setHavePhotons(bool havePhotons);
 	void setLimit(double limit);
 

--- a/include/crpropa/module/EMPairProduction.h
+++ b/include/crpropa/module/EMPairProduction.h
@@ -18,7 +18,7 @@ namespace crpropa {
  */
 class EMPairProduction: public Module {
 private:
-	PhotonField photonField;
+	ref_ptr<PhotonField> photonField;
 	bool haveElectrons;
 	double limit;
 
@@ -33,12 +33,12 @@ private:
 
 public:
 	EMPairProduction(
-		PhotonField photonField, //!< target photon background
+		ref_ptr<PhotonField> photonField, //!< target photon background
 		bool haveElectrons = false,    //!< switch to create secondary electron pair
 		double limit = 0.1             //!< step size limit as fraction of mean free path
 		);
 
-	void setPhotonField(PhotonField photonField);
+	void setPhotonField(ref_ptr<PhotonField> photonField);
 	void setHaveElectrons(bool haveElectrons);
 	void setLimit(double limit);
 

--- a/include/crpropa/module/EMPairProduction.h
+++ b/include/crpropa/module/EMPairProduction.h
@@ -33,7 +33,7 @@ private:
 
 public:
 	EMPairProduction(
-		PhotonField photonField = CMB, //!< target photon background
+		PhotonField photonField, //!< target photon background
 		bool haveElectrons = false,    //!< switch to create secondary electron pair
 		double limit = 0.1             //!< step size limit as fraction of mean free path
 		);

--- a/include/crpropa/module/EMTripletPairProduction.h
+++ b/include/crpropa/module/EMTripletPairProduction.h
@@ -36,7 +36,7 @@ private:
 
 public:
 	EMTripletPairProduction(
-		PhotonField photonField = CMB, //!< target photon background
+		PhotonField photonField, //!< target photon background
 		bool haveElectrons = false,    //!< switch to create secondary electron pair
 		double limit = 0.1             //!< step size limit as fraction of mean free path
 		);

--- a/include/crpropa/module/EMTripletPairProduction.h
+++ b/include/crpropa/module/EMTripletPairProduction.h
@@ -21,7 +21,7 @@ namespace crpropa {
 */
 class EMTripletPairProduction: public Module {
 private:
-	PhotonField photonField;
+	ref_ptr<PhotonField> photonField;
 	bool haveElectrons;
 	double limit;
 
@@ -36,12 +36,12 @@ private:
 
 public:
 	EMTripletPairProduction(
-		PhotonField photonField, //!< target photon background
+		ref_ptr<PhotonField> photonField, //!< target photon background
 		bool haveElectrons = false,    //!< switch to create secondary electron pair
 		double limit = 0.1             //!< step size limit as fraction of mean free path
 		);
 
-	void setPhotonField(PhotonField photonField);
+	void setPhotonField(ref_ptr<PhotonField> photonField);
 	void setHaveElectrons(bool haveElectrons);
 	void setLimit(double limit);
 

--- a/include/crpropa/module/ElasticScattering.h
+++ b/include/crpropa/module/ElasticScattering.h
@@ -14,7 +14,7 @@ namespace crpropa {
  */
 class ElasticScattering: public Module {
 private:
-    PhotonField photonField;
+    ref_ptr<PhotonField> photonField;
 
     std::vector<double> tabRate; // elastic scattering rate
     std::vector<std::vector<double> > tabCDF; // CDF as function of background photon energy
@@ -27,10 +27,10 @@ private:
     static const size_t neps;   // number of eps steps
 
 public:
-    ElasticScattering(PhotonField photonField);
+    ElasticScattering(ref_ptr<PhotonField> photonField);
     void initRate(std::string filename);
     void initCDF(std::string filename);
-    void setPhotonField(PhotonField photonField);
+    void setPhotonField(ref_ptr<PhotonField> photonField);
     void process(Candidate *candidate) const;
 };
 

--- a/include/crpropa/module/ElasticScattering.h
+++ b/include/crpropa/module/ElasticScattering.h
@@ -27,7 +27,7 @@ private:
     static const size_t neps;   // number of eps steps
 
 public:
-    ElasticScattering(PhotonField photonField = CMB);
+    ElasticScattering(PhotonField photonField);
     void initRate(std::string filename);
     void initCDF(std::string filename);
     void setPhotonField(PhotonField photonField);

--- a/include/crpropa/module/ElectronPairProduction.h
+++ b/include/crpropa/module/ElectronPairProduction.h
@@ -30,7 +30,7 @@ private:
 	bool haveElectrons;
 
 public:
-	ElectronPairProduction(PhotonField photonField = CMB, bool haveElectrons =
+	ElectronPairProduction(PhotonField photonField, bool haveElectrons =
 			false, double limit = 0.1);
 
 	void setPhotonField(PhotonField photonField);

--- a/include/crpropa/module/ElectronPairProduction.h
+++ b/include/crpropa/module/ElectronPairProduction.h
@@ -22,7 +22,7 @@ namespace crpropa {
  */
 class ElectronPairProduction: public Module {
 private:
-	PhotonField photonField;
+	ref_ptr<PhotonField> photonField;
 	std::vector<double> tabLossRate; /*< tabulated energy loss rate in [J/m] for protons at z = 0 */
 	std::vector<double> tabLorentzFactor; /*< tabulated Lorentz factor */
 	std::vector<std::vector<double> > tabSpectrum; /*< electron/positron cdf(Ee|log10(gamma)) for log10(Ee/eV)=7-24 in 170 steps and log10(gamma)=6-13 in 70 steps and*/
@@ -30,10 +30,10 @@ private:
 	bool haveElectrons;
 
 public:
-	ElectronPairProduction(PhotonField photonField, bool haveElectrons =
+	ElectronPairProduction(ref_ptr<PhotonField> photonField, bool haveElectrons =
 			false, double limit = 0.1);
 
-	void setPhotonField(PhotonField photonField);
+	void setPhotonField(ref_ptr<PhotonField> photonField);
 	void setHaveElectrons(bool haveElectrons);
 	void setLimit(double limit);
 

--- a/include/crpropa/module/PhotoDisintegration.h
+++ b/include/crpropa/module/PhotoDisintegration.h
@@ -42,7 +42,7 @@ private:
 	static const size_t nlg; // number of Lorentz-factor steps
 
 public:
-	PhotoDisintegration(PhotonField photonField = CMB, bool havePhotons = false, double limit = 0.1);
+	PhotoDisintegration(PhotonField photonField, bool havePhotons = false, double limit = 0.1);
 
 	void setPhotonField(PhotonField photonField);
 	void setHavePhotons(bool havePhotons);

--- a/include/crpropa/module/PhotoDisintegration.h
+++ b/include/crpropa/module/PhotoDisintegration.h
@@ -19,7 +19,7 @@ namespace crpropa {
  */
 class PhotoDisintegration: public Module {
 private:
-	PhotonField photonField;
+	ref_ptr<PhotonField> photonField;
 	double limit; // fraction of mean free path for limiting the next step
 	bool havePhotons;
 
@@ -42,9 +42,9 @@ private:
 	static const size_t nlg; // number of Lorentz-factor steps
 
 public:
-	PhotoDisintegration(PhotonField photonField, bool havePhotons = false, double limit = 0.1);
+	PhotoDisintegration(ref_ptr<PhotonField> photonField, bool havePhotons = false, double limit = 0.1);
 
-	void setPhotonField(PhotonField photonField);
+	void setPhotonField(ref_ptr<PhotonField> photonField);
 	void setHavePhotons(bool havePhotons);
 	void setLimit(double limit);
 

--- a/include/crpropa/module/PhotoPionProduction.h
+++ b/include/crpropa/module/PhotoPionProduction.h
@@ -39,7 +39,7 @@ protected:
 
 public:
 	PhotoPionProduction(
-		PhotonField photonField = CMB,
+		PhotonField photonField,
 		bool photons = false,
 		bool neutrinos = false,
 		bool electrons = false,

--- a/include/crpropa/module/PhotoPionProduction.h
+++ b/include/crpropa/module/PhotoPionProduction.h
@@ -24,7 +24,7 @@ struct SophiaEventOutput {
  */
 class PhotoPionProduction: public Module {
 protected:
-	PhotonField photonField;
+	ref_ptr<PhotonField> photonField;
 	PhotonFieldSampling photonFieldSampling;
 	std::vector<double> tabLorentz; ///< Lorentz factor of nucleus
 	std::vector<double> tabRedshifts;  ///< redshifts (optional for haveRedshiftDependence)
@@ -39,14 +39,14 @@ protected:
 
 public:
 	PhotoPionProduction(
-		PhotonField photonField,
+		ref_ptr<PhotonField> photonField,
 		bool photons = false,
 		bool neutrinos = false,
 		bool electrons = false,
 		bool antiNucleons = false,
 		double limit = 0.1,
 		bool haveRedshiftDependence = false);
-	void setPhotonField(PhotonField photonField);
+	void setPhotonField(ref_ptr<PhotonField> photonField);
 	void setHavePhotons(bool b);
 	void setHaveNeutrinos(bool b);
 	void setHaveElectrons(bool b);

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -47,6 +47,7 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %ignore operator crpropa::Observer*;
 %ignore operator crpropa::ObserverFeature*;
 %ignore operator crpropa::MagneticField*;
+%ignore operator crpropa::PhotonField*;
 %ignore operator crpropa::AdvectionField*;
 %ignore operator crpropa::ParticleCollector*;
 %ignore operator crpropa::Density*;
@@ -361,6 +362,9 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %implicitconv crpropa::ref_ptr<crpropa::MagneticField>;
 %template(MagneticFieldRefPtr) crpropa::ref_ptr<crpropa::MagneticField>;
 %include "crpropa/magneticField/MagneticField.h"
+
+%implicitconv crpropa::ref_ptr<crpropa::PhotonField>;
+%template(PhotonFieldRefPtr) crpropa::ref_ptr<crpropa::PhotonField>;
 
 %implicitconv crpropa::ref_ptr<crpropa::AdvectionField>;
 %template(AdvectionFieldRefPtr) crpropa::ref_ptr<crpropa::AdvectionField>;

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -164,7 +164,7 @@ BlackbodyPhotonField::BlackbodyPhotonField(std::string fieldName, double blackbo
 }
 
 double BlackbodyPhotonField::getPhotonDensity(double ePhoton) const {
-	return 8 * M_PI * std::pow(ePhoton / (h_planck * c_light), 3) / (std::exp(ePhoton / (k_boltzmann * this->blackbodyTemperature)) - 1);
+	return 8 * M_PI * pow_integer<3>(ePhoton / (h_planck * c_light)) / std::expm1(ePhoton / (k_boltzmann * this->blackbodyTemperature));
 }
 
 PhotonFieldSampling::PhotonFieldSampling() {

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -104,7 +104,7 @@ void TabularPhotonField::initRedshiftScaling() {
 		for (int j = 0; j < this->photonEnergies.size(); ++j) {
 			double e = this->photonEnergies[j];
 			if (z == 0.)
-				n0 += getPhotonDensity(e, 0.);
+				n0 = getPhotonDensity(e, z);
 			n += getPhotonDensity(e, z);
 		}
 		this->redshiftScalings.push_back(n / n0);

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -166,6 +166,22 @@ double BlackbodyPhotonField::getPhotonDensity(double ePhoton, double z) const {
 	return 8 * M_PI * pow_integer<3>(ePhoton / (h_planck * c_light)) / std::expm1(ePhoton / (k_boltzmann * this->blackbodyTemperature));
 }
 
+PowerLawPhotonField::PowerLawPhotonField(std::string fieldName, double eMin, double eMax, double powerLawIndex, double normFactor) {
+	this->fieldName = fieldName;
+	this->eMin = eMin;
+	this->eMax = eMax;
+	this->powerLawIndex = powerLawIndex;
+	this->normFactor = normFactor;
+}
+
+PowerLawPhotonField::getPhotonDensity(double ePhoton, double z) const {
+	if (ePhoton < this->eMin || ePhoton > this->eMax) {
+		return 0.;
+	} else {
+		return this->normFactor * std::pow(ePhoton / this->eMin, this->powerLawIndex);
+	}
+}
+
 PhotonFieldSampling::PhotonFieldSampling() {
 	bgFlag = 0;
 }

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -53,7 +53,7 @@ void TabularPhotonField::initPhotonEnergy(std::string fieldName) {
 	std::ifstream infile(path.c_str());
 
 	if (!infile.good())
-		throw std::runtime_error("TabularPhotonField::initPhotonEnergy: could not open file photonEnergy_" + fieldName);
+		throw std::runtime_error("TabularPhotonField::initPhotonEnergy: could not open " + path);
 
 	std::string line;
 	while (std::getline(infile, line)) {
@@ -69,7 +69,7 @@ void TabularPhotonField::initPhotonDensity(std::string fieldName) {
 	std::ifstream infile(path.c_str());
 
 	if (!infile.good())
-		throw std::runtime_error("TabularPhotonField::initPhotonDensity: could not open file photonDensity_" + fieldName);
+		throw std::runtime_error("TabularPhotonField::initPhotonDensity: could not open " + path);
 
 	std::string line;
 	while (std::getline(infile, line)) {
@@ -85,7 +85,7 @@ void TabularPhotonField::initRedshift(std::string fieldName) {
 	std::ifstream infile(path.c_str());
 
 	if (!infile.good())
-		throw std::runtime_error("TabularPhotonField::initRedshift: could not open file redshift_" + fieldName);
+		throw std::runtime_error("TabularPhotonField::initRedshift: could not open " + path);
 
 	std::string line;
 	while (std::getline(infile, line)) {

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -3,7 +3,6 @@
 #include "crpropa/Units.h"
 #include "crpropa/Random.h"
 
-#include <vector>
 #include <fstream>
 #include <stdexcept>
 #include <limits>

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -1,5 +1,4 @@
 #include "crpropa/PhotonBackground.h"
-#include "crpropa/Common.h"
 #include "crpropa/Units.h"
 #include "crpropa/Random.h"
 
@@ -13,18 +12,23 @@ namespace crpropa {
 TabularPhotonField::TabularPhotonField(std::string fieldName, bool isRedshiftDependent) {
 	this->fieldName = fieldName;
 	this->isRedshiftDependent = isRedshiftDependent;
-
-	initPhotonEnergy(this->fieldName);
-	initPhotonDensity(this->fieldName);
-	if (this->isRedshiftDependent) {
-		initRedshift(this->fieldName);
-	}
-
-	checkInputData();
-
-	if (this->isRedshiftDependent)
-		initRedshiftScaling();
 }
+
+// TabularPhotonField::TabularPhotonField(std::string fieldName, bool isRedshiftDependent) {
+// 	this->fieldName = fieldName;
+// 	this->isRedshiftDependent = isRedshiftDependent;
+
+// 	initPhotonEnergy(this->fieldName);
+// 	initPhotonDensity(this->fieldName);
+// 	if (this->isRedshiftDependent) {
+// 		initRedshift(this->fieldName);
+// 	}
+
+// 	checkInputData();
+
+// 	if (this->isRedshiftDependent)
+// 		initRedshiftScaling();
+// }
 
 double TabularPhotonField::getRedshiftScaling(double z) const {
 	if (this->isRedshiftDependent) {
@@ -48,51 +52,42 @@ double TabularPhotonField::getPhotonDensity(double ePhoton, double z) const {
 	}
 }
 
-void TabularPhotonField::initPhotonEnergy(std::string fieldName) {
-	std::string path = getDataPath("Scaling/photonEnergy_" + fieldName + ".txt");
-	std::ifstream infile(path.c_str());
-
+void TabularPhotonField::initPhotonEnergy(std::string filePath) {
+	std::ifstream infile(filePath.c_str());
 	if (!infile.good())
-		throw std::runtime_error("TabularPhotonField::initPhotonEnergy: could not open " + path);
+		throw std::runtime_error("TabularPhotonField::initPhotonEnergy: could not open " + filePath);
 
 	std::string line;
 	while (std::getline(infile, line)) {
 		if (line.size() > 0)
 			this->photonEnergies.push_back(std::stod(line));
 	}
-
 	infile.close();
 }
 
-void TabularPhotonField::initPhotonDensity(std::string fieldName) {
-	std::string path = getDataPath("Scaling/photonDensity_" + fieldName + ".txt");
-	std::ifstream infile(path.c_str());
-
+void TabularPhotonField::initPhotonDensity(std::string filePath) {
+	std::ifstream infile(filePath.c_str());
 	if (!infile.good())
-		throw std::runtime_error("TabularPhotonField::initPhotonDensity: could not open " + path);
+		throw std::runtime_error("TabularPhotonField::initPhotonDensity: could not open " + filePath);
 
 	std::string line;
 	while (std::getline(infile, line)) {
 		if (line.size() > 0)
 			this->photonDensity.push_back(std::stod(line));
 	}
-
 	infile.close();
 }
 
-void TabularPhotonField::initRedshift(std::string fieldName) {
-	std::string path = getDataPath("Scaling/redshift_" + fieldName + ".txt");
-	std::ifstream infile(path.c_str());
-
+void TabularPhotonField::initRedshift(std::string filePath) {
+	std::ifstream infile(filePath.c_str());
 	if (!infile.good())
-		throw std::runtime_error("TabularPhotonField::initRedshift: could not open " + path);
+		throw std::runtime_error("TabularPhotonField::initRedshift: could not open " + filePath);
 
 	std::string line;
 	while (std::getline(infile, line)) {
 		if (line.size() > 0)
 			this->redshifts.push_back(std::stod(line));
 	}
-
 	infile.close();
 }
 
@@ -104,58 +99,58 @@ void TabularPhotonField::initRedshiftScaling() {
 		for (int j = 0; j < this->photonEnergies.size(); ++j) {
 			double e = this->photonEnergies[j];
 			if (z == 0.)
-				n0 = getPhotonDensity(e, z);
+				n0 += getPhotonDensity(e, z);
 			n += getPhotonDensity(e, z);
 		}
 		this->redshiftScalings.push_back(n / n0);
 	}
 }
 
-void TabularPhotonField::checkInputData() const {
-	if (this->isRedshiftDependent) {
-		if (this->photonDensity.size() != this->photonEnergies.size() * this-> redshifts.size())
-			throw std::runtime_error("TabularPhotonField::checkInputData: length of photon density input is unequal to length of photon energy input times length of redshift input");
-	} else {
-		if (this->photonEnergies.size() != this->photonDensity.size())
-			throw std::runtime_error("TabularPhotonField::checkInputData: length of photon energy input is unequal to length of photon density input");
-	}
+// void TabularPhotonField::checkInputData() const {
+// 	if (this->isRedshiftDependent) {
+// 		if (this->photonDensity.size() != this->photonEnergies.size() * this-> redshifts.size())
+// 			throw std::runtime_error("TabularPhotonField::checkInputData: length of photon density input is unequal to length of photon energy input times length of redshift input");
+// 	} else {
+// 		if (this->photonEnergies.size() != this->photonDensity.size())
+// 			throw std::runtime_error("TabularPhotonField::checkInputData: length of photon energy input is unequal to length of photon density input");
+// 	}
 
-	for (int i = 0; i < this->photonEnergies.size(); ++i) {
-		double ePrevious = 0.;
-		double e = this->photonEnergies[i];
-		if (e <= 0.)
-			throw std::runtime_error("TabularPhotonField::checkInputData: a value in the photon energy input is not positive");
-		if (e <= ePrevious)
-			throw std::runtime_error("TabularPhotonField::checkInputData: photon energy values are not strictly increasing");
-		ePrevious = e;
-	}
+// 	for (int i = 0; i < this->photonEnergies.size(); ++i) {
+// 		double ePrevious = 0.;
+// 		double e = this->photonEnergies[i];
+// 		if (e <= 0.)
+// 			throw std::runtime_error("TabularPhotonField::checkInputData: a value in the photon energy input is not positive");
+// 		if (e <= ePrevious)
+// 			throw std::runtime_error("TabularPhotonField::checkInputData: photon energy values are not strictly increasing");
+// 		ePrevious = e;
+// 	}
 
-	for (int i = 0; i < this->photonDensity.size(); ++i) {
-		if (this->photonDensity[i] < 0.)
-			throw std::runtime_error("TabularPhotonField::checkInputData: a value in the photon density input is negative");
-	}
+// 	for (int i = 0; i < this->photonDensity.size(); ++i) {
+// 		if (this->photonDensity[i] < 0.)
+// 			throw std::runtime_error("TabularPhotonField::checkInputData: a value in the photon density input is negative");
+// 	}
 
-	if (this->isRedshiftDependent) {
-		if (this->redshifts[0] != 0.)
-			throw std::runtime_error("TabularPhotonField::checkInputData: redshift input must start with zero");
+// 	if (this->isRedshiftDependent) {
+// 		if (this->redshifts[0] != 0.)
+// 			throw std::runtime_error("TabularPhotonField::checkInputData: redshift input must start with zero");
 
-		for (int i = 0; i < this->redshifts.size(); ++i) {
-			double zPrevious = -1.;
-			double z = this->redshifts[i];
-			if (z < 0.)
-				throw std::runtime_error("TabularPhotonField::checkInputData: a value in the redshift input is negative");
-			if (z <= zPrevious)
-				throw std::runtime_error("TabularPhotonField::checkInputData: redshift values are not strictly increasing");
-			zPrevious = z;
-		}
+// 		for (int i = 0; i < this->redshifts.size(); ++i) {
+// 			double zPrevious = -1.;
+// 			double z = this->redshifts[i];
+// 			if (z < 0.)
+// 				throw std::runtime_error("TabularPhotonField::checkInputData: a value in the redshift input is negative");
+// 			if (z <= zPrevious)
+// 				throw std::runtime_error("TabularPhotonField::checkInputData: redshift values are not strictly increasing");
+// 			zPrevious = z;
+// 		}
 
-		for (int i = 0; i < this->redshiftScalings.size(); ++i) {
-			double scal = this->redshiftScalings[i];
-			if (scal <= 0.)
-				throw std::runtime_error("TabularPhotonField::checkInputData: a value in the redshift input for scaling is not positive");
-		}
-	}
-}
+// 		for (int i = 0; i < this->redshiftScalings.size(); ++i) {
+// 			double scal = this->redshiftScalings[i];
+// 			if (scal <= 0.)
+// 				throw std::runtime_error("TabularPhotonField::checkInputData: a value in the redshift input for scaling is not positive");
+// 		}
+// 	}
+// }
 
 BlackbodyPhotonField::BlackbodyPhotonField(std::string fieldName, double blackbodyTemperature) {
 	this->fieldName = fieldName;

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -155,22 +155,6 @@ double BlackbodyPhotonField::getPhotonDensity(double ePhoton, double z) const {
 	return 8 * M_PI * pow_integer<3>(ePhoton / (h_planck * c_light)) / std::expm1(ePhoton / (k_boltzmann * this->blackbodyTemperature));
 }
 
-PowerLawPhotonField::PowerLawPhotonField(std::string fieldName, double eMin, double eMax, double powerLawIndex, double normFactor) {
-	this->fieldName = fieldName;
-	this->eMin = eMin;
-	this->eMax = eMax;
-	this->powerLawIndex = powerLawIndex;
-	this->normFactor = normFactor;
-}
-
-double PowerLawPhotonField::getPhotonDensity(double ePhoton, double z) const {
-	if (ePhoton < this->eMin || ePhoton > this->eMax) {
-		return 0.;
-	} else {
-		return this->normFactor * std::pow(ePhoton / this->eMin, this->powerLawIndex);
-	}
-}
-
 PhotonFieldSampling::PhotonFieldSampling() {
 	bgFlag = 0;
 }

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -24,6 +24,14 @@ TabularPhotonField::TabularPhotonField(std::string fieldName, bool isRedshiftDep
 		initRedshiftScaling();
 }
 
+double TabularPhotonField::getPhotonDensity(double ePhoton, double z) const {
+	if (this->isRedshiftDependent) {
+		return interpolate2d(ePhoton, z, this->photonEnergies, this->redshifts, this->photonDensity);
+	} else {
+		return interpolate(ePhoton, this->photonEnergies, this->photonDensity);
+	}
+}
+
 double TabularPhotonField::getRedshiftScaling(double z) const {
 	if (this->isRedshiftDependent) {
 		if (z > this->redshifts.back()) {
@@ -35,14 +43,6 @@ double TabularPhotonField::getRedshiftScaling(double z) const {
 		}
 	} else {
 		return 1.;
-	}
-}
-
-double TabularPhotonField::getPhotonDensity(double ePhoton, double z) const {
-	if (this->isRedshiftDependent) {
-		return interpolate2d(ePhoton, z, this->photonEnergies, this->redshifts, this->photonDensity);
-	} else {
-		return interpolate(ePhoton, this->photonEnergies, this->photonDensity);
 	}
 }
 

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -162,7 +162,7 @@ BlackbodyPhotonField::BlackbodyPhotonField(std::string fieldName, double blackbo
 	this->blackbodyTemperature = blackbodyTemperature;
 }
 
-double BlackbodyPhotonField::getPhotonDensity(double ePhoton) const {
+double BlackbodyPhotonField::getPhotonDensity(double ePhoton, double z) const {
 	return 8 * M_PI * pow_integer<3>(ePhoton / (h_planck * c_light)) / std::expm1(ePhoton / (k_boltzmann * this->blackbodyTemperature));
 }
 

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -174,7 +174,7 @@ PowerLawPhotonField::PowerLawPhotonField(std::string fieldName, double eMin, dou
 	this->normFactor = normFactor;
 }
 
-PowerLawPhotonField::getPhotonDensity(double ePhoton, double z) const {
+double PowerLawPhotonField::getPhotonDensity(double ePhoton, double z) const {
 	if (ePhoton < this->eMin || ePhoton > this->eMax) {
 		return 0.;
 	} else {

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -98,11 +98,11 @@ void TabularPhotonField::initRedshift(std::string fieldName) {
 
 void TabularPhotonField::initRedshiftScaling() {
 	double n0 = 0.;
-	for (int i = 0; i < redshifts.size(); ++i) {
-		double z = redshifts[i];
+	for (int i = 0; i < this->redshifts.size(); ++i) {
+		double z = this->redshifts[i];
 		double n = 0.;
-		for (int j = 0; j < photonEnergies.size(); ++j) {
-			double e = photonEnergies[j];
+		for (int j = 0; j < this->photonEnergies.size(); ++j) {
+			double e = this->photonEnergies[j];
 			if (z == 0.)
 				n0 += getPhotonDensity(e, 0.);
 			n += getPhotonDensity(e, z);

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -11,21 +11,21 @@
 
 namespace crpropa {
 
-PhotonField::PhotonField(std::string fieldName, bool hasRedshiftDependence) {
+PhotonField::PhotonField(std::string fieldName, bool isRedshiftDependent) {
 	this->fieldName = fieldName;
-	this->hasRedshiftDependence = hasRedshiftDependence;
+	this->isRedshiftDependent = isRedshiftDependent;
 	if (this->fieldName == "CMB")
-		this->hasRedshiftDependence = false;
+		this->isRedshiftDependent = false;
 
 	initPhotonEnergy(this->fieldName);
 	initPhotonDensity(this->fieldName);
-	if (this->hasRedshiftDependence) {
+	if (this->isRedshiftDependent) {
 		initRedshift(this->fieldName);
 	}
 
 	checkInputData();
 
-	if (this->hasRedshiftDependence)
+	if (this->isRedshiftDependent)
 		initRedshiftScaling();
 }
 
@@ -33,12 +33,12 @@ std::string PhotonField::getFieldName() const {
 	return this->fieldName;
 }
 
-bool PhotonField::getHasRedshiftDependence() const {
-	return this->hasRedshiftDependence;
+bool PhotonField::hasRedshiftDependence() const {
+	return this->isRedshiftDependent;
 }
 
 double PhotonField::getRedshiftScaling(double z) const {
-	if (this->hasRedshiftDependence) {
+	if (this->isRedshiftDependent) {
 		if (z > this->redshifts.back()) {
 			return 0.;
 		} else if (z < this->redshifts.front()) {
@@ -52,7 +52,7 @@ double PhotonField::getRedshiftScaling(double z) const {
 }
 
 double PhotonField::getPhotonDensity(double ePhoton, double z) const {
-	if (this->hasRedshiftDependence) {
+	if (this->isRedshiftDependent) {
 		return interpolate2d(ePhoton, z, this->photonEnergies, this->redshifts, this->photonDensity);
 	} else {
 		return interpolate(ePhoton, this->photonEnergies, this->photonDensity);
@@ -123,7 +123,7 @@ void PhotonField::initRedshiftScaling() {
 }
 
 void PhotonField::checkInputData() const {
-	if (this->hasRedshiftDependence) {
+	if (this->isRedshiftDependent) {
 		if (this->photonDensity.size() != this->photonEnergies.size() * this-> redshifts.size())
 			throw std::runtime_error("PhotonField::checkInputData: length of photon density input is unequal to length of photon energy input times length of redshift input");
 	} else {
@@ -146,7 +146,7 @@ void PhotonField::checkInputData() const {
 			throw std::runtime_error("PhotonField::checkInputData: a value in the photon density input is negative");
 	}
 
-	if (this->hasRedshiftDependence) {
+	if (this->isRedshiftDependent) {
 		if (this->redshifts[0] != 0.)
 			throw std::runtime_error("PhotonField::checkInputData: redshift input must start with zero");
 

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -12,23 +12,17 @@ namespace crpropa {
 TabularPhotonField::TabularPhotonField(std::string fieldName, bool isRedshiftDependent) {
 	this->fieldName = fieldName;
 	this->isRedshiftDependent = isRedshiftDependent;
+
+	readPhotonEnergy(getDataPath("") + "Scaling/" + this->fieldName + "_photonEnergy.txt");
+	readPhotonDensity(getDataPath("") + "Scaling/" + this->fieldName + "_photonDensity.txt");
+	if (this->isRedshiftDependent)
+		readRedshift(getDataPath("") + "Scaling/" + this->fieldName + "_redshift.txt");
+
+	checkInputData();
+
+	if (this->isRedshiftDependent)
+		initRedshiftScaling();
 }
-
-// TabularPhotonField::TabularPhotonField(std::string fieldName, bool isRedshiftDependent) {
-// 	this->fieldName = fieldName;
-// 	this->isRedshiftDependent = isRedshiftDependent;
-
-// 	initPhotonEnergy(this->fieldName);
-// 	initPhotonDensity(this->fieldName);
-// 	if (this->isRedshiftDependent) {
-// 		initRedshift(this->fieldName);
-// 	}
-
-// 	checkInputData();
-
-// 	if (this->isRedshiftDependent)
-// 		initRedshiftScaling();
-// }
 
 double TabularPhotonField::getRedshiftScaling(double z) const {
 	if (this->isRedshiftDependent) {
@@ -52,10 +46,10 @@ double TabularPhotonField::getPhotonDensity(double ePhoton, double z) const {
 	}
 }
 
-void TabularPhotonField::initPhotonEnergy(std::string filePath) {
+void TabularPhotonField::readPhotonEnergy(std::string filePath) {
 	std::ifstream infile(filePath.c_str());
 	if (!infile.good())
-		throw std::runtime_error("TabularPhotonField::initPhotonEnergy: could not open " + filePath);
+		throw std::runtime_error("TabularPhotonField::readPhotonEnergy: could not open " + filePath);
 
 	std::string line;
 	while (std::getline(infile, line)) {
@@ -65,10 +59,10 @@ void TabularPhotonField::initPhotonEnergy(std::string filePath) {
 	infile.close();
 }
 
-void TabularPhotonField::initPhotonDensity(std::string filePath) {
+void TabularPhotonField::readPhotonDensity(std::string filePath) {
 	std::ifstream infile(filePath.c_str());
 	if (!infile.good())
-		throw std::runtime_error("TabularPhotonField::initPhotonDensity: could not open " + filePath);
+		throw std::runtime_error("TabularPhotonField::readPhotonDensity: could not open " + filePath);
 
 	std::string line;
 	while (std::getline(infile, line)) {
@@ -78,7 +72,7 @@ void TabularPhotonField::initPhotonDensity(std::string filePath) {
 	infile.close();
 }
 
-void TabularPhotonField::initRedshift(std::string filePath) {
+void TabularPhotonField::readRedshift(std::string filePath) {
 	std::ifstream infile(filePath.c_str());
 	if (!infile.good())
 		throw std::runtime_error("TabularPhotonField::initRedshift: could not open " + filePath);
@@ -106,51 +100,51 @@ void TabularPhotonField::initRedshiftScaling() {
 	}
 }
 
-// void TabularPhotonField::checkInputData() const {
-// 	if (this->isRedshiftDependent) {
-// 		if (this->photonDensity.size() != this->photonEnergies.size() * this-> redshifts.size())
-// 			throw std::runtime_error("TabularPhotonField::checkInputData: length of photon density input is unequal to length of photon energy input times length of redshift input");
-// 	} else {
-// 		if (this->photonEnergies.size() != this->photonDensity.size())
-// 			throw std::runtime_error("TabularPhotonField::checkInputData: length of photon energy input is unequal to length of photon density input");
-// 	}
+void TabularPhotonField::checkInputData() const {
+	if (this->isRedshiftDependent) {
+		if (this->photonDensity.size() != this->photonEnergies.size() * this-> redshifts.size())
+			throw std::runtime_error("TabularPhotonField::checkInputData: length of photon density input is unequal to length of photon energy input times length of redshift input");
+	} else {
+		if (this->photonEnergies.size() != this->photonDensity.size())
+			throw std::runtime_error("TabularPhotonField::checkInputData: length of photon energy input is unequal to length of photon density input");
+	}
 
-// 	for (int i = 0; i < this->photonEnergies.size(); ++i) {
-// 		double ePrevious = 0.;
-// 		double e = this->photonEnergies[i];
-// 		if (e <= 0.)
-// 			throw std::runtime_error("TabularPhotonField::checkInputData: a value in the photon energy input is not positive");
-// 		if (e <= ePrevious)
-// 			throw std::runtime_error("TabularPhotonField::checkInputData: photon energy values are not strictly increasing");
-// 		ePrevious = e;
-// 	}
+	for (int i = 0; i < this->photonEnergies.size(); ++i) {
+		double ePrevious = 0.;
+		double e = this->photonEnergies[i];
+		if (e <= 0.)
+			throw std::runtime_error("TabularPhotonField::checkInputData: a value in the photon energy input is not positive");
+		if (e <= ePrevious)
+			throw std::runtime_error("TabularPhotonField::checkInputData: photon energy values are not strictly increasing");
+		ePrevious = e;
+	}
 
-// 	for (int i = 0; i < this->photonDensity.size(); ++i) {
-// 		if (this->photonDensity[i] < 0.)
-// 			throw std::runtime_error("TabularPhotonField::checkInputData: a value in the photon density input is negative");
-// 	}
+	for (int i = 0; i < this->photonDensity.size(); ++i) {
+		if (this->photonDensity[i] < 0.)
+			throw std::runtime_error("TabularPhotonField::checkInputData: a value in the photon density input is negative");
+	}
 
-// 	if (this->isRedshiftDependent) {
-// 		if (this->redshifts[0] != 0.)
-// 			throw std::runtime_error("TabularPhotonField::checkInputData: redshift input must start with zero");
+	if (this->isRedshiftDependent) {
+		if (this->redshifts[0] != 0.)
+			throw std::runtime_error("TabularPhotonField::checkInputData: redshift input must start with zero");
 
-// 		for (int i = 0; i < this->redshifts.size(); ++i) {
-// 			double zPrevious = -1.;
-// 			double z = this->redshifts[i];
-// 			if (z < 0.)
-// 				throw std::runtime_error("TabularPhotonField::checkInputData: a value in the redshift input is negative");
-// 			if (z <= zPrevious)
-// 				throw std::runtime_error("TabularPhotonField::checkInputData: redshift values are not strictly increasing");
-// 			zPrevious = z;
-// 		}
+		for (int i = 0; i < this->redshifts.size(); ++i) {
+			double zPrevious = -1.;
+			double z = this->redshifts[i];
+			if (z < 0.)
+				throw std::runtime_error("TabularPhotonField::checkInputData: a value in the redshift input is negative");
+			if (z <= zPrevious)
+				throw std::runtime_error("TabularPhotonField::checkInputData: redshift values are not strictly increasing");
+			zPrevious = z;
+		}
 
-// 		for (int i = 0; i < this->redshiftScalings.size(); ++i) {
-// 			double scal = this->redshiftScalings[i];
-// 			if (scal <= 0.)
-// 				throw std::runtime_error("TabularPhotonField::checkInputData: a value in the redshift input for scaling is not positive");
-// 		}
-// 	}
-// }
+		for (int i = 0; i < this->redshiftScalings.size(); ++i) {
+			double scalingFactor = this->redshiftScalings[i];
+			if (scalingFactor <= 0.)
+				throw std::runtime_error("TabularPhotonField::checkInputData: initRedshiftScaling has created a non-positive scaling factor");
+		}
+	}
+}
 
 BlackbodyPhotonField::BlackbodyPhotonField(std::string fieldName, double blackbodyTemperature) {
 	this->fieldName = fieldName;

--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -16,7 +16,7 @@ EMDoublePairProduction::EMDoublePairProduction(PhotonField photonField, bool hav
 
 void EMDoublePairProduction::setPhotonField(PhotonField photonField) {
 	this->photonField = photonField;
-	std::string fname = photonFieldName(photonField);
+	std::string fname = photonField.getFieldName();
 	setDescription("EMDoublePairProduction: " + fname);
 	initRate(getDataPath("EMDoublePairProduction/rate_" + fname + ".txt"));
 }
@@ -88,7 +88,7 @@ void EMDoublePairProduction::process(Candidate *candidate) const {
 
 	// interaction rate
 	double rate = interpolate(E, tabEnergy, tabRate);
-	rate *= pow(1 + z, 2) * photonFieldScaling(photonField, z);
+	rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z);
 
 	// check for interaction
 	Random &random = Random::instance();

--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -88,7 +88,7 @@ void EMDoublePairProduction::process(Candidate *candidate) const {
 
 	// interaction rate
 	double rate = interpolate(E, tabEnergy, tabRate);
-	rate *= pow_integer(1 + z) * photonField->getRedshiftScaling(z);
+	rate *= pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
 
 	// check for interaction
 	Random &random = Random::instance();

--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -8,15 +8,15 @@
 
 namespace crpropa {
 
-EMDoublePairProduction::EMDoublePairProduction(PhotonField photonField, bool haveElectrons, double limit) {
+EMDoublePairProduction::EMDoublePairProduction(ref_ptr<PhotonField> photonField, bool haveElectrons, double limit) {
 	setPhotonField(photonField);
 	this->haveElectrons = haveElectrons;
 	this->limit = limit;
 }
 
-void EMDoublePairProduction::setPhotonField(PhotonField photonField) {
+void EMDoublePairProduction::setPhotonField(ref_ptr<PhotonField> photonField) {
 	this->photonField = photonField;
-	std::string fname = photonField.getFieldName();
+	std::string fname = photonField->getFieldName();
 	setDescription("EMDoublePairProduction: " + fname);
 	initRate(getDataPath("EMDoublePairProduction/rate_" + fname + ".txt"));
 }
@@ -88,7 +88,7 @@ void EMDoublePairProduction::process(Candidate *candidate) const {
 
 	// interaction rate
 	double rate = interpolate(E, tabEnergy, tabRate);
-	rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z);
+	rate *= pow_integer(1 + z) * photonField->getRedshiftScaling(z);
 
 	// check for interaction
 	Random &random = Random::instance();

--- a/src/module/EMInverseComptonScattering.cpp
+++ b/src/module/EMInverseComptonScattering.cpp
@@ -11,15 +11,15 @@ namespace crpropa {
 
 static const double mec2 = mass_electron * c_squared;
 
-EMInverseComptonScattering::EMInverseComptonScattering(PhotonField photonField, bool havePhotons, double limit) {
+EMInverseComptonScattering::EMInverseComptonScattering(ref_ptr<PhotonField> photonField, bool havePhotons, double limit) {
 	setPhotonField(photonField);
 	this->havePhotons = havePhotons;
 	this->limit = limit;
 }
 
-void EMInverseComptonScattering::setPhotonField(PhotonField photonField) {
+void EMInverseComptonScattering::setPhotonField(ref_ptr<PhotonField> photonField) {
 	this->photonField = photonField;
-	std::string fname = photonField.getFieldName();
+	std::string fname = photonField->getFieldName();
 	setDescription("EMInverseComptonScattering: " + fname);
 	initRate(getDataPath("EMInverseComptonScattering/rate_" + fname + ".txt"));
 	initCumulativeRate(getDataPath("EMInverseComptonScattering/cdf_" + fname + ".txt"));
@@ -209,7 +209,7 @@ void EMInverseComptonScattering::process(Candidate *candidate) const {
 
 	// interaction rate
 	double rate = interpolate(E, tabEnergy, tabRate);
-	rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z);
+	rate *= pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
 
 	// check for interaction
 	Random &random = Random::instance();

--- a/src/module/EMInverseComptonScattering.cpp
+++ b/src/module/EMInverseComptonScattering.cpp
@@ -19,7 +19,7 @@ EMInverseComptonScattering::EMInverseComptonScattering(PhotonField photonField, 
 
 void EMInverseComptonScattering::setPhotonField(PhotonField photonField) {
 	this->photonField = photonField;
-	std::string fname = photonFieldName(photonField);
+	std::string fname = photonField.getFieldName();
 	setDescription("EMInverseComptonScattering: " + fname);
 	initRate(getDataPath("EMInverseComptonScattering/rate_" + fname + ".txt"));
 	initCumulativeRate(getDataPath("EMInverseComptonScattering/cdf_" + fname + ".txt"));
@@ -209,7 +209,7 @@ void EMInverseComptonScattering::process(Candidate *candidate) const {
 
 	// interaction rate
 	double rate = interpolate(E, tabEnergy, tabRate);
-	rate *= pow(1 + z, 2) * photonFieldScaling(photonField, z);
+	rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z);
 
 	// check for interaction
 	Random &random = Random::instance();

--- a/src/module/EMPairProduction.cpp
+++ b/src/module/EMPairProduction.cpp
@@ -17,7 +17,7 @@ EMPairProduction::EMPairProduction(PhotonField photonField, bool haveElectrons, 
 
 void EMPairProduction::setPhotonField(PhotonField photonField) {
 	this->photonField = photonField;
-	std::string fname = photonFieldName(photonField);
+	std::string fname = photonField.getFieldName();
 	setDescription("EMPairProduction: " + fname);
 	initRate(getDataPath("EMPairProduction/rate_" + fname + ".txt"));
 	initCumulativeRate(getDataPath("EMPairProduction/cdf_" + fname + ".txt"));
@@ -212,7 +212,7 @@ void EMPairProduction::process(Candidate *candidate) const {
 
 	// interaction rate
 	double rate = interpolate(E, tabEnergy, tabRate);
-	rate *= pow(1 + z, 2) * photonFieldScaling(photonField, z);
+	rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z);
 
 	// check for interaction
 	Random &random = Random::instance();

--- a/src/module/EMPairProduction.cpp
+++ b/src/module/EMPairProduction.cpp
@@ -11,13 +11,13 @@ namespace crpropa {
 
 static const double mec2 = mass_electron * c_squared;
 
-EMPairProduction::EMPairProduction(PhotonField photonField, bool haveElectrons, double limit) : haveElectrons(haveElectrons), limit(limit) {
+EMPairProduction::EMPairProduction(ref_ptr<PhotonField> photonField, bool haveElectrons, double limit) : haveElectrons(haveElectrons), limit(limit) {
 	setPhotonField(photonField);
 }
 
-void EMPairProduction::setPhotonField(PhotonField photonField) {
+void EMPairProduction::setPhotonField(ref_ptr<PhotonField> photonField) {
 	this->photonField = photonField;
-	std::string fname = photonField.getFieldName();
+	std::string fname = photonField->getFieldName();
 	setDescription("EMPairProduction: " + fname);
 	initRate(getDataPath("EMPairProduction/rate_" + fname + ".txt"));
 	initCumulativeRate(getDataPath("EMPairProduction/cdf_" + fname + ".txt"));
@@ -212,7 +212,7 @@ void EMPairProduction::process(Candidate *candidate) const {
 
 	// interaction rate
 	double rate = interpolate(E, tabEnergy, tabRate);
-	rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z);
+	rate *= pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
 
 	// check for interaction
 	Random &random = Random::instance();

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -10,15 +10,15 @@ namespace crpropa {
 
 static const double mec2 = mass_electron * c_squared;
 
-EMTripletPairProduction::EMTripletPairProduction(PhotonField photonField, bool haveElectrons, double limit) {
+EMTripletPairProduction::EMTripletPairProduction(ref_ptr<PhotonField> photonField, bool haveElectrons, double limit) {
 	setPhotonField(photonField);
 	this->haveElectrons = haveElectrons;
 	this->limit = limit;
 }
 
-void EMTripletPairProduction::setPhotonField(PhotonField photonField) {
+void EMTripletPairProduction::setPhotonField(ref_ptr<PhotonField> photonField) {
 	this->photonField = photonField;
-	std::string fname = photonField.getFieldName();
+	std::string fname = photonField->getFieldName();
 	setDescription("EMTripletPairProduction: " + fname);
 	initRate(getDataPath("EMTripletPairProduction/rate_" + fname + ".txt"));
 	initCumulativeRate(getDataPath("EMTripletPairProduction/cdf_" + fname + ".txt"));
@@ -141,7 +141,7 @@ void EMTripletPairProduction::process(Candidate *candidate) const {
 		return;
 
 	// cosmological scaling of interaction distance (comoving)
-	double scaling = pow(1 + z, 2) * photonField.getRedshiftScaling(z);
+	double scaling = pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
 	double rate = scaling * interpolate(E, tabEnergy, tabRate);
 
 	// check for interaction

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -18,7 +18,7 @@ EMTripletPairProduction::EMTripletPairProduction(PhotonField photonField, bool h
 
 void EMTripletPairProduction::setPhotonField(PhotonField photonField) {
 	this->photonField = photonField;
-	std::string fname = photonFieldName(photonField);
+	std::string fname = photonField.getFieldName();
 	setDescription("EMTripletPairProduction: " + fname);
 	initRate(getDataPath("EMTripletPairProduction/rate_" + fname + ".txt"));
 	initCumulativeRate(getDataPath("EMTripletPairProduction/cdf_" + fname + ".txt"));
@@ -141,7 +141,7 @@ void EMTripletPairProduction::process(Candidate *candidate) const {
 		return;
 
 	// cosmological scaling of interaction distance (comoving)
-	double scaling = pow(1 + z, 2) * photonFieldScaling(photonField, z);
+	double scaling = pow(1 + z, 2) * photonField.getRedshiftScaling(z);
 	double rate = scaling * interpolate(E, tabEnergy, tabRate);
 
 	// check for interaction

--- a/src/module/ElasticScattering.cpp
+++ b/src/module/ElasticScattering.cpp
@@ -19,13 +19,13 @@ const double ElasticScattering::epsmin = log10(2 * eV) + 3;    // log10 minimum 
 const double ElasticScattering::epsmax = log10(2 * eV) + 8.12; // log10 maximum photon background energy in nucleus rest frame for elastic scattering
 const size_t ElasticScattering::neps = 513; // number of photon background energies in nucleus rest frame
 
-ElasticScattering::ElasticScattering(PhotonField f) {
+ElasticScattering::ElasticScattering(ref_ptr<PhotonField> f) {
 	setPhotonField(f);
 }
 
-void ElasticScattering::setPhotonField(PhotonField photonField) {
+void ElasticScattering::setPhotonField(ref_ptr<PhotonField> photonField) {
 	this->photonField = photonField;
-	std::string fname = photonField.getFieldName();
+	std::string fname = photonField->getFieldName();
 	setDescription("ElasticScattering: " + fname);
 	initRate(getDataPath("ElasticScattering/rate_" + fname.substr(0,3) + ".txt"));
 	initCDF(getDataPath("ElasticScattering/cdf_" + fname.substr(0,3) + ".txt"));
@@ -99,7 +99,7 @@ void ElasticScattering::process(Candidate *candidate) const {
 
 		double rate = interpolateEquidistant(lg, lgmin, lgmax, tabRate);
 		rate *= Z * N / double(A);  // TRK scaling
-		rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z);  // cosmological scaling
+		rate *= pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);  // cosmological scaling
 
 		// check for interaction
 		Random &random = Random::instance();

--- a/src/module/ElasticScattering.cpp
+++ b/src/module/ElasticScattering.cpp
@@ -25,7 +25,7 @@ ElasticScattering::ElasticScattering(PhotonField f) {
 
 void ElasticScattering::setPhotonField(PhotonField photonField) {
 	this->photonField = photonField;
-	std::string fname = photonFieldName(photonField);
+	std::string fname = photonField.getFieldName();
 	setDescription("ElasticScattering: " + fname);
 	initRate(getDataPath("ElasticScattering/rate_" + fname.substr(0,3) + ".txt"));
 	initCDF(getDataPath("ElasticScattering/cdf_" + fname.substr(0,3) + ".txt"));
@@ -99,7 +99,7 @@ void ElasticScattering::process(Candidate *candidate) const {
 
 		double rate = interpolateEquidistant(lg, lgmin, lgmax, tabRate);
 		rate *= Z * N / double(A);  // TRK scaling
-		rate *= pow(1 + z, 2) * photonFieldScaling(photonField, z);  // cosmological scaling
+		rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z);  // cosmological scaling
 
 		// check for interaction
 		Random &random = Random::instance();

--- a/src/module/ElectronPairProduction.cpp
+++ b/src/module/ElectronPairProduction.cpp
@@ -10,16 +10,16 @@
 
 namespace crpropa {
 
-ElectronPairProduction::ElectronPairProduction(PhotonField photonField,
+ElectronPairProduction::ElectronPairProduction(ref_ptr<PhotonField> photonField,
 		bool haveElectrons, double limit) {
 	setPhotonField(photonField);
 	this->haveElectrons = haveElectrons;
 	this->limit = limit;
 }
 
-void ElectronPairProduction::setPhotonField(PhotonField photonField) {
+void ElectronPairProduction::setPhotonField(ref_ptr<PhotonField> photonField) {
 	this->photonField = photonField;
-	std::string fname = photonField.getFieldName();
+	std::string fname = photonField->getFieldName();
 	setDescription("ElectronPairProduction: " + fname);
 	initRate(getDataPath("ElectronPairProduction/lossrate_" + fname + ".txt"));
 	initSpectrum(getDataPath("ElectronPairProduction/spectrum_" + fname.substr(0,3) + ".txt"));
@@ -93,7 +93,7 @@ double ElectronPairProduction::lossLength(int id, double lf, double z) const {
 		rate = tabLossRate.back() * pow(lf / tabLorentzFactor.back(), -0.6); // extrapolation
 
 	double A = nuclearMass(id) / mass_proton; // more accurate than massNumber(Id)
-	rate *= Z * Z / A * pow(1 + z, 3) * photonField.getRedshiftScaling(z);
+	rate *= Z * Z / A * pow_integer<3>(1 + z) * photonField->getRedshiftScaling(z);
 	return 1. / rate;
 }
 

--- a/src/module/ElectronPairProduction.cpp
+++ b/src/module/ElectronPairProduction.cpp
@@ -19,7 +19,7 @@ ElectronPairProduction::ElectronPairProduction(PhotonField photonField,
 
 void ElectronPairProduction::setPhotonField(PhotonField photonField) {
 	this->photonField = photonField;
-	std::string fname = photonFieldName(photonField);
+	std::string fname = photonField.getFieldName();
 	setDescription("ElectronPairProduction: " + fname);
 	initRate(getDataPath("ElectronPairProduction/lossrate_" + fname + ".txt"));
 	initSpectrum(getDataPath("ElectronPairProduction/spectrum_" + fname.substr(0,3) + ".txt"));
@@ -93,7 +93,7 @@ double ElectronPairProduction::lossLength(int id, double lf, double z) const {
 		rate = tabLossRate.back() * pow(lf / tabLorentzFactor.back(), -0.6); // extrapolation
 
 	double A = nuclearMass(id) / mass_proton; // more accurate than massNumber(Id)
-	rate *= Z * Z / A * pow(1 + z, 3) * photonFieldScaling(photonField, z);
+	rate *= Z * Z / A * pow(1 + z, 3) * photonField.getRedshiftScaling(z);
 	return 1. / rate;
 }
 

--- a/src/module/PhotoDisintegration.cpp
+++ b/src/module/PhotoDisintegration.cpp
@@ -25,7 +25,7 @@ PhotoDisintegration::PhotoDisintegration(PhotonField f, bool havePhotons, double
 
 void PhotoDisintegration::setPhotonField(PhotonField photonField) {
 	this->photonField = photonField;
-	std::string fname = photonFieldName(photonField);
+	std::string fname = photonField.getFieldName();
 	setDescription("PhotoDisintegration: " + fname);
 	initRate(getDataPath("Photodisintegration/rate_" + fname + ".txt"));
 	initBranching(getDataPath("Photodisintegration/branching_" + fname + ".txt"));
@@ -172,7 +172,7 @@ void PhotoDisintegration::process(Candidate *candidate) const {
 			return;
 
 		double rate = interpolateEquidistant(lg, lgmin, lgmax, pdRate[idx]);
-		rate *= pow(1 + z, 2) * photonFieldScaling(photonField, z); // cosmological scaling, rate per comoving distance
+		rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z); // cosmological scaling, rate per comoving distance
 
 		// check if interaction occurs in this step
 		// otherwise limit next step to a fraction of the mean free path
@@ -296,7 +296,7 @@ double PhotoDisintegration::lossLength(int id, double gamma, double z) {
 	double lossRate = interpolateEquidistant(lg, lgmin, lgmax, rate);
 
 	// comological scaling, rate per physical distance
-	lossRate *= pow(1 + z, 3) * photonFieldScaling(photonField, z);
+	lossRate *= pow(1 + z, 3) * photonField.getRedshiftScaling(z);
 
 	// average number of nucleons lost for all disintegration channels
 	double avg_dA = 0;

--- a/src/module/PhotoDisintegration.cpp
+++ b/src/module/PhotoDisintegration.cpp
@@ -17,15 +17,15 @@ const double PhotoDisintegration::lgmin = 6;  // minimum log10(Lorentz-factor)
 const double PhotoDisintegration::lgmax = 14; // maximum log10(Lorentz-factor)
 const size_t PhotoDisintegration::nlg = 201;  // number of Lorentz-factor steps
 
-PhotoDisintegration::PhotoDisintegration(PhotonField f, bool havePhotons, double limit) {
+PhotoDisintegration::PhotoDisintegration(ref_ptr<PhotonField> f, bool havePhotons, double limit) {
 	setPhotonField(f);
 	this->havePhotons = havePhotons;
 	this->limit = limit;
 }
 
-void PhotoDisintegration::setPhotonField(PhotonField photonField) {
+void PhotoDisintegration::setPhotonField(ref_ptr<PhotonField> photonField) {
 	this->photonField = photonField;
-	std::string fname = photonField.getFieldName();
+	std::string fname = photonField->getFieldName();
 	setDescription("PhotoDisintegration: " + fname);
 	initRate(getDataPath("Photodisintegration/rate_" + fname + ".txt"));
 	initBranching(getDataPath("Photodisintegration/branching_" + fname + ".txt"));
@@ -172,7 +172,7 @@ void PhotoDisintegration::process(Candidate *candidate) const {
 			return;
 
 		double rate = interpolateEquidistant(lg, lgmin, lgmax, pdRate[idx]);
-		rate *= pow(1 + z, 2) * photonField.getRedshiftScaling(z); // cosmological scaling, rate per comoving distance
+		rate *= pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z); // cosmological scaling, rate per comoving distance
 
 		// check if interaction occurs in this step
 		// otherwise limit next step to a fraction of the mean free path
@@ -296,7 +296,7 @@ double PhotoDisintegration::lossLength(int id, double gamma, double z) {
 	double lossRate = interpolateEquidistant(lg, lgmin, lgmax, rate);
 
 	// comological scaling, rate per physical distance
-	lossRate *= pow(1 + z, 3) * photonField.getRedshiftScaling(z);
+	lossRate *= pow_integer<3>(1 + z) * photonField->getRedshiftScaling(z);
 
 	// average number of nucleons lost for all disintegration channels
 	double avg_dA = 0;

--- a/src/module/PhotoPionProduction.cpp
+++ b/src/module/PhotoPionProduction.cpp
@@ -28,7 +28,7 @@ PhotoPionProduction::PhotoPionProduction(PhotonField field, bool photons, bool n
 void PhotoPionProduction::setPhotonField(PhotonField field) {
 	photonField = field;
 	if (haveRedshiftDependence) {
-		if (field==CMB){
+		if (photonField.getHasRedshiftDependence()){
 			std::cout << "PhotoPionProduction: tabulated redshift dependence not needed for CMB, switching off" << std::endl;
 			haveRedshiftDependence = false;
 		}
@@ -36,14 +36,14 @@ void PhotoPionProduction::setPhotonField(PhotonField field) {
 			KISS_LOG_WARNING << "PhotoPionProduction: You are using the 2-dimensional tabulated redshift evolution, which is not available for other interactions. To be consistent across all interactions you may deactivate this <setHaveRedshiftDependence(False)>.";
 		}
 	}
-	std::string fname = photonFieldName(field);
+	std::string fname = photonField.getFieldName();
 	setDescription("PhotoPionProduction: " + fname);
 	if (haveRedshiftDependence)
 		initRate(getDataPath("PhotoPionProduction/rate_" + fname.replace(0, 3, "IRBz") + ".txt"));
 	else
 		initRate(getDataPath("PhotoPionProduction/rate_" + fname + ".txt"));
 
-	int background = (photonField == CMB) ? 1 : 2; // photon background: 1 for CMB, 2 for Kneiske IRB
+	int background = (fname == "CMB") ? 1 : 2; // photon background: 1 for CMB, 2 for Kneiske IRB
 	this->photonFieldSampling = PhotonFieldSampling(background);
 }
 
@@ -136,7 +136,7 @@ double PhotoPionProduction::nucleonMFP(double gamma, double z, bool onProton) co
 	if (haveRedshiftDependence)
 		rate = interpolate2d(z, gamma, tabRedshifts, tabLorentz, tabRate);
 	else
-		rate = interpolate(gamma, tabLorentz, tabRate) * photonFieldScaling(photonField, z);
+		rate = interpolate(gamma, tabLorentz, tabRate) * photonField.getRedshiftScaling(z);
 
 	// cosmological scaling
 	rate *= pow(1 + z, 2);
@@ -218,7 +218,7 @@ void PhotoPionProduction::performInteraction(Candidate *candidate, bool onProton
 	int sign = (id > 0) ? 1 : -1;
 
 	// check if below SOPHIA's energy threshold
-	double E_threshold = (photonField == CMB) ? 3.72e18 * eV : 5.83e15 * eV;
+	double E_threshold = (photonField.getFieldName() == "CMB") ? 3.72e18 * eV : 5.83e15 * eV;
 	if (EpA * (1 + z) < E_threshold)
 		return;
 

--- a/src/module/PhotoPionProduction.cpp
+++ b/src/module/PhotoPionProduction.cpp
@@ -15,7 +15,7 @@
 
 namespace crpropa {
 
-PhotoPionProduction::PhotoPionProduction(PhotonField field, bool photons, bool neutrinos, bool electrons, bool antiNucleons, double l, bool redshift) {
+PhotoPionProduction::PhotoPionProduction(ref_ptr<PhotonField> field, bool photons, bool neutrinos, bool electrons, bool antiNucleons, double l, bool redshift) {
 	havePhotons = photons;
 	haveNeutrinos = neutrinos;
 	haveElectrons = electrons;
@@ -25,10 +25,10 @@ PhotoPionProduction::PhotoPionProduction(PhotonField field, bool photons, bool n
 	setPhotonField(field);
 }
 
-void PhotoPionProduction::setPhotonField(PhotonField field) {
+void PhotoPionProduction::setPhotonField(ref_ptr<PhotonField> field) {
 	photonField = field;
 	if (haveRedshiftDependence) {
-		if (photonField.hasRedshiftDependence()){
+		if (photonField->hasRedshiftDependence()){
 			std::cout << "PhotoPionProduction: tabulated redshift dependence not needed for CMB, switching off" << std::endl;
 			haveRedshiftDependence = false;
 		}
@@ -36,7 +36,7 @@ void PhotoPionProduction::setPhotonField(PhotonField field) {
 			KISS_LOG_WARNING << "PhotoPionProduction: You are using the 2-dimensional tabulated redshift evolution, which is not available for other interactions. To be consistent across all interactions you may deactivate this <setHaveRedshiftDependence(False)>.";
 		}
 	}
-	std::string fname = photonField.getFieldName();
+	std::string fname = photonField->getFieldName();
 	setDescription("PhotoPionProduction: " + fname);
 	if (haveRedshiftDependence)
 		initRate(getDataPath("PhotoPionProduction/rate_" + fname.replace(0, 3, "IRBz") + ".txt"));
@@ -136,10 +136,10 @@ double PhotoPionProduction::nucleonMFP(double gamma, double z, bool onProton) co
 	if (haveRedshiftDependence)
 		rate = interpolate2d(z, gamma, tabRedshifts, tabLorentz, tabRate);
 	else
-		rate = interpolate(gamma, tabLorentz, tabRate) * photonField.getRedshiftScaling(z);
+		rate = interpolate(gamma, tabLorentz, tabRate) * photonField->getRedshiftScaling(z);
 
 	// cosmological scaling
-	rate *= pow(1 + z, 2);
+	rate *= pow_integer<2>(1 + z);
 
 	return 1. / rate;
 }
@@ -218,7 +218,7 @@ void PhotoPionProduction::performInteraction(Candidate *candidate, bool onProton
 	int sign = (id > 0) ? 1 : -1;
 
 	// check if below SOPHIA's energy threshold
-	double E_threshold = (photonField.getFieldName() == "CMB") ? 3.72e18 * eV : 5.83e15 * eV;
+	double E_threshold = (photonField->getFieldName() == "CMB") ? 3.72e18 * eV : 5.83e15 * eV;
 	if (EpA * (1 + z) < E_threshold)
 		return;
 

--- a/src/module/PhotoPionProduction.cpp
+++ b/src/module/PhotoPionProduction.cpp
@@ -28,7 +28,7 @@ PhotoPionProduction::PhotoPionProduction(PhotonField field, bool photons, bool n
 void PhotoPionProduction::setPhotonField(PhotonField field) {
 	photonField = field;
 	if (haveRedshiftDependence) {
-		if (photonField.getHasRedshiftDependence()){
+		if (photonField.hasRedshiftDependence()){
 			std::cout << "PhotoPionProduction: tabulated redshift dependence not needed for CMB, switching off" << std::endl;
 			haveRedshiftDependence = false;
 		}

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -19,17 +19,16 @@
 namespace crpropa {
 
 // declare all available, built-in photon fields
-	ref_ptr<PhotonField> CMB = new BlackbodyPhotonField("CMB", 2.73);
-// ref_ptr<PhotonField> CMB = new CMB();  // not working! Compiler: "CMB does not name a type"
-ref_ptr<PhotonField> IRB = new TabularPhotonField("IRB_Kneiske04", true);
-ref_ptr<PhotonField> IRB_Kneiske04 = new TabularPhotonField("IRB_Kneiske04", true);
-ref_ptr<PhotonField> IRB_Stecker05 = new TabularPhotonField("IRB_Stecker05", true);
-ref_ptr<PhotonField> IRB_Franceschini08 = new TabularPhotonField("IRB_Franceschini08", true);
-ref_ptr<PhotonField> IRB_Finke10 = new TabularPhotonField("IRB_Finke10", true);
-ref_ptr<PhotonField> IRB_Dominguez11 = new TabularPhotonField("IRB_Dominguez11", true);
-ref_ptr<PhotonField> IRB_Gilmore12 = new TabularPhotonField("IRB_Gilmore12", true);
-ref_ptr<PhotonField> IRB_Stecker16_upper = new TabularPhotonField("IRB_Stecker16_upper", true);
-ref_ptr<PhotonField> IRB_Stecker16_lower = new TabularPhotonField("IRB_Stecker16_lower", true);
+ref_ptr<PhotonField> CMB = new BlackbodyPhotonField("CMB", 2.73);
+ref_ptr<PhotonField> IRB = new TabularPhotonField("IRB_Kneiske04");
+ref_ptr<PhotonField> IRB_Kneiske04 = new TabularPhotonField("IRB_Kneiske04");
+ref_ptr<PhotonField> IRB_Stecker05 = new TabularPhotonField("IRB_Stecker05");
+ref_ptr<PhotonField> IRB_Franceschini08 = new TabularPhotonField("IRB_Franceschini08");
+ref_ptr<PhotonField> IRB_Finke10 = new TabularPhotonField("IRB_Finke10");
+ref_ptr<PhotonField> IRB_Dominguez11 = new TabularPhotonField("IRB_Dominguez11");
+ref_ptr<PhotonField> IRB_Gilmore12 = new TabularPhotonField("IRB_Gilmore12");
+ref_ptr<PhotonField> IRB_Stecker16_upper = new TabularPhotonField("IRB_Stecker16_upper");
+ref_ptr<PhotonField> IRB_Stecker16_lower = new TabularPhotonField("IRB_Stecker16_lower");
 
 // ElectronPairProduction -----------------------------------------------------
 TEST(ElectronPairProduction, allBackgrounds) {

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -1,6 +1,7 @@
 #include "crpropa/Candidate.h"
 #include "crpropa/Units.h"
 #include "crpropa/ParticleID.h"
+#include "crpropa/PhotonBackground.h"
 #include "crpropa/module/ElectronPairProduction.h"
 #include "crpropa/module/NuclearDecay.h"
 #include "crpropa/module/PhotoDisintegration.h"
@@ -16,6 +17,19 @@
 #include <fstream>
 
 namespace crpropa {
+
+// declare all available, built-in photon fields
+PhotonField CMB = PhotonField("CMB");
+PhotonField IRB = PhotonField("IRB_Kneiske04");
+PhotonField IRB_Kneiske04 = PhotonField("IRB_Kneiske04");
+PhotonField IRB_Stecker05 = PhotonField("IRB_Stecker05");
+PhotonField IRB_Franceschini08 = PhotonField("IRB_Franceschini08");
+PhotonField IRB_Finke10 = PhotonField("IRB_Finke10");
+PhotonField IRB_Dominguez11 = PhotonField("IRB_Dominguez11");
+PhotonField IRB_Gilmore12 = PhotonField("IRB_Gilmore12");
+PhotonField IRB_Stecker16_upper = PhotonField("IRB_Stecker16_upper");
+PhotonField IRB_Stecker16_lower = PhotonField("IRB_Stecker16_lower");
+// PhotonField URB_Protheroe96 = PhotonField("URB_Protheroe96");
 
 // ElectronPairProduction -----------------------------------------------------
 TEST(ElectronPairProduction, allBackgrounds) {
@@ -352,7 +366,7 @@ TEST(PhotoDisintegration, iron) {
 
 TEST(PhotoDisintegration, thisIsNotNucleonic) {
 	// Test that nothing happens to an electron.
-	PhotoDisintegration pd;
+	PhotoDisintegration pd(CMB);
 	Candidate c;
 	c.setCurrentStep(1 * Mpc);
 	c.current.setId(11); // electron
@@ -364,7 +378,7 @@ TEST(PhotoDisintegration, thisIsNotNucleonic) {
 
 TEST(PhotoDisintegration, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	PhotoDisintegration pd;
+	PhotoDisintegration pd(CMB);
 	Candidate c;
 	c.setNextStep(std::numeric_limits<double>::max());
 	c.current.setId(nucleusId(4, 2));
@@ -442,7 +456,7 @@ TEST(ElasticScattering, secondaries) {
 // PhotoPionProduction --------------------------------------------------------
 TEST(PhotoPionProduction, allBackgrounds) {
 	// Test if all interaction data files can be loaded.
-	PhotoPionProduction ppp;
+	PhotoPionProduction ppp(CMB);
 	ppp.setPhotonField(IRB_Kneiske04);
 	ppp.setPhotonField(IRB_Stecker05);
 	ppp.setPhotonField(IRB_Franceschini08);
@@ -456,7 +470,7 @@ TEST(PhotoPionProduction, allBackgrounds) {
 TEST(PhotoPionProduction, proton) {
 	// Test photo-pion interaction for 100 EeV proton.
 	// This test can stochastically fail.
-	PhotoPionProduction ppp;
+	PhotoPionProduction ppp(CMB);
 	Candidate c(nucleusId(1, 1), 100 * EeV);
 	c.setCurrentStep(1000 * Mpc);
 	ppp.process(&c);
@@ -474,7 +488,7 @@ TEST(PhotoPionProduction, proton) {
 TEST(PhotoPionProduction, helium) {
 	// Test photo-pion interaction for 400 EeV He nucleus.
 	// This test can stochastically fail.
-	PhotoPionProduction ppp;
+	PhotoPionProduction ppp(CMB);
 	Candidate c;
 	c.current.setId(nucleusId(4, 2));
 	c.current.setEnergy(400 * EeV);
@@ -488,7 +502,7 @@ TEST(PhotoPionProduction, helium) {
 
 TEST(PhotoPionProduction, thisIsNotNucleonic) {
 	// Test if noting happens to an electron.
-	PhotoPionProduction ppp;
+	PhotoPionProduction ppp(CMB);
 	Candidate c;
 	c.current.setId(11); // electron
 	c.current.setEnergy(10 * EeV);
@@ -500,7 +514,7 @@ TEST(PhotoPionProduction, thisIsNotNucleonic) {
 
 TEST(PhotoPionProduction, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	PhotoPionProduction ppp;
+	PhotoPionProduction ppp(CMB);
 	Candidate c(nucleusId(1, 1), 200 * EeV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	ppp.process(&c);
@@ -548,7 +562,7 @@ TEST(Redshift, limitRedshiftDecrease) {
 // EMPairProduction -----------------------------------------------------------
 TEST(EMPairProduction, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	EMPairProduction m;
+	EMPairProduction m(CMB);
 	Candidate c(22, 1E17 * eV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	m.process(&c);
@@ -557,13 +571,13 @@ TEST(EMPairProduction, limitNextStep) {
 
 TEST(EMPairProduction, secondaries) {
 	// Test if secondaries are correctly produced.
-	EMPairProduction m;
+	EMPairProduction m(CMB);
 	m.setHaveElectrons(true);
 
 	std::vector<PhotonField> fields;
 	fields.push_back(CMB);
 	fields.push_back(IRB_Gilmore12);
-	fields.push_back(URB_Protheroe96);
+	// fields.push_back(URB_Protheroe96);
 
 	// loop over photon backgrounds
 	for (int f = 0; f < fields.size(); f++) {
@@ -602,7 +616,7 @@ TEST(EMPairProduction, secondaries) {
 // EMDoublePairProduction -----------------------------------------------------
 TEST(EMDoublePairProduction, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	EMDoublePairProduction m;
+	EMDoublePairProduction m(CMB);
 	Candidate c(22, 1E17 * eV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	m.process(&c);
@@ -611,13 +625,13 @@ TEST(EMDoublePairProduction, limitNextStep) {
 
 TEST(EMDoublePairProduction, secondaries) {
 	// Test if secondaries are correctly produced.
-	EMDoublePairProduction m;
+	EMDoublePairProduction m(CMB);
 	m.setHaveElectrons(true);
 
 	std::vector<PhotonField> fields;
 	fields.push_back(CMB);
 	fields.push_back(IRB_Gilmore12);
-	fields.push_back(URB_Protheroe96);
+	// fields.push_back(URB_Protheroe96);
 
 	// loop over photon backgrounds
 	for (int f = 0; f < fields.size(); f++) {
@@ -656,7 +670,7 @@ TEST(EMDoublePairProduction, secondaries) {
 // EMTripletPairProduction ----------------------------------------------------
 TEST(EMTripletPairProduction, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	EMTripletPairProduction m;
+	EMTripletPairProduction m(CMB);
 	Candidate c(11, 1E17 * eV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	m.process(&c);
@@ -665,13 +679,13 @@ TEST(EMTripletPairProduction, limitNextStep) {
 
 TEST(EMTripletPairProduction, secondaries) {
 	// Test if secondaries are correctly produced.
-	EMTripletPairProduction m;
+	EMTripletPairProduction m(CMB);
 	m.setHaveElectrons(true);
 
 	std::vector<PhotonField> fields;
 	fields.push_back(CMB);
 	fields.push_back(IRB_Gilmore12);
-	fields.push_back(URB_Protheroe96);
+	// fields.push_back(URB_Protheroe96);
 
 	// loop over photon backgrounds
 	for (int f = 0; f < fields.size(); f++) {
@@ -713,7 +727,7 @@ TEST(EMTripletPairProduction, secondaries) {
 // EMInverseComptonScattering -------------------------------------------------
 TEST(EMInverseComptonScattering, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	EMInverseComptonScattering m;
+	EMInverseComptonScattering m(CMB);
 	Candidate c(11, 1E17 * eV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	m.process(&c);
@@ -722,13 +736,13 @@ TEST(EMInverseComptonScattering, limitNextStep) {
 
 TEST(EMInverseComptonScattering, secondaries) {
 	// Test if secondaries are correctly produced.
-	EMInverseComptonScattering m;
+	EMInverseComptonScattering m(CMB);
 	m.setHavePhotons(true);
 
 	std::vector<PhotonField> fields;
 	fields.push_back(CMB);
 	fields.push_back(IRB_Gilmore12);
-	fields.push_back(URB_Protheroe96);
+	// fields.push_back(URB_Protheroe96);
 
 	// loop over photon backgrounds
 	for (int f = 0; f < fields.size(); f++) {

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -20,6 +20,7 @@ namespace crpropa {
 
 // declare all available, built-in photon fields
 ref_ptr<PhotonField> CMB = new BlackbodyPhotonField("CMB", 2.73);
+// ref_ptr<PhotonField> CMB = new CMB();  // not working! Compiler: "CMB does not name a type"
 ref_ptr<PhotonField> IRB = new TabularPhotonField("IRB_Kneiske04");
 ref_ptr<PhotonField> IRB_Kneiske04 = new TabularPhotonField("IRB_Kneiske04");
 ref_ptr<PhotonField> IRB_Stecker05 = new TabularPhotonField("IRB_Stecker05");

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -19,17 +19,16 @@
 namespace crpropa {
 
 // declare all available, built-in photon fields
-PhotonField CMB = PhotonField("CMB");
-PhotonField IRB = PhotonField("IRB_Kneiske04");
-PhotonField IRB_Kneiske04 = PhotonField("IRB_Kneiske04");
-PhotonField IRB_Stecker05 = PhotonField("IRB_Stecker05");
-PhotonField IRB_Franceschini08 = PhotonField("IRB_Franceschini08");
-PhotonField IRB_Finke10 = PhotonField("IRB_Finke10");
-PhotonField IRB_Dominguez11 = PhotonField("IRB_Dominguez11");
-PhotonField IRB_Gilmore12 = PhotonField("IRB_Gilmore12");
-PhotonField IRB_Stecker16_upper = PhotonField("IRB_Stecker16_upper");
-PhotonField IRB_Stecker16_lower = PhotonField("IRB_Stecker16_lower");
-// PhotonField URB_Protheroe96 = PhotonField("URB_Protheroe96");
+PhotonField CMB = BlackbodyPhotonField("CMB", 2.73);
+PhotonField IRB = TabularPhotonField("IRB_Kneiske04");
+PhotonField IRB_Kneiske04 = TabularPhotonField("IRB_Kneiske04");
+PhotonField IRB_Stecker05 = TabularPhotonField("IRB_Stecker05");
+PhotonField IRB_Franceschini08 = TabularPhotonField("IRB_Franceschini08");
+PhotonField IRB_Finke10 = TabularPhotonField("IRB_Finke10");
+PhotonField IRB_Dominguez11 = TabularPhotonField("IRB_Dominguez11");
+PhotonField IRB_Gilmore12 = TabularPhotonField("IRB_Gilmore12");
+PhotonField IRB_Stecker16_upper = TabularPhotonField("IRB_Stecker16_upper");
+PhotonField IRB_Stecker16_lower = TabularPhotonField("IRB_Stecker16_lower");
 
 // ElectronPairProduction -----------------------------------------------------
 TEST(ElectronPairProduction, allBackgrounds) {

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -19,17 +19,17 @@
 namespace crpropa {
 
 // declare all available, built-in photon fields
-ref_ptr<PhotonField> CMB = new BlackbodyPhotonField("CMB", 2.73);
+	ref_ptr<PhotonField> CMB = new BlackbodyPhotonField("CMB", 2.73);
 // ref_ptr<PhotonField> CMB = new CMB();  // not working! Compiler: "CMB does not name a type"
-ref_ptr<PhotonField> IRB = new TabularPhotonField("IRB_Kneiske04");
-ref_ptr<PhotonField> IRB_Kneiske04 = new TabularPhotonField("IRB_Kneiske04");
-ref_ptr<PhotonField> IRB_Stecker05 = new TabularPhotonField("IRB_Stecker05");
-ref_ptr<PhotonField> IRB_Franceschini08 = new TabularPhotonField("IRB_Franceschini08");
-ref_ptr<PhotonField> IRB_Finke10 = new TabularPhotonField("IRB_Finke10");
-ref_ptr<PhotonField> IRB_Dominguez11 = new TabularPhotonField("IRB_Dominguez11");
-ref_ptr<PhotonField> IRB_Gilmore12 = new TabularPhotonField("IRB_Gilmore12");
-ref_ptr<PhotonField> IRB_Stecker16_upper = new TabularPhotonField("IRB_Stecker16_upper");
-ref_ptr<PhotonField> IRB_Stecker16_lower = new TabularPhotonField("IRB_Stecker16_lower");
+ref_ptr<PhotonField> IRB = new TabularPhotonField("IRB_Kneiske04", true);
+ref_ptr<PhotonField> IRB_Kneiske04 = new TabularPhotonField("IRB_Kneiske04", true);
+ref_ptr<PhotonField> IRB_Stecker05 = new TabularPhotonField("IRB_Stecker05", true);
+ref_ptr<PhotonField> IRB_Franceschini08 = new TabularPhotonField("IRB_Franceschini08", true);
+ref_ptr<PhotonField> IRB_Finke10 = new TabularPhotonField("IRB_Finke10", true);
+ref_ptr<PhotonField> IRB_Dominguez11 = new TabularPhotonField("IRB_Dominguez11", true);
+ref_ptr<PhotonField> IRB_Gilmore12 = new TabularPhotonField("IRB_Gilmore12", true);
+ref_ptr<PhotonField> IRB_Stecker16_upper = new TabularPhotonField("IRB_Stecker16_upper", true);
+ref_ptr<PhotonField> IRB_Stecker16_lower = new TabularPhotonField("IRB_Stecker16_lower", true);
 
 // ElectronPairProduction -----------------------------------------------------
 TEST(ElectronPairProduction, allBackgrounds) {

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -19,16 +19,16 @@
 namespace crpropa {
 
 // declare all available, built-in photon fields
-PhotonField CMB = BlackbodyPhotonField("CMB", 2.73);
-PhotonField IRB = TabularPhotonField("IRB_Kneiske04");
-PhotonField IRB_Kneiske04 = TabularPhotonField("IRB_Kneiske04");
-PhotonField IRB_Stecker05 = TabularPhotonField("IRB_Stecker05");
-PhotonField IRB_Franceschini08 = TabularPhotonField("IRB_Franceschini08");
-PhotonField IRB_Finke10 = TabularPhotonField("IRB_Finke10");
-PhotonField IRB_Dominguez11 = TabularPhotonField("IRB_Dominguez11");
-PhotonField IRB_Gilmore12 = TabularPhotonField("IRB_Gilmore12");
-PhotonField IRB_Stecker16_upper = TabularPhotonField("IRB_Stecker16_upper");
-PhotonField IRB_Stecker16_lower = TabularPhotonField("IRB_Stecker16_lower");
+ref_ptr<PhotonField> CMB = new BlackbodyPhotonField("CMB", 2.73);
+ref_ptr<PhotonField> IRB = new TabularPhotonField("IRB_Kneiske04");
+ref_ptr<PhotonField> IRB_Kneiske04 = new TabularPhotonField("IRB_Kneiske04");
+ref_ptr<PhotonField> IRB_Stecker05 = new TabularPhotonField("IRB_Stecker05");
+ref_ptr<PhotonField> IRB_Franceschini08 = new TabularPhotonField("IRB_Franceschini08");
+ref_ptr<PhotonField> IRB_Finke10 = new TabularPhotonField("IRB_Finke10");
+ref_ptr<PhotonField> IRB_Dominguez11 = new TabularPhotonField("IRB_Dominguez11");
+ref_ptr<PhotonField> IRB_Gilmore12 = new TabularPhotonField("IRB_Gilmore12");
+ref_ptr<PhotonField> IRB_Stecker16_upper = new TabularPhotonField("IRB_Stecker16_upper");
+ref_ptr<PhotonField> IRB_Stecker16_lower = new TabularPhotonField("IRB_Stecker16_lower");
 
 // ElectronPairProduction -----------------------------------------------------
 TEST(ElectronPairProduction, allBackgrounds) {

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -18,30 +18,27 @@
 
 namespace crpropa {
 
-// declare all available, built-in photon fields
-ref_ptr<PhotonField> CMB = new BlackbodyPhotonField("CMB", 2.73);
-ref_ptr<PhotonField> IRB = new TabularPhotonField("IRB_Kneiske04");
-ref_ptr<PhotonField> IRB_Kneiske04 = new TabularPhotonField("IRB_Kneiske04");
-ref_ptr<PhotonField> IRB_Stecker05 = new TabularPhotonField("IRB_Stecker05");
-ref_ptr<PhotonField> IRB_Franceschini08 = new TabularPhotonField("IRB_Franceschini08");
-ref_ptr<PhotonField> IRB_Finke10 = new TabularPhotonField("IRB_Finke10");
-ref_ptr<PhotonField> IRB_Dominguez11 = new TabularPhotonField("IRB_Dominguez11");
-ref_ptr<PhotonField> IRB_Gilmore12 = new TabularPhotonField("IRB_Gilmore12");
-ref_ptr<PhotonField> IRB_Stecker16_upper = new TabularPhotonField("IRB_Stecker16_upper");
-ref_ptr<PhotonField> IRB_Stecker16_lower = new TabularPhotonField("IRB_Stecker16_lower");
-
 // ElectronPairProduction -----------------------------------------------------
 TEST(ElectronPairProduction, allBackgrounds) {
 	// Test if interaction data files are loaded.
-	ElectronPairProduction epp(CMB);
-	epp.setPhotonField(IRB_Kneiske04);
-	epp.setPhotonField(IRB_Stecker05);
-	epp.setPhotonField(IRB_Franceschini08);
-	epp.setPhotonField(IRB_Finke10);
-	epp.setPhotonField(IRB_Dominguez11);
-	epp.setPhotonField(IRB_Gilmore12);
-	epp.setPhotonField(IRB_Stecker16_upper);
-	epp.setPhotonField(IRB_Stecker16_lower);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ElectronPairProduction epp(CMB_instance);
+	ref_ptr<PhotonField> IRB = new IRB_Kneiske04();
+	epp.setPhotonField(IRB);
+	IRB = new IRB_Stecker05();
+	epp.setPhotonField(IRB);
+	IRB = new IRB_Franceschini08();
+	epp.setPhotonField(IRB);
+	IRB = new IRB_Finke10();
+	epp.setPhotonField(IRB);
+	IRB = new IRB_Dominguez11();
+	epp.setPhotonField(IRB);
+	IRB = new IRB_Gilmore12();
+	epp.setPhotonField(IRB);
+	IRB = new IRB_Stecker16_upper();
+	epp.setPhotonField(IRB);
+	IRB = new IRB_Stecker16_lower();
+	epp.setPhotonField(IRB);
 }
 
 TEST(ElectronPairProduction, energyDecreasing) {
@@ -50,7 +47,8 @@ TEST(ElectronPairProduction, energyDecreasing) {
 	c.setCurrentStep(2 * Mpc);
 	c.current.setId(nucleusId(1, 1)); // proton
 
-	ElectronPairProduction epp1(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ElectronPairProduction epp1(CMB_instance);
 	for (int i = 0; i < 80; i++) {
 		double E = pow(10, 15 + i * 0.1) * eV;
 		c.current.setEnergy(E);
@@ -58,6 +56,7 @@ TEST(ElectronPairProduction, energyDecreasing) {
 		EXPECT_LE(c.current.getEnergy(), E);
 	}
 
+	ref_ptr<PhotonField> IRB = new IRB_Kneiske04();
 	ElectronPairProduction epp2(IRB);
 	for (int i = 0; i < 80; i++) {
 		double E = pow(10, 15 + i * 0.1) * eV;
@@ -69,7 +68,8 @@ TEST(ElectronPairProduction, energyDecreasing) {
 
 TEST(ElectronPairProduction, belowEnergyTreshold) {
 	// Test if nothing happens below 1e15 eV.
-	ElectronPairProduction epp(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ElectronPairProduction epp(CMB_instance);
 	Candidate c(nucleusId(1, 1), 1E14 * eV);
 	epp.process(&c);
 	EXPECT_DOUBLE_EQ(1E14 * eV, c.current.getEnergy());
@@ -77,7 +77,8 @@ TEST(ElectronPairProduction, belowEnergyTreshold) {
 
 TEST(ElectronPairProduction, thisIsNotNucleonic) {
 	// Test if non-nuclei are skipped.
-	ElectronPairProduction epp(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ElectronPairProduction epp(CMB_instance);
 	Candidate c(11, 1E20 * eV);  // electron
 	epp.process(&c);
 	EXPECT_DOUBLE_EQ(1E20 * eV, c.current.getEnergy());
@@ -104,8 +105,9 @@ TEST(ElectronPairProduction, valuesCMB) {
 	Candidate c;
 	c.setCurrentStep(1 * Mpc);
 	c.current.setId(nucleusId(1, 1)); // proton
+	ref_ptr<PhotonField> CMB_instance = new CMB();
 
-	ElectronPairProduction epp(CMB);
+	ElectronPairProduction epp(CMB_instance);
 	for (int i = 0; i < x.size(); i++) {
 		c.current.setEnergy(x[i]);
 		epp.process(&c);
@@ -136,6 +138,7 @@ TEST(ElectronPairProduction, valuesIRB) {
 	Candidate c;
 	c.setCurrentStep(1 * Mpc);
 	c.current.setId(nucleusId(1, 1)); // proton
+	ref_ptr<PhotonField> IRB = new IRB_Kneiske04();
 
 	ElectronPairProduction epp(IRB);
 	for (int i = 0; i < x.size(); i++) {
@@ -278,21 +281,31 @@ TEST(NuclearDecay, thisIsNotNucleonic) {
 // PhotoDisintegration --------------------------------------------------------
 TEST(PhotoDisintegration, allBackgrounds) {
 	// Test if interaction data files are loaded.
-	PhotoDisintegration pd(CMB);
-	pd.setPhotonField(IRB_Kneiske04);
-	pd.setPhotonField(IRB_Stecker05);
-	pd.setPhotonField(IRB_Franceschini08);
-	pd.setPhotonField(IRB_Finke10);
-	pd.setPhotonField(IRB_Dominguez11);
-	pd.setPhotonField(IRB_Gilmore12);
-	pd.setPhotonField(IRB_Stecker16_upper);
-	pd.setPhotonField(IRB_Stecker16_lower);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoDisintegration pd(CMB_instance);
+	ref_ptr<PhotonField> IRB = new IRB_Kneiske04();
+	pd.setPhotonField(IRB);
+	IRB = new IRB_Stecker05();
+	pd.setPhotonField(IRB);
+	IRB = new IRB_Franceschini08();
+	pd.setPhotonField(IRB);
+	IRB = new IRB_Finke10();
+	pd.setPhotonField(IRB);
+	IRB = new IRB_Dominguez11();
+	pd.setPhotonField(IRB);
+	IRB = new IRB_Gilmore12();
+	pd.setPhotonField(IRB);
+	IRB = new IRB_Stecker16_upper();
+	pd.setPhotonField(IRB);
+	IRB = new IRB_Stecker16_lower();
+	pd.setPhotonField(IRB);
 }
 
 TEST(PhotoDisintegration, carbon) {
 	// Test if a 100 EeV C-12 nucleus photo-disintegrates (at least once) over a distance of 1 Gpc.
 	// This test can stochastically fail.
-	PhotoDisintegration pd(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoDisintegration pd(CMB_instance);
 	Candidate c;
 	int id = nucleusId(12, 6);
 	c.current.setId(id);
@@ -327,6 +340,7 @@ TEST(PhotoDisintegration, carbon) {
 TEST(PhotoDisintegration, iron) {
 	// Test if a 200 EeV Fe-56 nucleus photo-disintegrates (at least once) over a distance of 1 Gpc.
 	// This test can stochastically fail.
+	ref_ptr<PhotonField> IRB = new IRB_Kneiske04();
 	PhotoDisintegration pd(IRB);
 	Candidate c;
 	int id = nucleusId(56, 26);
@@ -365,7 +379,8 @@ TEST(PhotoDisintegration, iron) {
 
 TEST(PhotoDisintegration, thisIsNotNucleonic) {
 	// Test that nothing happens to an electron.
-	PhotoDisintegration pd(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoDisintegration pd(CMB_instance);
 	Candidate c;
 	c.setCurrentStep(1 * Mpc);
 	c.current.setId(11); // electron
@@ -377,7 +392,8 @@ TEST(PhotoDisintegration, thisIsNotNucleonic) {
 
 TEST(PhotoDisintegration, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	PhotoDisintegration pd(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoDisintegration pd(CMB_instance);
 	Candidate c;
 	c.setNextStep(std::numeric_limits<double>::max());
 	c.current.setId(nucleusId(4, 2));
@@ -388,7 +404,9 @@ TEST(PhotoDisintegration, limitNextStep) {
 
 TEST(PhotoDisintegration, allIsotopes) {
 	// Test if all isotopes are handled.
-	PhotoDisintegration pd1(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoDisintegration pd1(CMB_instance);
+	ref_ptr<PhotonField> IRB = new IRB_Kneiske04();
 	PhotoDisintegration pd2(IRB);
 	Candidate c;
 	c.setCurrentStep(10 * Mpc);
@@ -409,7 +427,8 @@ TEST(PhotoDisintegration, allIsotopes) {
 
 TEST(Photodisintegration, updateParticleParentProperties)
 { // Issue: #204
-	PhotoDisintegration pd(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoDisintegration pd(CMB_instance);
 
 	Candidate c(nucleusId(56,26), 500 * EeV, Vector3d(1 * Mpc, 0, 0));
 
@@ -426,14 +445,17 @@ TEST(Photodisintegration, updateParticleParentProperties)
 // ElasticScattering ----------------------------------------------------------
 TEST(ElasticScattering, allBackgrounds) {
 	// Test if interaction data files are loaded.
-	ElasticScattering scattering(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ElasticScattering scattering(CMB_instance);
+	ref_ptr<PhotonField> IRB = new IRB_Kneiske04();
 	scattering.setPhotonField(IRB);
 }
 
 TEST(ElasticScattering, secondaries) {
 	// Test the creation of cosmic ray photons.
 	// This test can stochastically fail.
-	ElasticScattering scattering(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ElasticScattering scattering(CMB_instance);
 	Candidate c;
 	int id = nucleusId(12, 6);
 	c.current.setId(id);
@@ -455,21 +477,31 @@ TEST(ElasticScattering, secondaries) {
 // PhotoPionProduction --------------------------------------------------------
 TEST(PhotoPionProduction, allBackgrounds) {
 	// Test if all interaction data files can be loaded.
-	PhotoPionProduction ppp(CMB);
-	ppp.setPhotonField(IRB_Kneiske04);
-	ppp.setPhotonField(IRB_Stecker05);
-	ppp.setPhotonField(IRB_Franceschini08);
-	ppp.setPhotonField(IRB_Finke10);
-	ppp.setPhotonField(IRB_Dominguez11);
-	ppp.setPhotonField(IRB_Gilmore12);
-	ppp.setPhotonField(IRB_Stecker16_upper);
-	ppp.setPhotonField(IRB_Stecker16_lower);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoPionProduction ppp(CMB_instance);
+	ref_ptr<PhotonField> IRB = new IRB_Kneiske04();
+	ppp.setPhotonField(IRB);
+	IRB = new IRB_Stecker05();
+	ppp.setPhotonField(IRB);
+	IRB = new IRB_Franceschini08();
+	ppp.setPhotonField(IRB);
+	IRB = new IRB_Finke10();
+	ppp.setPhotonField(IRB);
+	IRB = new IRB_Dominguez11();
+	ppp.setPhotonField(IRB);
+	IRB = new IRB_Gilmore12();
+	ppp.setPhotonField(IRB);
+	IRB = new IRB_Stecker16_upper();
+	ppp.setPhotonField(IRB);
+	IRB = new IRB_Stecker16_lower();
+	ppp.setPhotonField(IRB);
 }
 
 TEST(PhotoPionProduction, proton) {
 	// Test photo-pion interaction for 100 EeV proton.
 	// This test can stochastically fail.
-	PhotoPionProduction ppp(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoPionProduction ppp(CMB_instance);
 	Candidate c(nucleusId(1, 1), 100 * EeV);
 	c.setCurrentStep(1000 * Mpc);
 	ppp.process(&c);
@@ -487,7 +519,8 @@ TEST(PhotoPionProduction, proton) {
 TEST(PhotoPionProduction, helium) {
 	// Test photo-pion interaction for 400 EeV He nucleus.
 	// This test can stochastically fail.
-	PhotoPionProduction ppp(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoPionProduction ppp(CMB_instance);
 	Candidate c;
 	c.current.setId(nucleusId(4, 2));
 	c.current.setEnergy(400 * EeV);
@@ -501,7 +534,8 @@ TEST(PhotoPionProduction, helium) {
 
 TEST(PhotoPionProduction, thisIsNotNucleonic) {
 	// Test if noting happens to an electron.
-	PhotoPionProduction ppp(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoPionProduction ppp(CMB_instance);
 	Candidate c;
 	c.current.setId(11); // electron
 	c.current.setEnergy(10 * EeV);
@@ -513,7 +547,8 @@ TEST(PhotoPionProduction, thisIsNotNucleonic) {
 
 TEST(PhotoPionProduction, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	PhotoPionProduction ppp(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoPionProduction ppp(CMB_instance);
 	Candidate c(nucleusId(1, 1), 200 * EeV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	ppp.process(&c);
@@ -523,7 +558,8 @@ TEST(PhotoPionProduction, limitNextStep) {
 TEST(PhotoPionProduction, secondaries) {
 	// Test photo-pion interaction for 100 EeV proton.
 	// This test can stochastically fail.
-	PhotoPionProduction ppp(CMB, true, true, true);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	PhotoPionProduction ppp(CMB_instance, true, true, true);
 	Candidate c(nucleusId(1, 1), 100 * EeV);
 	c.setCurrentStep(1000 * Mpc);
 	ppp.process(&c);
@@ -561,7 +597,8 @@ TEST(Redshift, limitRedshiftDecrease) {
 // EMPairProduction -----------------------------------------------------------
 TEST(EMPairProduction, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	EMPairProduction m(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	EMPairProduction m(CMB_instance);
 	Candidate c(22, 1E17 * eV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	m.process(&c);
@@ -570,13 +607,14 @@ TEST(EMPairProduction, limitNextStep) {
 
 TEST(EMPairProduction, secondaries) {
 	// Test if secondaries are correctly produced.
-	EMPairProduction m(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ref_ptr<PhotonField> IRB = new IRB_Gilmore12();
+	EMPairProduction m(CMB_instance);
 	m.setHaveElectrons(true);
 
 	std::vector< ref_ptr<PhotonField> > fields;
-	fields.push_back(CMB);
-	fields.push_back(IRB_Gilmore12);
-	// fields.push_back(URB_Protheroe96);
+	fields.push_back(CMB_instance);
+	fields.push_back(IRB);
 
 	// loop over photon backgrounds
 	for (int f = 0; f < fields.size(); f++) {
@@ -615,7 +653,8 @@ TEST(EMPairProduction, secondaries) {
 // EMDoublePairProduction -----------------------------------------------------
 TEST(EMDoublePairProduction, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	EMDoublePairProduction m(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	EMDoublePairProduction m(CMB_instance);
 	Candidate c(22, 1E17 * eV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	m.process(&c);
@@ -624,13 +663,14 @@ TEST(EMDoublePairProduction, limitNextStep) {
 
 TEST(EMDoublePairProduction, secondaries) {
 	// Test if secondaries are correctly produced.
-	EMDoublePairProduction m(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ref_ptr<PhotonField> IRB = new IRB_Gilmore12();
+	EMDoublePairProduction m(CMB_instance);
 	m.setHaveElectrons(true);
 
 	std::vector< ref_ptr<PhotonField> > fields;
-	fields.push_back(CMB);
-	fields.push_back(IRB_Gilmore12);
-	// fields.push_back(URB_Protheroe96);
+	fields.push_back(CMB_instance);
+	fields.push_back(IRB);
 
 	// loop over photon backgrounds
 	for (int f = 0; f < fields.size(); f++) {
@@ -669,7 +709,8 @@ TEST(EMDoublePairProduction, secondaries) {
 // EMTripletPairProduction ----------------------------------------------------
 TEST(EMTripletPairProduction, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	EMTripletPairProduction m(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	EMTripletPairProduction m(CMB_instance);
 	Candidate c(11, 1E17 * eV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	m.process(&c);
@@ -678,13 +719,14 @@ TEST(EMTripletPairProduction, limitNextStep) {
 
 TEST(EMTripletPairProduction, secondaries) {
 	// Test if secondaries are correctly produced.
-	EMTripletPairProduction m(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ref_ptr<PhotonField> IRB = new IRB_Gilmore12();
+	EMTripletPairProduction m(CMB_instance);
 	m.setHaveElectrons(true);
 
 	std::vector< ref_ptr<PhotonField> > fields;
-	fields.push_back(CMB);
-	fields.push_back(IRB_Gilmore12);
-	// fields.push_back(URB_Protheroe96);
+	fields.push_back(CMB_instance);
+	fields.push_back(IRB);
 
 	// loop over photon backgrounds
 	for (int f = 0; f < fields.size(); f++) {
@@ -726,7 +768,8 @@ TEST(EMTripletPairProduction, secondaries) {
 // EMInverseComptonScattering -------------------------------------------------
 TEST(EMInverseComptonScattering, limitNextStep) {
 	// Test if the interaction limits the next propagation step.
-	EMInverseComptonScattering m(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	EMInverseComptonScattering m(CMB_instance);
 	Candidate c(11, 1E17 * eV);
 	c.setNextStep(std::numeric_limits<double>::max());
 	m.process(&c);
@@ -735,13 +778,14 @@ TEST(EMInverseComptonScattering, limitNextStep) {
 
 TEST(EMInverseComptonScattering, secondaries) {
 	// Test if secondaries are correctly produced.
-	EMInverseComptonScattering m(CMB);
+	ref_ptr<PhotonField> CMB_instance = new CMB();
+	ref_ptr<PhotonField> IRB = new IRB_Gilmore12();
+	EMInverseComptonScattering m(CMB_instance);
 	m.setHavePhotons(true);
 
 	std::vector< ref_ptr<PhotonField> > fields;
-	fields.push_back(CMB);
-	fields.push_back(IRB_Gilmore12);
-	// fields.push_back(URB_Protheroe96);
+	fields.push_back(CMB_instance);
+	fields.push_back(IRB);
 
 	// loop over photon backgrounds
 	for (int f = 0; f < fields.size(); f++) {

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -573,7 +573,7 @@ TEST(EMPairProduction, secondaries) {
 	EMPairProduction m(CMB);
 	m.setHaveElectrons(true);
 
-	std::vector<PhotonField> fields;
+	std::vector< ref_ptr<PhotonField> > fields;
 	fields.push_back(CMB);
 	fields.push_back(IRB_Gilmore12);
 	// fields.push_back(URB_Protheroe96);

--- a/test/testInteraction.cpp
+++ b/test/testInteraction.cpp
@@ -627,7 +627,7 @@ TEST(EMDoublePairProduction, secondaries) {
 	EMDoublePairProduction m(CMB);
 	m.setHaveElectrons(true);
 
-	std::vector<PhotonField> fields;
+	std::vector< ref_ptr<PhotonField> > fields;
 	fields.push_back(CMB);
 	fields.push_back(IRB_Gilmore12);
 	// fields.push_back(URB_Protheroe96);
@@ -681,7 +681,7 @@ TEST(EMTripletPairProduction, secondaries) {
 	EMTripletPairProduction m(CMB);
 	m.setHaveElectrons(true);
 
-	std::vector<PhotonField> fields;
+	std::vector< ref_ptr<PhotonField> > fields;
 	fields.push_back(CMB);
 	fields.push_back(IRB_Gilmore12);
 	// fields.push_back(URB_Protheroe96);
@@ -738,7 +738,7 @@ TEST(EMInverseComptonScattering, secondaries) {
 	EMInverseComptonScattering m(CMB);
 	m.setHavePhotons(true);
 
-	std::vector<PhotonField> fields;
+	std::vector< ref_ptr<PhotonField> > fields;
 	fields.push_back(CMB);
 	fields.push_back(IRB_Gilmore12);
 	// fields.push_back(URB_Protheroe96);

--- a/test/testSimulationExecution.py
+++ b/test/testSimulationExecution.py
@@ -25,8 +25,8 @@ class test1DChainWithSecondaries(unittest.TestCase):
         sim = crp.ModuleList()
 
         # photon fields
-        CMB = crp.PhotonField("CMB")
-        IRB = crp.PhotonField("IRB_Kneiske04")
+        CMB = crp.BlackbodyPhotonField("CMB", 2.73)
+        IRB = crp.TabularPhotonField("IRB_Kneiske04")
 
         sim.add(crp.SimplePropagation(1 * crp.kpc, 1 * crp.Mpc))
         sim.add(crp.Redshift())

--- a/test/testSimulationExecution.py
+++ b/test/testSimulationExecution.py
@@ -25,8 +25,8 @@ class test1DChainWithSecondaries(unittest.TestCase):
         sim = crp.ModuleList()
 
         # photon fields
-        CMB = crp.BlackbodyPhotonField("CMB", 2.73)
-        IRB = crp.TabularPhotonField("IRB_Kneiske04")
+        CMB = crp.CMB()
+        IRB = crp.IRB_Kneiske04()
 
         sim.add(crp.SimplePropagation(1 * crp.kpc, 1 * crp.Mpc))
         sim.add(crp.Redshift())

--- a/test/testSimulationExecution.py
+++ b/test/testSimulationExecution.py
@@ -24,15 +24,19 @@ class test1DChainWithSecondaries(unittest.TestCase):
 
         sim = crp.ModuleList()
 
+        # photon fields
+        CMB = crp.PhotonField("CMB")
+        IRB = crp.PhotonField("IRB_Kneiske04")
+
         sim.add(crp.SimplePropagation(1 * crp.kpc, 1 * crp.Mpc))
         sim.add(crp.Redshift())
-        sim.add(crp.PhotoPionProduction(crp.CMB))
-        sim.add(crp.PhotoPionProduction(crp.IRB))
-        sim.add(crp.PhotoDisintegration(crp.CMB))
-        sim.add(crp.PhotoDisintegration(crp.IRB))
+        sim.add(crp.PhotoPionProduction(CMB))
+        sim.add(crp.PhotoPionProduction(IRB))
+        sim.add(crp.PhotoDisintegration(CMB))
+        sim.add(crp.PhotoDisintegration(IRB))
         sim.add(crp.NuclearDecay())
-        sim.add(crp.ElectronPairProduction(crp.CMB))
-        sim.add(crp.ElectronPairProduction(crp.IRB))
+        sim.add(crp.ElectronPairProduction(CMB))
+        sim.add(crp.ElectronPairProduction(IRB))
         sim.add(crp.MinimumEnergy(1 * crp.EeV))
         sim.add(crp.EMCascade())
 


### PR DESCRIPTION
Hi everyone,

as we had discussed previously, the way of how photon fields are implemented in CRPropa needs an overhaul and where reasonable should converge towards the user-concept of magnetic fields. It is also mandatory for variable photon fields to be introduced although this PR constrains itself to the currently available photon fields.

This PR should provide an advanced draft of how such an implementation could look like. The main features are:

1) A user can call a PhotonField object in the steering file, modify it, and pass it to an interaction module as it is currently possible with B-fields. An example of how this looks like is
```
CMB = PhotonField("CMB")
ppp = PhotoPionProduction(CMB)
```

2) Interaction modules infer most photon field data from this PhotonField class. This includes the photon field density in dependence of energy and redshift, the redshift scaling factor and other parameters relevant to the photon field. Shared data files are untouched and still required by all relevant interaction modules. Features coming with this implementation are:
```
In  [1]: IRB = PhotonField("IRB_Kneiske04")

In  [2]: IRB.getFieldName()
Out [2]: "IRB_Kneiske04"

In  [3]: IRB.getHasRedshiftDependence()
Out [3]: True

In  [4]: IRB.getPhotonDensity(1 * eV, 2.1)
Out [4]: 540.77
```

3) The concept of externally defined redshift scaling factors, currently existing as shared data files, is abandoned in favor of an internal scaling factor computation from the information about the photon field itself. This was never a function the user had access to and was inferred by interaction modules to modify the interaction rate with redshift. Now one can type:
```
In  [5]: IRB.getRedshiftScaling(3.14)
Out [5]: 0.114
```
4) All photon field data is inferred from a single point defining the entire photon field. For the time being, in this draft, the photon field data is available from the ```~/Scaling/``` directory in CRPropa in the form of 3 separate files:
* photonEnergy_fieldName.txt - photon energies [J] where the field is defined
* redshift_fieldName.txt - redshifts where the field is defined (if this file doesn't exist the field is initialized with no redshift dependence)
* photonDensity_fieldName.txt comoving photon number density [1/m³]. The length of this file is either equal to photonEnergy (if no redshift dependence) or equal to len(photonEnergy) * len(redshift).
* photonEnergy and redshift do not need to be equidistant
* The three input files are checked for basic correctness upon initialisation of the photon field (correct file lengths, photonEnergies and redshift >=0 & increasing, photonDensity >= 0)

-------------------------------
**How this PR is structured:**
It might look scary at first glance due to the large amount of files modified. However, this is a minimal example of what would have to be modified, thus we do not get around to modifying a couple of files simultaneously. Yet, the type of modifications make quite clear what happened here:

1) PhotonBackground.cpp /.h
The core part: removal of enum environment for photon fields, static name-getter methods and redshift scaling class. Addition of PhotonField class
2) interactionModules .h (8x)
In the header file, the defaulting to the CMB has been disabled. What behaviour is that anyways?
3) interactionModules .cpp (8x)
Replace name-getter and redshift scaling methods by call to PhotonField class
4) testInteraction.cpp
Updated call to modules, declare all photon fields according to PhotonField syntax. Passes all tests.

-------------------------------
**Tests and supporting files**

If you pull this branch you need to generate the 3 photon-field defining data files for each photon field. This can be done in one single call of these [auxfiles.zip](https://github.com/CRPropa/CRPropa3/files/4519070/auxfiles.zip). The first you do here is to run convert_photonFields.py in the main directory of your pulled CRPropa-data clone and have the file outputted all the relevant files which then need to go into ```~/Scaling/``` or your CRPropa shared file section. The other file plot_IRB_parameters.py plots some data of the fields and compares to some aspects of the old functions. Examples include:

The photon densities of the IRB fields:
![all IRB models @ z0 0](https://user-images.githubusercontent.com/16683448/80035643-a694ab80-84f0-11ea-8f72-75679d12367f.png)

And the comparison of the internally generated redshift scaling factors to the externally generated factors generated by calc_scaling.py in the CRPropa-data repo.
![all_IRB_scalingRatios](https://user-images.githubusercontent.com/16683448/80035678-b8764e80-84f0-11ea-8f52-e494b4aaa3af.png)

And as always, I'm thrilled to know about your thoughts!
Cheers,
Mario