### PR TITLE
Minimum energy for specific types of particles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,6 @@ option(ENABLE_TESTING "Build tests and enable test target" ON)
 if(ENABLE_TESTING)
 	include_directories(libs/gtest/include)
 	add_subdirectory(libs/gtest)
-	list(APPEND CRPROPA_EXTRA_LIBRARIES gtest)
-	list(APPEND CRPROPA_EXTRA_INCLUDES libs/gtest/include)
 	if(APPLE)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1")
 	endif(APPLE)
@@ -484,7 +482,6 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include FILES_MATCHIN
 install(DIRECTORY ${CMAKE_BINARY_DIR}/data/ DESTINATION share/crpropa/ PATTERN ".git" EXCLUDE)
 
 install(DIRECTORY libs/kiss/include/ DESTINATION include)
-install(DIRECTORY libs/gtest/include/ DESTINATION include)
 
 # ------------------------------------------------------------------
 # Documentation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ option(ENABLE_TESTING "Build tests and enable test target" ON)
 if(ENABLE_TESTING)
 	include_directories(libs/gtest/include)
 	add_subdirectory(libs/gtest)
+	list(APPEND CRPROPA_EXTRA_LIBRARIES gtest)
+	list(APPEND CRPROPA_EXTRA_INCLUDES libs/gtest/include)
 	if(APPLE)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_USE_OWN_TR1_TUPLE=1")
 	endif(APPLE)
@@ -482,6 +484,7 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include FILES_MATCHIN
 install(DIRECTORY ${CMAKE_BINARY_DIR}/data/ DESTINATION share/crpropa/ PATTERN ".git" EXCLUDE)
 
 install(DIRECTORY libs/kiss/include/ DESTINATION include)
+install(DIRECTORY libs/gtest/include/ DESTINATION include)
 
 # ------------------------------------------------------------------
 # Documentation

--- a/include/crpropa/module/BreakCondition.h
+++ b/include/crpropa/module/BreakCondition.h
@@ -102,6 +102,28 @@ public:
 };
 
 /**
+ @class MinimumEnergyParticle
+ @brief Deactivates the candidate below a minimum energy for specific particle Ids.
+
+ This modules deactivates the candidate below a given minimum energy for specific particle types.
+ In that case the property ("Deactivated", module::description) is set.
+ Care should be taken when calling this module multiple times (use consistent global energy).
+ */
+class MinimumEnergyParticle: public AbstractCondition {
+	std::vector<double> minEnergies;
+	std::vector<int> particleIds;
+	double minEnergyGlobal;
+public:
+	MinimumEnergyParticle(double minEnergyGlobal = 0);
+	void setMinimumGlobalEnergy(double energy);
+	double getMinimumGlobalEnergy() const;
+	void add(int id, double energy);
+	std::string getDescription() const;
+	void process(Candidate *candidate) const;
+};
+
+
+/**
  @class DetectionLength
  @brief Detects the candidate at a given trajectoryLength
  

--- a/include/crpropa/module/BreakCondition.h
+++ b/include/crpropa/module/BreakCondition.h
@@ -102,21 +102,21 @@ public:
 };
 
 /**
- @class MinimumEnergyParticle
+ @class MinimumEnergyPerParticleId
  @brief Deactivates the candidate below a minimum energy for specific particle Ids.
 
  This modules deactivates the candidate below a given minimum energy for specific particle types.
  In that case the property ("Deactivated", module::description) is set.
- Care should be taken when calling this module multiple times (use consistent global energy).
+ All particles whose minimum energies are not specified follow the more general minEnergyOthers condition.
  */
-class MinimumEnergyParticle: public AbstractCondition {
+class MinimumEnergyPerParticleId: public AbstractCondition {
 	std::vector<double> minEnergies;
 	std::vector<int> particleIds;
-	double minEnergyGlobal;
+	double minEnergyOthers;
 public:
-	MinimumEnergyParticle(double minEnergyGlobal = 0);
-	void setMinimumGlobalEnergy(double energy);
-	double getMinimumGlobalEnergy() const;
+	MinimumEnergyPerParticleId(double minEnergyOthers = 0);
+	void setMinimumEnergyOthers(double energy);
+	double getMinimumEnergyOthers() const;
 	void add(int id, double energy);
 	std::string getDescription() const;
 	void process(Candidate *candidate) const;

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -205,6 +205,19 @@ public:
 };
 
 /**
+ @class ObserverCustomVeto
+ @brief Custom veto for user-defined particle types.
+ */
+class ObserverCustomVeto: public ObserverFeature {
+private:
+	int vetoParticleId;
+public:
+	ObserverCustomVeto(int pId);
+	DetectionState checkDetection(Candidate *candidate) const;
+	std::string getDescription() const;
+};
+
+/**
  @class ObserverTimeEvolution
  @brief Observes the time evolution of the candidates (phase-space elements)
  This observer is very useful if the time evolution of the particle density is needed. It detects all candidates in regular timeintervals and limits the nextStep of candidates to prevent overshooting of detection intervals.

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -205,14 +205,14 @@ public:
 };
 
 /**
- @class ObserverCustomVeto
+ @class ObserverParticleIdVeto
  @brief Custom veto for user-defined particle types.
  */
-class ObserverCustomVeto: public ObserverFeature {
+class ObserverParticleIdVeto: public ObserverFeature {
 private:
 	int vetoParticleId;
 public:
-	ObserverCustomVeto(int pId);
+	ObserverParticleIdVeto(int pId);
 	DetectionState checkDetection(Candidate *candidate) const;
 	std::string getDescription() const;
 };

--- a/src/module/BreakCondition.cpp
+++ b/src/module/BreakCondition.cpp
@@ -182,41 +182,42 @@ std::string MinimumChargeNumber::getDescription() const {
 }
 
 //*****************************************************************************
-MinimumEnergyParticle::MinimumEnergyParticle(double minEnergyGlobal) {
-	setMinimumGlobalEnergy(minEnergyGlobal);
+MinimumEnergyPerParticleId::MinimumEnergyPerParticleId(double minEnergyOthers) {
+	setMinimumEnergyOthers(minEnergyOthers);
 }
 
-void MinimumEnergyParticle::add(int id, double energy) {
+void MinimumEnergyPerParticleId::add(int id, double energy) {
 	particleIds.push_back(id);
 	minEnergies.push_back(energy);
 }
 
-void MinimumEnergyParticle::setMinimumGlobalEnergy(double energy) {
-	minEnergyGlobal = energy;
+void MinimumEnergyPerParticleId::setMinimumEnergyOthers(double energy) {
+	minEnergyOthers = energy;
 }
 
-double MinimumEnergyParticle::getMinimumGlobalEnergy() const {
-	return minEnergyGlobal;
+double MinimumEnergyPerParticleId::getMinimumEnergyOthers() const {
+	return minEnergyOthers;
 }
 
-void MinimumEnergyParticle::process(Candidate *c) const {
+void MinimumEnergyPerParticleId::process(Candidate *c) const {
 	for (int i = 0; i < particleIds.size(); i++) {
 		if (c->current.getId() == particleIds[i]) {
-			if (c->current.getEnergy() < minEnergies[i]) {
+			if (c->current.getEnergy() < minEnergies[i])
 				reject(c);
-			} else
+			else
 				return;
 		}
 	}
-	if (c->current.getEnergy() < minEnergyGlobal)
+
+	if (c->current.getEnergy() < minEnergyOthers)
 		reject(c);
 	else
 		return;
 }
 
-std::string MinimumEnergyParticle::getDescription() const {
+std::string MinimumEnergyPerParticleId::getDescription() const {
 	std::stringstream s;
-	s << "Minimum energy global: " << minEnergyGlobal / eV << " eV";
+	s << "Minimum energy for non-specified particles: " << minEnergyOthers / eV << " eV";
 	for (int i = 0; i < minEnergies.size(); i++) {
 		s << "  for particle " << particleIds[i] << " : " << minEnergies[i] / eV << " eV";
 	}

--- a/src/module/BreakCondition.cpp
+++ b/src/module/BreakCondition.cpp
@@ -182,6 +182,52 @@ std::string MinimumChargeNumber::getDescription() const {
 }
 
 //*****************************************************************************
+MinimumEnergyParticle::MinimumEnergyParticle(double minEnergyGlobal) {
+	setMinimumGlobalEnergy(minEnergyGlobal);
+}
+
+void MinimumEnergyParticle::add(int id, double energy) {
+	particleIds.push_back(id);
+	minEnergies.push_back(energy);
+}
+
+void MinimumEnergyParticle::setMinimumGlobalEnergy(double energy) {
+	minEnergyGlobal = energy;
+}
+
+double MinimumEnergyParticle::getMinimumGlobalEnergy() const {
+	return minEnergyGlobal;
+}
+
+void MinimumEnergyParticle::process(Candidate *c) const {
+	for (int i = 0; i < particleIds.size(); i++) {
+		if (c->current.getId() == particleIds[i]) {
+			if (c->current.getEnergy() < minEnergies[i]) {
+				reject(c);
+			} else
+				return;
+		}
+	}
+	if (c->current.getEnergy() < minEnergyGlobal)
+		reject(c);
+	else
+		return;
+}
+
+std::string MinimumEnergyParticle::getDescription() const {
+	std::stringstream s;
+	s << "Minimum energy global: " << minEnergyGlobal / eV << " eV";
+	for (int i = 0; i < minEnergies.size(); i++) {
+		s << "  for particle " << particleIds[i] << " : " << minEnergies[i] / eV << " eV";
+	}
+	s << "Flag: '" << rejectFlagKey << "' -> '" << rejectFlagValue << "', ";
+	s << "MakeInactive: " << (makeRejectedInactive ? "yes" : "no");
+	if (rejectAction.valid())
+		s << ", Action: " << rejectAction->getDescription();
+	return s.str();
+}
+
+//*****************************************************************************
 DetectionLength::DetectionLength(double detLength) :
 		detLength(detLength) {
 }

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -304,6 +304,22 @@ std::string ObserverElectronVeto::getDescription() const {
 	return "ObserverElectronVeto";
 }
 
+// ObserverCustomVeto -------------------------------------------------------
+ObserverCustomVeto::ObserverCustomVeto(int pId) {
+	vetoParticleId = pId;
+}
+
+DetectionState ObserverCustomVeto::checkDetection(Candidate *c) const {
+	if (c->current.getId() == vetoParticleId)
+		return VETO;
+	return NOTHING;
+}
+
+std::string ObserverCustomVeto::getDescription() const {
+	return "ObserverCustomVeto";
+}
+
+
 // ObserverTimeEvolution --------------------------------------------------------
 ObserverTimeEvolution::ObserverTimeEvolution() {}
 

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -305,18 +305,18 @@ std::string ObserverElectronVeto::getDescription() const {
 }
 
 // ObserverCustomVeto -------------------------------------------------------
-ObserverCustomVeto::ObserverCustomVeto(int pId) {
+ObserverParticleIdVeto::ObserverParticleIdVeto(int pId) {
 	vetoParticleId = pId;
 }
 
-DetectionState ObserverCustomVeto::checkDetection(Candidate *c) const {
+DetectionState ObserverParticleIdVeto::checkDetection(Candidate *c) const {
 	if (c->current.getId() == vetoParticleId)
 		return VETO;
 	return NOTHING;
 }
 
-std::string ObserverCustomVeto::getDescription() const {
-	return "ObserverCustomVeto";
+std::string ObserverParticleIdVeto::getDescription() const {
+	return "ObserverParticleIdVeto";
 }
 
 

--- a/test/testBreakCondition.cpp
+++ b/test/testBreakCondition.cpp
@@ -53,8 +53,8 @@ TEST(MinimumChargeNumber, test) {
 	EXPECT_TRUE(c.hasProperty("Rejected"));
 }
 
-TEST(MinimumEnergyParticle, test) {
-	MinimumEnergyParticle minEnergy(1);
+TEST(MinimumEnergyPerParticleId, test) {
+	MinimumEnergyPerParticleId minEnergy(1);
 	minEnergy.add(22, 10);
 	minEnergy.add(12, 2);
 	minEnergy.add(11, 20);

--- a/test/testBreakCondition.cpp
+++ b/test/testBreakCondition.cpp
@@ -53,6 +53,49 @@ TEST(MinimumChargeNumber, test) {
 	EXPECT_TRUE(c.hasProperty("Rejected"));
 }
 
+TEST(MinimumEnergyParticle, test) {
+	MinimumEnergyParticle minEnergy(1);
+	minEnergy.add(22, 10);
+	minEnergy.add(12, 2);
+	minEnergy.add(11, 20);
+
+	Candidate c;
+
+	c.current.setEnergy(20);
+	c.current.setId(22);
+	minEnergy.process(&c);
+	EXPECT_TRUE(c.isActive());
+
+	c.current.setEnergy(5);
+	c.current.setId(22);
+	minEnergy.process(&c);
+	EXPECT_FALSE(c.isActive());
+	EXPECT_TRUE(c.hasProperty("Rejected"));
+
+	c.setActive(true);
+	c.removeProperty("Rejected");
+
+	c.current.setEnergy(10);
+	c.current.setId(11);
+	minEnergy.process(&c);
+	EXPECT_FALSE(c.isActive());
+	EXPECT_TRUE(c.hasProperty("Rejected"));
+
+	c.setActive(true);
+	c.removeProperty("Rejected");
+
+	c.current.setEnergy(5);
+	c.current.setId(12);
+	minEnergy.process(&c);
+	EXPECT_TRUE(c.isActive());	
+
+	c.current.setEnergy(0.1);
+	c.current.setId(12);
+	minEnergy.process(&c);
+	EXPECT_FALSE(c.isActive());
+	EXPECT_TRUE(c.hasProperty("Rejected"));
+}
+
 TEST(MaximumTrajectoryLength, test) {
 	MaximumTrajectoryLength maxLength(10);
 	Candidate c;


### PR DESCRIPTION
- Allows user-written plugins to access the googletest suite by installing them.

- Provides functionalities to apply a minimum energy break condition for specific types of particles (useful for CR-induced cascades, for example).

The name MinimumEnergyParticle is probably not the best, but I couldn't think of anything better than this... or MinimumEnergySpecificTypesOfParticles.
