### PR TITLE
Automatic coverage reports through coveralls.io service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ addons:
         - gcc-6
         - g++-6
         - gfortran-6
+        - gcc-9
+        - g++-9
+        - gfortran-9
         - swig
         - libfftw3-dev
         - libcfitsio-dev
@@ -26,6 +29,7 @@ addons:
         - graphviz
         - pandoc
         - python3-pip
+        - lcov
       sources: &sources
         - ubuntu-toolchain-r-test
 cache:
@@ -40,6 +44,13 @@ matrix:
         - COMPILER_NAME=gcc CXX=g++-6 CC=gcc-6 FC=gfortran-6
         - PYTHON_EXECUTABLE=/usr/bin/python3
         - BUILD_DOC=true
+    - os : linux
+      dist: bionic
+      compiler: gcc
+      env:
+        - COMPILER_NAME=gcc CXX=g++-9 CC=gcc-9 FC=gfortran-9
+        - PYTHON_EXECUTABLE=/usr/bin/python3
+        - COVERALLS=true
     - os : linux
       dist: bionic
       compiler: clang
@@ -75,6 +86,10 @@ before_install:
       HOMEBREW_NO_AUTO_UPDATE=1 brew install gcc || true;
       HOMEBREW_NO_AUTO_UPDATE=1 brew link --overwrite gcc;
     fi;
+  - |
+    if [ $COVERALLS ]; then
+      pip install --user cpp-coveralls
+    fi;
 
 before_script:
   - mkdir build
@@ -85,7 +100,12 @@ before_script:
       echo "Using data file from cache!"
       cp $DATAFILE .
     fi
-  - cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE -DENABLE_TESTING=On
+  - |
+    if [ $COVERALLS ]; then
+        cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE -DENABLE_TESTING=On -DCMAKE_BUILD_TYPE:STRING=Debug -DENABLE_COVERAGE=TRUE
+    else
+        cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE -DENABLE_TESTING=On
+    fi
   - cp data.tar.gz $HOME/crpropa_cache
 script:
   - VERBOSE=1 make
@@ -127,4 +147,7 @@ after_success:
       git -c user.name='travis' -c user.email='travis' commit -m `echo Build_$TRAVIS_COMMIT` index.html
       git push
       cd ..
-    fi
+    fi;
+    if [ $COVERALLS ]; then
+        coveralls --gcov /usr/bin/gcov-9 --gcov-options '\-lp' --root $HOME/build/CRPropa/CRPropa3 --build-root $HOME/build/CRPropa/CRPropa3/build --include src --include include --exclude ".*CMakeFiles.*" --exclude libs --exclude test
+    fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,8 @@ matrix:
       dist: bionic
       compiler: gcc
       env:
-        - COMPILER_NAME=gcc CXX=g++-6 CC=gcc-6 FC=gfortran-6
-        - PYTHON_EXECUTABLE=/usr/bin/python3
-        - BUILD_DOC=true
+         - COMPILER_NAME=gcc CXX=g++-6 CC=gcc-6 FC=gfortran-6
+         - PYTHON_EXECUTABLE=/usr/bin/python2
     - os : linux
       dist: bionic
       compiler: gcc
@@ -53,21 +52,16 @@ matrix:
         - COVERALLS=true
     - os : linux
       dist: bionic
+      compiler: gcc
+      env:
+        - COMPILER_NAME=gcc CXX=g++-6 CC=gcc-6 FC=gfortran-6
+        - PYTHON_EXECUTABLE=/usr/bin/python3
+        - BUILD_DOC=true
+    - os : linux
+      dist: bionic
       compiler: clang
       env:
         - PYTHON_EXECUTABLE=/usr/bin/python3 FC=gfortran-6
-        - LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH
-    - os : linux
-      dist: bionic
-      compiler: gcc
-      env:
-         - COMPILER_NAME=gcc CXX=g++-6 CC=gcc-6 FC=gfortran-6
-         - PYTHON_EXECUTABLE=/usr/bin/python2
-    - os : linux
-      dist: bionic
-      compiler: clang
-      env:
-        - PYTHON_EXECUTABLE=/usr/bin/python2 FC=gfortran-6
         - LD_LIBRARY_PATH=/usr/local/clang/lib:$LD_LIBRARY_PATH
     - os : osx
       compiler: clang


### PR DESCRIPTION
I think that coverage reports are rarely (if ever?) used when people (including CRPropa developers) compile the code offline since it is slowing down the compilation and an additional flag in CMake has to be turned on. Thus, I propose with this PR that we introduce automatic coverage which will be executed by TravisCI and pushed to free-for-free-software service Coveralls.io. This will be integrated with the GitHub workflow and advise all of us that we need to cover the code with tests. Consequently, the quality of the code will be higher. 