### PR TITLE
Improvement SourceEmissionCone:

### DIFF
--- a/include/crpropa/Source.h
+++ b/include/crpropa/Source.h
@@ -447,6 +447,7 @@ class SourceEmissionCone: public SourceFeature {
 public:
 	SourceEmissionCone(Vector3d direction, double aperture);
 	void prepareParticle(ParticleState &particle) const;
+	void setDirection(Vector3d direction);
 	void setDescription();
 };
 

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -795,13 +795,23 @@ void SourceEmissionMap::setEmissionMap(EmissionMap *emissionMap) {
 
 // ----------------------------------------------------------------------------
 SourceEmissionCone::SourceEmissionCone(Vector3d direction, double aperture) :
-		direction(direction), aperture(aperture) {
+	aperture(aperture) {
+	setDirection(direction);
 	setDescription();
+	
 }
 
 void SourceEmissionCone::prepareParticle(ParticleState& particle) const {
 	Random &random = Random::instance();
 	particle.setDirection(random.randConeVector(direction, aperture));
+}
+
+void SourceEmissionCone::setDirection(Vector3d dir) {
+	if (dir.getR() == 0) {
+		throw std::runtime_error("SourceEmissionCone: The direction vector was a null vector.");
+	} else {
+		direction = dir.getUnitVector();
+	}
 }
 
 void SourceEmissionCone::setDescription() {

--- a/test/testSource.cpp
+++ b/test/testSource.cpp
@@ -252,6 +252,18 @@ TEST(SourceComposition, simpleTest) {
 	EXPECT_GE(6 * Rmax, p.getEnergy());
 }
 
+TEST(SourceEmissionCone, simpleTest) {
+	Vector3d direction(42., 0., 0.);
+	double aperture = 1/42.;
+	
+	SourceEmissionCone source(direction, aperture);
+	
+	ParticleState p;
+	source.prepareParticle(p);
+	double angle = direction.getAngleTo(p.getDirection());
+	EXPECT_LE(angle, aperture);
+}
+
 #ifdef CRPROPA_HAVE_MUPARSER
 TEST(SourceGenericComposition, simpleTest) {
 	double Emin = 10;


### PR DESCRIPTION
Implement normalization of the direction vector.

When used with very large numbers the SourceEmissionCone source feature would deliver sometimes NANs in the prepared particle direction. 

This bug(?) was found by @JonPaulLundquist. I could reproduce it with the attached script and solved the issue by implementing a normalization routine for the source feature. A simple test was added additionally.


`from crpropa import *`
`direction = Vector3d(1e20, -2e22, 1e21)`
``
`s = Source()`
`s.add(SourceParticleType(nucleusId(1, 1)))`
`s.add(SourceEmissionCone(direction, 0.1))`
``
`while True:`
`Dir = s.getCandidate().source.getDirection()`
`    if Dir.x != Dir.x:`
`        print Dir`
`        break`