### PR TITLE
Basic file versioning of the data archive in CMakeLists.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,8 @@ before_script:
   - mkdir build
   - cd build
   - |
-    DATAFILE=$HOME/crpropa_cache/data.tar.gz
+    CRPROPA_DATAFILE_VER=`grep "CRPROPA_DATAFILE_VER " $TRAVIS_BUILD_DIR/CMakeLists.txt | cut -d \" -f2`
+    DATAFILE=$HOME/crpropa_cache/data-$CRPROPA_DATAFILE_VER.tar.gz
     if [ -f $DATAFILE ]; then
       echo "Using data file from cache!"
       cp $DATAFILE .
@@ -100,7 +101,7 @@ before_script:
     else
         cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE -DENABLE_TESTING=On
     fi
-  - cp data.tar.gz $HOME/crpropa_cache
+  - cp data-$CRPROPA_DATAFILE_VER.tar.gz $HOME/crpropa_cache
 script:
   - VERBOSE=1 make
   - make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Planck JF12b variant of the JF12Field. See arXiv:1601.00546. Thanks to
 	Mikhail Zotov for contributing.
 * ParticleCollector can provide Candidates directly to ModuleList::run
+* Basic file versioning of the data archive in CMakeLists.txt
 
 ### Interface change:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,24 +313,25 @@ endif(APPLE)
 # Download data files (interaction data, masses, decay data ...)
 # ----------------------------------------------------------------------------
 OPTION(DOWNLOAD_DATA "Download CRProap Data files" ON)
+set(CRPROPA_DATAFILE_VER "2017-11-09")
 if(DOWNLOAD_DATA)
 	message("-- Downloading data file from crpropa.desy.de ~ 50 MB")
 	file(DOWNLOAD
-		https://www.desy.de/~crpropa/data/interaction_data/data.tar.gz-CHECKSUM
-		${CMAKE_BINARY_DIR}/data.tar.gz-CHECKSUM)
-	file(STRINGS ${CMAKE_BINARY_DIR}/data.tar.gz-CHECKSUM DATA_CHECKSUM LIMIT_COUNT 1 LENGTH_MINIMUM 32 LENGTH_MAXIMUM 32)
+		https://www.desy.de/~crpropa/data/interaction_data/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM
+		${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM)
+	file(STRINGS ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM DATA_CHECKSUM LIMIT_COUNT 1 LENGTH_MINIMUM 32 LENGTH_MAXIMUM 32)
 	file(DOWNLOAD
-		https://www.desy.de/~crpropa/data/interaction_data/data.tar.gz
-		${CMAKE_BINARY_DIR}/data.tar.gz
+		https://www.desy.de/~crpropa/data/interaction_data/data-${CRPROPA_DATAFILE_VER}.tar.gz
+		${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz
 		EXPECTED_MD5 "${DATA_CHECKSUM}")
 	message("-- Extracting data file")
 else()
 	message("-- Downloading of data file disabled")
 endif(DOWNLOAD_DATA)
-if(EXISTS ${CMAKE_BINARY_DIR}/data.tar.gz)
-	execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_BINARY_DIR}/data.tar.gz WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+if(EXISTS ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz)
+	execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 else()
-	message(WARNING "CRPropa data file not found at ${CMAKE_BINARY_DIR}/data.tar.gz
+	message(WARNING "CRPropa data file not found at ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz
 CRPropa should compile, but will likely not work properly! Please install data file manually, or use the automatic download which is enabled by default.")
 endif()
 

--- a/doc/pages/Data-files.md
+++ b/doc/pages/Data-files.md
@@ -1,24 +1,26 @@
 CRPropa needs a number of data files to run. These include databases for nuclear mass and decay rates, interaction rates for photodisintegration, photo-pion production and electron-pair production, as well as the data files for DINT and EleCa.
 The scripts and files that are used to prepare the data files are tracked by the [CRPropa3-data repository](https://github.com/CRPropa/CRPropa3-data).
 
-Since a git repository is not well suited to store these large files, they are downloaded automatically during cmake configuration. In case you want to use a different photodisintegration model or want to download the default data file manually use the following [link](https://www.desy.de/~crpropa/data/interaction_data/) to the tarballs files and extract them to your install folder.
+Since a git repository is not well suited to store these large files (and git-lfs is not free on GitHub), the data files are downloaded automatically during cmake configuration. In case you want to use a different photodisintegration model or want to download the default data file manually use the following [link](https://www.desy.de/~crpropa/data/interaction_data/) to the tarballs files and extract them to your install folder.
 
-**Default data files:** (data.tar.gz)
+**Default data files:** (data-YYYY-MM-DD.tar.gz where YYYY-MM-DD depends on the data files version)
 Contains interaction rates nuclei, electrons and photons and spectra of secondary particles from these interactions, as well as data on nuclear masses and decay rates.
 Uses photodisintegration cross sections (for A > 12) from TALYS 1.8 with a partially modified set of GDR parameters.
 
-**Alternative 1:** (data_2016_03_21_Kossov.tar.gz)
+**Alternative 1:** (data-2016-03-21-Kossov.tar.gz)
 Photodisintegration interaction rates for the Kossov model.
 
-**Alternative 2:** (data_2016_03_21_PSB.tar.gz)
+**Alternative 2:** (data-2016-03-21-PSB.tar.gz)
 Photodisintegration interaction rates for the PSB model.
 
 ### Verify the Data Files Integrity
 
-Every data file should have a corresponding -CHECKSUM file in which appropriate MD5 sums are stored. A checksum file can be generated with, for example:
+Every data file should have a corresponding -CHECKSUM file in which the appropriate MD5 sum is stored. A checksum file can be generated as follows:
 ```
-$ ls data.tar.gz | xargs -I{} sh -c 'md5sum "$1" > "$1-CHECKSUM"' -- {}
+$ ls data-YYYY-MM-DD.tar.gz | xargs -I{} sh -c 'md5sum "$1" > "$1-CHECKSUM"' -- {}
 ```
+where **YYYY-MM-DD** can be obtained directly with `date +"%Y-%m-%d"`.
+
 To verify the integrity of the data files, a it is enough to download the checksum file in the same directory with the data file:
 ```
 $ md5sum -c *-CHECKSUM


### PR DESCRIPTION
This is just a small change in `CMakeLists.txt` to accommodate PR #286: **data.tar.gz** becomes **data-`date +"%Y-%m-%d"`.tar.gz**. I've put also a copy of the current `data.tar.gz` at our DESY [data download path](https://www.desy.de/~crpropa/data/interaction_data/).