### PR TITLE
Em cascades fix

### DIFF
--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -63,14 +63,16 @@ void EMDoublePairProduction::performInteraction(Candidate *candidate) const {
 	// Use assumption of Lee 96 arXiv:9604098
 	// Energy is equally shared between one e+e- pair, but take mass of second e+e- pair into account.
 	// This approximation has been shown to be valid within -1.5%.
-	double E = candidate->current.getEnergy();
+	// Scale the particle energy instead of background photons
+	double z = candidate->getRedshift();
+	double E = candidate->current.getEnergy() * (1 + z);
 	double Ee = (E - 2 * mass_electron * c_squared) / 2;
 
 	Random &random = Random::instance();
 	Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());
 
-	candidate->addSecondary( 11, Ee, pos);
-	candidate->addSecondary(-11, Ee, pos);
+	candidate->addSecondary( 11, Ee / (1 + z), pos);
+	candidate->addSecondary(-11, Ee / (1 + z), pos);
 }
 
 void EMDoublePairProduction::process(Candidate *candidate) const {

--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -97,8 +97,7 @@ void EMDoublePairProduction::process(Candidate *candidate) const {
 	double randDistance = -log(random.rand()) / rate;
 	if (candidate->getCurrentStep() > randDistance)
 		performInteraction(candidate);
-	else
-		candidate->limitNextStep(limit / rate);
+	candidate->limitNextStep(limit / rate);
 }
 
 } // namespace crpropa

--- a/src/module/EMInverseComptonScattering.cpp
+++ b/src/module/EMInverseComptonScattering.cpp
@@ -67,7 +67,7 @@ void EMInverseComptonScattering::initCumulativeRate(std::string filename) {
 	tabE.clear();
 	tabs.clear();
 	tabCDF.clear();
-	
+
 	// skip header
 	while (infile.peek() == '#')
 		infile.ignore(std::numeric_limits < std::streamsize > ::max(), '\n');
@@ -216,8 +216,7 @@ void EMInverseComptonScattering::process(Candidate *candidate) const {
 	double randDistance = -log(random.rand()) / rate;
 	if (candidate->getCurrentStep() > randDistance)
 		performInteraction(candidate);
-	else
-		candidate->limitNextStep(limit / rate);
+	candidate->limitNextStep(limit / rate);
 }
 
 } // namespace crpropa

--- a/src/module/EMPairProduction.cpp
+++ b/src/module/EMPairProduction.cpp
@@ -65,7 +65,7 @@ void EMPairProduction::initCumulativeRate(std::string filename) {
 	tabE.clear();
 	tabs.clear();
 	tabCDF.clear();
-	
+
 	// skip header
 	while (infile.peek() == '#')
 		infile.ignore(std::numeric_limits < std::streamsize > ::max(), '\n');
@@ -219,8 +219,7 @@ void EMPairProduction::process(Candidate *candidate) const {
 	double randDistance = -log(random.rand()) / rate;
 	if (candidate->getCurrentStep() > randDistance)
 		performInteraction(candidate);
-	else
-		candidate->limitNextStep(limit / rate);
+	candidate->limitNextStep(limit / rate);
 }
 
 } // namespace crpropa

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -149,8 +149,7 @@ void EMTripletPairProduction::process(Candidate *candidate) const {
 	double randDistance = -log(random.rand()) / rate;
 	if (candidate->getCurrentStep() > randDistance)
 		performInteraction(candidate);
-	else
-		candidate->limitNextStep(limit / rate);
+	candidate->limitNextStep(limit / rate);
 }
 
 } // namespace crpropa

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -67,7 +67,7 @@ void EMTripletPairProduction::initCumulativeRate(std::string filename) {
 	tabE.clear();
 	tabs.clear();
 	tabCDF.clear();
-	
+
 	// skip header
 	while (infile.peek() == '#')
 		infile.ignore(std::numeric_limits < std::streamsize > ::max(), '\n');
@@ -118,8 +118,8 @@ void EMTripletPairProduction::performInteraction(Candidate *candidate) const {
 
 	if (haveElectrons) {
 		Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());
-		candidate->addSecondary( 11, Epp, pos);
-		candidate->addSecondary(-11, Epp, pos);
+		candidate->addSecondary( 11, Epp / (1 + z), pos);
+		candidate->addSecondary(-11, Epp / (1 + z), pos);
 	}
 
 	// update the primary particle energy; do this after adding the secondaries to correctly set the secondaries parent


### PR DESCRIPTION
This PR solves the issue of the insufficient EM cascade generation in CRPropa chain, otherwise observed in comparison with other simulations, e.g. done for [IGMF studies](https://arxiv.org/abs/1101.0932).

The issue seems to be mainly related to the step size in the photons and electrons interactions, which was limited only if an interaction did not take place. Also in some places the appropriate scaling of the secondaries energy with redshift was not applied.
