### PR TITLE
Em cascades fix 3.1.6

### DIFF
--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -63,14 +63,16 @@ void EMDoublePairProduction::performInteraction(Candidate *candidate) const {
 	// Use assumption of Lee 96 arXiv:9604098
 	// Energy is equally shared between one e+e- pair, but take mass of second e+e- pair into account.
 	// This approximation has been shown to be valid within -1.5%.
-	double E = candidate->current.getEnergy();
+	// Scale the particle energy instead of background photons
+	double z = candidate->getRedshift();
+	double E = candidate->current.getEnergy() * (1 + z);
 	double Ee = (E - 2 * mass_electron * c_squared) / 2;
 
 	Random &random = Random::instance();
 	Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());
 
-	candidate->addSecondary( 11, Ee, pos);
-	candidate->addSecondary(-11, Ee, pos);
+	candidate->addSecondary( 11, Ee / (1 + z), pos);
+	candidate->addSecondary(-11, Ee / (1 + z), pos);
 }
 
 void EMDoublePairProduction::process(Candidate *candidate) const {

--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -97,8 +97,7 @@ void EMDoublePairProduction::process(Candidate *candidate) const {
 	double randDistance = -log(random.rand()) / rate;
 	if (candidate->getCurrentStep() > randDistance)
 		performInteraction(candidate);
-	else
-		candidate->limitNextStep(limit / rate);
+	candidate->limitNextStep(limit / rate);
 }
 
 } // namespace crpropa

--- a/src/module/EMInverseComptonScattering.cpp
+++ b/src/module/EMInverseComptonScattering.cpp
@@ -67,7 +67,7 @@ void EMInverseComptonScattering::initCumulativeRate(std::string filename) {
 	tabE.clear();
 	tabs.clear();
 	tabCDF.clear();
-	
+
 	// skip header
 	while (infile.peek() == '#')
 		infile.ignore(std::numeric_limits < std::streamsize > ::max(), '\n');
@@ -216,8 +216,7 @@ void EMInverseComptonScattering::process(Candidate *candidate) const {
 	double randDistance = -log(random.rand()) / rate;
 	if (candidate->getCurrentStep() > randDistance)
 		performInteraction(candidate);
-	else
-		candidate->limitNextStep(limit / rate);
+	candidate->limitNextStep(limit / rate);
 }
 
 } // namespace crpropa

--- a/src/module/EMPairProduction.cpp
+++ b/src/module/EMPairProduction.cpp
@@ -65,7 +65,7 @@ void EMPairProduction::initCumulativeRate(std::string filename) {
 	tabE.clear();
 	tabs.clear();
 	tabCDF.clear();
-	
+
 	// skip header
 	while (infile.peek() == '#')
 		infile.ignore(std::numeric_limits < std::streamsize > ::max(), '\n');
@@ -219,8 +219,7 @@ void EMPairProduction::process(Candidate *candidate) const {
 	double randDistance = -log(random.rand()) / rate;
 	if (candidate->getCurrentStep() > randDistance)
 		performInteraction(candidate);
-	else
-		candidate->limitNextStep(limit / rate);
+	candidate->limitNextStep(limit / rate);
 }
 
 } // namespace crpropa

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -149,8 +149,7 @@ void EMTripletPairProduction::process(Candidate *candidate) const {
 	double randDistance = -log(random.rand()) / rate;
 	if (candidate->getCurrentStep() > randDistance)
 		performInteraction(candidate);
-	else
-		candidate->limitNextStep(limit / rate);
+	candidate->limitNextStep(limit / rate);
 }
 
 } // namespace crpropa

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -67,7 +67,7 @@ void EMTripletPairProduction::initCumulativeRate(std::string filename) {
 	tabE.clear();
 	tabs.clear();
 	tabCDF.clear();
-	
+
 	// skip header
 	while (infile.peek() == '#')
 		infile.ignore(std::numeric_limits < std::streamsize > ::max(), '\n');
@@ -118,8 +118,8 @@ void EMTripletPairProduction::performInteraction(Candidate *candidate) const {
 
 	if (haveElectrons) {
 		Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());
-		candidate->addSecondary( 11, Epp, pos);
-		candidate->addSecondary(-11, Epp, pos);
+		candidate->addSecondary( 11, Epp / (1 + z), pos);
+		candidate->addSecondary(-11, Epp / (1 + z), pos);
 	}
 
 	// update the primary particle energy; do this after adding the secondaries to correctly set the secondaries parent


### PR DESCRIPTION
This PR solves the issue of the insufficient EM cascade generation in CRPropa chain, otherwise observed in comparison with other simulations, e.g. [those](https://arxiv.org/abs/1101.0932) done for IGMF studies. Concretely, CRPropa simulation results in a too hard spectrum, peaked at high energies.

The issue seems to be mainly related to the step size in the photons and electrons interactions, which was limited only if an interaction did not take place. Also in some places the appropriate scaling with redshift of the secondaries energies was not applied.

The code in the PR is intentionally based on CRPropa [v3.1.6](https://github.com/CRPropa/CRPropa3/tree/3.1.6), as the latest version in the master branch seems to have issues initializing the `EMPairProduction` module. The proposed changes do not affect the commits made in between `3.1.6` tag and `master`.

Below is an example script to reproduce the results from fig. 5 (lower panel, central plot - 1ES 0229+200, "maximal" case) from [here](https://arxiv.org/abs/1101.0932). It can be used to check the effectiveness of the proposed changes.

```python
#!/usr/bin/env python
# coding=utf-8

import os
import numpy

os.environ['OMP_NUM_THREADS'] = '4'
import crpropa
from crpropa import *

# =================
# === Main code ===
# =================

nParticles = int(1e2)

setCosmologyParameters(0.7, 0.3)
sourceRedshift = 0.14
spectrumStr = "E^-1*exp(-E/(100*TeV))"
eMin = 100e9*eV
eMax = 1e15*eV

Bamplitude = 0e-12*gauss
gridSize = 10
gridSpacing = 1e3 *kpc

jetAngle    = numpy.radians(0.1)
obsAngle    = numpy.radians(0)
obsPosAngle = numpy.radians(0)

output_file_name = "events_max.dat.gz"

# ------------------------------
# *** Setting up the B-field ***
print("Setting up the B-field grid...")
print(f"B amplitude: {Bamplitude/gauss:.1e} G")
print(f"Grid size: {gridSize:d} bins")
print(f"Grid step: {gridSpacing/Mpc:.1e} Mpc")

vgrid = VectorGrid(Vector3d(0), gridSize, gridSpacing)
Bfield = MagneticFieldGrid(vgrid)

print("Done.")
# ----------------------

# print some properties of our field
print(f'<B^2> = {rmsFieldStrength(vgrid) / gauss : .1e} G')   # RMS
print(f'<|B|> = {meanFieldStrength(vgrid) / gauss : .1e} G')  # mean

# -----------------------------
# *** Setting up the source ***
sourceDistance = redshift2ComovingDistance(sourceRedshift)

jetCone_x = -1*numpy.cos(obsAngle)
jetCone_y = -1*numpy.sin(obsAngle)*numpy.cos(obsPosAngle)
jetCone_z = -1*numpy.sin(obsAngle)*numpy.sin(obsPosAngle)

source = Source()
genericSourceComposition = SourceGenericComposition(eMin, eMax, spectrumStr)
genericSourceComposition.add(22,1)

source.add(SourcePosition(sourceDistance))
source.add(SourceRedshift(sourceRedshift))
source.add(genericSourceComposition)
source.add(SourceEmissionCone(Vector3d(jetCone_x, jetCone_y, jetCone_z), jetAngle))
print(source)
# -----------------------------

# add an observer
observer = Observer()
observer.add( ObserverSmallSphere(Vector3d(0), 1*Mpc) )

output = TextOutput(output_file_name)
output.disableAll()
output.enable(Output.CurrentIdColumn)
output.enable(Output.CreatedIdColumn)
output.enable(Output.CurrentEnergyColumn)
output.enable(Output.CurrentPositionColumn)
output.enable(Output.CurrentDirectionColumn)

observer.onDetection(output)

simulation = ModuleList()
simulation.add(PropagationCK(Bfield, 1e-4, 1*kpc, 10*Mpc))
simulation.add(Redshift())
simulation.add(EMPairProduction(CMB, True))
simulation.add(EMPairProduction(IRB_Franceschini08, True))
simulation.add(EMInverseComptonScattering(CMB, True))
simulation.add(EMInverseComptonScattering(IRB_Franceschini08, True))
simulation.add(MinimumEnergy(1e8*eV))
simulation.add(MaximumTrajectoryLength(1*Gpc))
simulation.add(observer)
simulation.setShowProgress(True)

print(simulation)

simulation.run(source, nParticles, True, True)

output.close()
```