### PR TITLE
Fix in simplegridturbulence

### DIFF
--- a/doc/pages/example_notebooks/advanced/CustomObserver.v4.ipynb
+++ b/doc/pages/example_notebooks/advanced/CustomObserver.v4.ipynb
@@ -13,7 +13,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -63,14 +66,17 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
     "from crpropa import Mpc, nG, EeV\n",
     "import numpy as np\n",
     "\n",
-    "vgrid = crpropa.VectorGrid(crpropa.Vector3d(0), 128, 1 * Mpc)\n",
+    "vgrid = crpropa.Grid3f(crpropa.Vector3d(0), 128, 1 * Mpc)\n",
     "crpropa.initTurbulence(vgrid, 1 * nG, 2 * Mpc, 5 * Mpc, -11. / 3.)\n",
     "BField = crpropa.MagneticFieldGrid(vgrid)\n",
     "\n",
@@ -188,7 +194,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": []
@@ -196,23 +205,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/pages/example_notebooks/extragalactic_fields/MHD_models.v4.ipynb
+++ b/doc/pages/example_notebooks/extragalactic_fields/MHD_models.v4.ipynb
@@ -19,7 +19,10 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -50,7 +53,7 @@
     "# m.add(SimplePropagation(minStep,maxStep))\n",
     "\n",
     "## initiate grid to hold field values\n",
-    "vgrid = VectorGrid( gridOrigin, gridSize, spacing )\n",
+    "vgrid = Grid3f( gridOrigin, gridSize, spacing )\n",
     "## load values to the grid\n",
     "loadGrid( vgrid, filename_bfield, b_factor )\n",
     "## use grid as magnetic field\n",
@@ -71,7 +74,10 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -89,7 +95,10 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -109,7 +118,10 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -130,7 +142,10 @@
    "cell_type": "code",
    "execution_count": 65,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -158,7 +173,10 @@
    "cell_type": "code",
    "execution_count": 67,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -207,7 +225,10 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -237,7 +258,10 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -271,7 +295,10 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -299,9 +326,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/doc/pages/example_notebooks/galactic_backtracking/galactic_backtracking.v4.ipynb
+++ b/doc/pages/example_notebooks/galactic_backtracking/galactic_backtracking.v4.ipynb
@@ -107,7 +107,10 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -231,7 +234,7 @@
     "    print('Preparing turbulent grid')\n",
     "    lMin = 8 * parsec\n",
     "    lMax = 272 * parsec\n",
-    "    turbulentGrid = VectorGrid(Vector3d(0.), 256, 4 * parsec)\n",
+    "    turbulentGrid = Grid3f(Vector3d(0.), 256, 4 * parsec)\n",
     "    crpropa.initTurbulence(turbulentGrid, 1, lMin, lMax, -11./3, seed) #Brms scales automatically\n",
     "    B.setTurbulentGrid(turbulentGrid)\n",
     "\n",
@@ -275,23 +278,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.16"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/pages/example_notebooks/propagation_comparison/Propagation_Comparison_CK_BP.ipynb
+++ b/doc/pages/example_notebooks/propagation_comparison/Propagation_Comparison_CK_BP.ipynb
@@ -205,9 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -247,9 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -1229,7 +1225,7 @@
     "b = 100*nG\n",
     "spacing = lMin/2.\n",
     "#spacing = R / 2 *pc  # lMin > 2 * spacing\n",
-    "vgrid = VectorGrid(Vector3d(0), N_grid, spacing)\n",
+    "vgrid = Grid3f(Vector3d(0), N_grid, spacing)\n",
     "initTurbulence(vgrid, b, lMin, lMax, -11./3., randomSeed)\n",
     "turb_field = MagneticFieldGrid(vgrid)"
    ]
@@ -1513,23 +1509,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15rc1"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/doc/pages/example_notebooks/sim4D/sim4D.v4.ipynb
+++ b/doc/pages/example_notebooks/sim4D/sim4D.v4.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "\n",
     "# set up random turbulent field\n",
-    "vgrid = VectorGrid(Vector3d(0), 512, 30 * kpc)\n",
+    "vgrid = Grid3f(Vector3d(0), 512, 30 * kpc)\n",
     "initTurbulence(vgrid, 8 * nG, 60 * kpc, 800 * kpc, -11. / 3, 42)\n",
     "Bfield = MagneticFieldGrid(vgrid)\n",
     "\n",
@@ -103,9 +103,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/pages/example_notebooks/trajectories/trajectories.v4.ipynb
+++ b/doc/pages/example_notebooks/trajectories/trajectories.v4.ipynb
@@ -35,7 +35,7 @@
     "from crpropa import *\n",
     "\n",
     "randomSeed = 42\n",
-    "vgrid = VectorGrid(Vector3d(0), 256, 30*kpc)\n",
+    "vgrid = Grid3f(Vector3d(0), 256, 30*kpc)\n",
     "initTurbulence(vgrid, 8*nG, 60*kpc, 800*kpc, -11./3., randomSeed)\n",
     "Bfield = MagneticFieldGrid(vgrid)\n",
     "\n",
@@ -60,7 +60,10 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -85,7 +88,10 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -942,23 +948,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/include/crpropa/magneticField/turbulentField/SimpleGridTurbulence.h
+++ b/include/crpropa/magneticField/turbulentField/SimpleGridTurbulence.h
@@ -47,7 +47,7 @@ class SimpleTurbulenceSpectrum : public TurbulenceSpectrum {
 	*/
 	double getCorrelationLength() const {
 		return turbulentCorrelationLength(getLmin(), getLmax(),
-		                                  -getSindex() - 2);
+		                                  getSindex());
 	}
 	static double turbulentCorrelationLength(double lMin, double lMax,
 	                                         double s) {


### PR DESCRIPTION
Just a fix of my mistake in which the s(pectral) index ("5/3") is replaced with the alpha index ("-11/3") in the correlation length expression for `SimpleTurbulenceSpectrum`. I also updated docs to use `Grid3f` instead of `VectorGrid`.