### PR TITLE
fix segfault in DintPropagation due to size check in wrong place

### DIFF
--- a/src/PhotonPropagation.cpp
+++ b/src/PhotonPropagation.cpp
@@ -241,12 +241,12 @@ void DintPropagation(
 		InitializeSpectrum(&inputSpectrum);
 
 		// process secondaries
-		while ((secondaries.back().X1 > 0) and (secondaries.size() > 0)) {
+		while ((secondaries.size() > 0 ) && (secondaries.back().X1 > 0)) {
 			double Dmax = secondaries.back().X1;  // upper bound of distance bin
 			double Dmin = max(Dmax - dMargin, 0.);  // lower bound of distance bin
 
 			// add all secondaries within the current distance bin
-			while ((secondaries.back().X1 > Dmin) and (secondaries.size() > 0)) {
+			while ((secondaries.size() > 0) && (secondaries.back().X1 > Dmin)) {
 				FillInSpectrum(&inputSpectrum, secondaries.back());
 				secondaries.pop_back();
 			}


### PR DESCRIPTION
I know DINT is probably on its way out, but right now it crashes for me. 

This commit fixes it (the size check is in the wrong place here, and trying to access .back().X1 on a zero-size vector triggers a segfault for me, although I guess it can also fail silently).  The second check is probably extraneous but I fixed it anyway. 