### PR TITLE
Trying to fix make doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ script:
   - |
     if [ $BUILD_DOC ]; then
       echo "Building Documentation"
-      pip3 install m2r==0.2.1 Sphinx==1.7.9 nbsphinx==0.3.5 breathe==4.10.0 exhale==0.2.3  sphinx-rtd-theme==0.4.3 recommonmark==0.6.0
+      pip3 install wheel m2r==0.2.1 Sphinx==1.7.9 nbsphinx==0.3.5 breathe==4.10.0 exhale==0.2.3  sphinx-rtd-theme==0.4.3 recommonmark==0.6.0
       cmake ..
       make doc
       touch doc/.nojekyll


### PR DESCRIPTION
Looks like an error in a new version of Ubuntu - missing the wheel package:
```
...
  Running setup.py bdist_wheel for m2r: finished with status 'error'

  Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-lgreiffg/m2r/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmp__bo87sypip-wheel- --python-tag cp36:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help
  error: invalid command 'bdist_wheel'
```