### PR TITLE
Fix default argument of TurbulentField

### DIFF
--- a/include/crpropa/magneticField/turbulentField/TurbulentField.h
+++ b/include/crpropa/magneticField/turbulentField/TurbulentField.h
@@ -49,7 +49,7 @@ class TurbulenceSpectrum : public Referenced {
 	 range
 	*/
 	TurbulenceSpectrum(double Brms, double lMin, double lMax,
-	                   double lBendover = 1, double sIndex = 5. / 3.,
+	                   double lBendover = 1, double sIndex = (5. / 3.),
 	                   double qIndex = 4)
 	    : Brms(Brms), lMin(lMin), lMax(lMax), lBendover(lBendover),
 	      sIndex(sIndex), qIndex(qIndex) {


### PR DESCRIPTION
This should fix issue #322.

For some reason, which I do not understand, only the numerator of sIndex= 5. / 3. was initialized in the constructor. Adding brackets around that fraction seems to fix the problem.