### PR TITLE
Fix KISS Warnings in gas density classes

### DIFF
--- a/src/massDistribution/ConstantDensity.cpp
+++ b/src/massDistribution/ConstantDensity.cpp
@@ -26,14 +26,11 @@ double ConstantDensity::getDensity(const Vector3d &position) const {
 	if(isH2)
 		n += H2densitynumber;
 
-	// check if any density is activ and give warning if not
-	bool anyDensityActive = isHI||isHII||isH2;
-
-	if(anyDensityActive == false){
+	// check if all densities are active and raise warning if not
+	if((isHI & isHII & isH2) == false){
 		KISS_LOG_WARNING
-			<< "\n called getDensity on deactivated ConstantDensity \n"
-			<< "returned 0 density\n"
-			<< "please use setHx(true, n)\n";
+			<< "\nCalled getDensity on (partly) deactivated ConstantDensity \n"
+			<< "gas density model. Make sure this was intentional.";
 	}
 
 	return n;
@@ -49,14 +46,11 @@ double ConstantDensity::getNucleonDensity(const Vector3d &position) const {
 	if(isH2)
 		n += 2*H2densitynumber;
 
-	// check if any density is activ and give warning if not
-	bool anyDensityActive = isHI||isHII||isH2;
-
-	if(anyDensityActive == false){
+	// check if all densities are active and raise warning if not
+	if((isHI & isHII & isH2) == false){
 		KISS_LOG_WARNING
-			<< "\n called getNucleonDensity on deactivated ConstantDensity \n"
-			<< "returned 0 density\n"
-			<< "please use setHx(true, n)\n";
+			<< "\nCalled getNucleonDensity on (partly) deactivated ConstantDensity \n"
+			<< "gas density model. Make sure this was intentional.";
 	}
 	return n;
 }
@@ -126,17 +120,17 @@ void ConstantDensity::setH2(double densitynumber) {
 
 std::string ConstantDensity::getDescription() {
 	std::stringstream s;
-	s << "ConstantDensity:";
+	s << "ConstantDensity:\n";
 	s<< "HI component is ";
 	if(!isHI)
 		s<< "not ";
-	s<< "activ and has a density of " << HIdensitynumber/ccm << " cm^-3" << "      HII component is ";
+	s<< "active and has a density of " << HIdensitynumber/ccm << " cm^-3" << "\nHII component is ";
 	if(!isHII)
 		s<< "not ";
-	s<<"activ and  has a density of " << HIIdensitynumber/ccm<<" cm^-3" <<  "      H2 component is ";
+	s<<"active and has a density of " << HIIdensitynumber/ccm<<" cm^-3" <<  "\nH2 component is ";
 	if(!isH2)
 		s<<"not ";
-	s<<"activ and  has a density of " << H2densitynumber/ccm << " cm^-3";
+	s<<"active and has a density of " << H2densitynumber/ccm << " cm^-3";
 	return s.str();
 }
 

--- a/src/massDistribution/ConstantDensity.cpp
+++ b/src/massDistribution/ConstantDensity.cpp
@@ -7,7 +7,7 @@
 namespace crpropa{
 
 ConstantDensity::ConstantDensity(double HI, double HII, double H2) {
-	// set all types activ which are not equal 0 and change densitynumber
+	// set all types active which are not equal 0 and change number density
 	if(HI!=0)
 		setHI(true, HI);
 	if(HII!=0)

--- a/src/massDistribution/Cordes.cpp
+++ b/src/massDistribution/Cordes.cpp
@@ -39,7 +39,7 @@ bool Cordes::getIsForH2() {
 
 std::string Cordes::getDescription() {
 	std::stringstream s;
-	s << "Density Cordes include HII component";
+	s << "Density Cordes: includes only an HII component";
 	return s.str();
 }
 

--- a/src/massDistribution/Ferriere.cpp
+++ b/src/massDistribution/Ferriere.cpp
@@ -256,7 +256,7 @@ bool Ferriere::getIsForH2(){
 
 std::string Ferriere::getDescription() {
 	std::stringstream s;
-	s << "Density modell Ferriere 2007:\n";
+	s << "Density model Ferriere 2007:\n";
 	s<< "HI component is ";
 	if(!isforHI)
 		s<< "not ";

--- a/src/massDistribution/Ferriere.cpp
+++ b/src/massDistribution/Ferriere.cpp
@@ -198,13 +198,11 @@ double Ferriere::getDensity(const Vector3d &position) const{
 	if(isforH2){
 		n+=getH2Density(position);
 	}
-
-	// check if any density is activ and give warning if not
-	if(isforHI||isforHII||isforH2 == false){
+	// check if all densities are active and raise warning if not
+	if((isforHI & isforHII & isforH2) == false){
 		KISS_LOG_WARNING
-			<< "\n called getDensity on deactivated Ferriere \n"
-			<< "returned 0 density\n"
-			<< "please activate \n";
+			<< "\nCalled getDensity on (partly) deactivated Ferriere \n"
+			<< "gas density model. Make sure this was intentional.";
 	}
 
 	return n;
@@ -222,12 +220,11 @@ double Ferriere::getNucleonDensity(const Vector3d &position) const{
 		n+= 2*getH2Density(position);
 	}
 
-	// check if any density is activ and give warning if not
-	if(isforHI||isforHII||isforH2 == false){
+	// check if all densities is active and raise warning if not
+	if((isforHI & isforHII & isforH2) == false){
 		KISS_LOG_WARNING
-			<< "\n called getDensity on deactivated ConstantDensity \n"
-			<< "returned 0 density\n"
-			<< "please activate\n";
+			<< "\nCalled getNucleonDensity on (partly) deactivated Ferriere \n"
+			<< "gas density model. Make sure this was intentional.";
 	}
 
 	return n;
@@ -259,17 +256,17 @@ bool Ferriere::getIsForH2(){
 
 std::string Ferriere::getDescription() {
 	std::stringstream s;
-	s << "Density modell Ferriere 2007: ";
+	s << "Density modell Ferriere 2007:\n";
 	s<< "HI component is ";
 	if(!isforHI)
 		s<< "not ";
-	s<< "activ. HII component is ";
+	s<< "active.\nHII component is ";
 	if(!isforHII)
 		s<< "not ";
-	s<<"activ. H2 component is ";
+	s<<"active.\nH2 component is ";
 	if(!isforH2)
 		s<<"not ";
-	s<<"activ.";
+	s<<"active.";
 	return s.str();
 }
 

--- a/src/massDistribution/Nakanishi.cpp
+++ b/src/massDistribution/Nakanishi.cpp
@@ -105,7 +105,7 @@ void Nakanishi::setIsForH2(bool H2) {
 
 std::string Nakanishi::getDescription() {
 	std::stringstream s;
-	s << "Density modell Nakanishi:\n";
+	s << "Density model Nakanishi:\n";
 	s<< "HI component is ";
 	if(isforHI==false)
 		s<< "not ";

--- a/src/massDistribution/Nakanishi.cpp
+++ b/src/massDistribution/Nakanishi.cpp
@@ -57,14 +57,11 @@ double Nakanishi::getDensity(const Vector3d &position) const {
 	if(isforH2)
 		n += getH2Density(position);
 
-	// check if any density is activ and give warning if not
-	bool anyDensityActive = isforHI||isforH2;
-
-	if(anyDensityActive == false){
+	// check if all densities are active and raise warning if not
+	if((isforHI & isforH2) == false){
 		KISS_LOG_WARNING
-			<< "\n called getDensity on deactivated Nakanishi \n"
-			<< "returned 0 density\n"
-			<< "please activate\n";
+			<< "\nCalled getDensity on (partly) deactivated Nakanishi \n"
+			<< "gas density model. Make sure this was intentional.";
 	}
 
 	return n;
@@ -77,15 +74,11 @@ double Nakanishi::getNucleonDensity(const Vector3d &position) const {
 	if(isforH2)
 		n += 2*getH2Density(position);	// weight 2 for molecular hydrogen
 
-	// check if any density is activ and give warning if not
-	bool anyDensityActive = isforHI||isforH2;
-
-	if(anyDensityActive == false){
+	// check if all densities are active and raise warning if not
+	if((isforHI & isforH2) == false){
 		KISS_LOG_WARNING
-			<< "\n tryed to get nucleon-density although all density-types are deaktivated \n"
-			<< "density-module: Nakanishi\n"
-			<< "returned 0 density\n"
-			<< "please use constant Density with 0 \n";
+			<< "\n"<<"Called getNucleonDensity on (partly) deactivated Nakanishi \n"
+			<< "gas density model. Make sure this was intentional.";
 	}
 
 	return n;
@@ -112,14 +105,14 @@ void Nakanishi::setIsForH2(bool H2) {
 
 std::string Nakanishi::getDescription() {
 	std::stringstream s;
-	s << "Density modell Nakanishi: ";
+	s << "Density modell Nakanishi:\n";
 	s<< "HI component is ";
 	if(isforHI==false)
 		s<< "not ";
-	s<< "activ. H2 component is ";
+	s<< "active.\nH2 component is ";
 	if(isforH2==false)
 		s<<"not ";
-	s<<"activ. Nakanishi has no HII component.";
+	s<<"active.\nNakanishi has no HII component.";
 
 	return s.str();
 }


### PR DESCRIPTION
@avvliet found that a lot of KISS warnings are raised, when he tested the massDistribution examples. 

This was related to a bug in the implementation of the check if a warning should be raised. Now the KISS warning is raised when one or more components (HI, HII, H2) of the gas distributions is available but *not* activated. The option to deactivate individual components was implemented to allow for combinations of several gas distribution models. 

Furthermore, some typos were fixed and the formatting of the warnings and the getDescription method updated.