### PR TITLE
Fix photon field

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,9 +330,9 @@ endif(APPLE)
 # Download data files (interaction data, masses, decay data ...)
 # ----------------------------------------------------------------------------
 OPTION(DOWNLOAD_DATA "Download CRPropa data files" ON)
-set(CRPROPA_DATAFILE_VER "2020-11-28")
+set(CRPROPA_DATAFILE_VER "2021-07-20")
 if(DOWNLOAD_DATA)
-  message("-- Downloading data file from crpropa.desy.de ~ 50 MB")
+  message("-- Downloading data file from crpropa.desy.de ~ 65 MB")
   file(DOWNLOAD
     https://www.desy.de/~crpropa/data/interaction_data/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM
     ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,7 @@ endif(APPLE)
 # Download data files (interaction data, masses, decay data ...)
 # ----------------------------------------------------------------------------
 OPTION(DOWNLOAD_DATA "Download CRPropa data files" ON)
-set(CRPROPA_DATAFILE_VER "2021-07-20")
+set(CRPROPA_DATAFILE_VER "2021-07-30")
 if(DOWNLOAD_DATA)
   message("-- Downloading data file from crpropa.desy.de ~ 65 MB")
   file(DOWNLOAD

--- a/src/module/PhotoPionProduction.cpp
+++ b/src/module/PhotoPionProduction.cpp
@@ -27,8 +27,9 @@ PhotoPionProduction::PhotoPionProduction(ref_ptr<PhotonField> field, bool photon
 
 void PhotoPionProduction::setPhotonField(ref_ptr<PhotonField> field) {
 	photonField = field;
+	std::string fname = photonField->getFieldName();
 	if (haveRedshiftDependence) {
-		if (photonField->hasRedshiftDependence()){
+		if (fname == "CMB"){
 			std::cout << "PhotoPionProduction: tabulated redshift dependence not needed for CMB, switching off" << std::endl;
 			haveRedshiftDependence = false;
 		}
@@ -36,10 +37,11 @@ void PhotoPionProduction::setPhotonField(ref_ptr<PhotonField> field) {
 			KISS_LOG_WARNING << "PhotoPionProduction: You are using the 2-dimensional tabulated redshift evolution, which is not available for other interactions. To be consistent across all interactions you may deactivate this <setHaveRedshiftDependence(False)>.";
 		}
 	}
-	std::string fname = photonField->getFieldName();
+	
 	setDescription("PhotoPionProduction: " + fname);
-	if (haveRedshiftDependence)
+	if (haveRedshiftDependence){
 		initRate(getDataPath("PhotoPionProduction/rate_" + fname.replace(0, 3, "IRBz") + ".txt"));
+	}
 	else
 		initRate(getDataPath("PhotoPionProduction/rate_" + fname + ".txt"));
 

--- a/src/module/PhotoPionProduction.cpp
+++ b/src/module/PhotoPionProduction.cpp
@@ -29,8 +29,8 @@ void PhotoPionProduction::setPhotonField(ref_ptr<PhotonField> field) {
 	photonField = field;
 	std::string fname = photonField->getFieldName();
 	if (haveRedshiftDependence) {
-		if (fname == "CMB"){
-			std::cout << "PhotoPionProduction: tabulated redshift dependence not needed for CMB, switching off" << std::endl;
+		if (photonField->hasRedshiftDependence() == false){
+			std::cout << "PhotoPionProduction: tabulated redshift dependence not needed for " + fname + ", switching off" << std::endl;
 			haveRedshiftDependence = false;
 		}
 		else {


### PR DESCRIPTION
This PR should fix the issue brought up in #340.

The issue was twofold:
1) Some tables (interaction rates for redshift independent photo pion production on the EBL) were not correctly copied from version 3.1.6 to version 3.1.7.
2) The check for the CMB target photon field (in PhotoPionProduction) was not implemented correctly.

@Leander Schlegel from Ruhr University Bochum did quite some checks to pin down this problem and confirms that the version of this PR yields the same PPP secondaries as version 3.1.6.