### PR TITLE
Fix magnetic lenses test

### DIFF
--- a/python/1_swig.i
+++ b/python/1_swig.i
@@ -118,4 +118,5 @@ __WITHNUMPY = False
 #endif
 
 
-
+/* Hide some known warnings */
+#pragma SWIG nowarn=312,325,361,389,401,503,508,509

--- a/python/4_lens.i
+++ b/python/4_lens.i
@@ -81,139 +81,97 @@
 %include "crpropa/magneticLens/ParticleMapsContainer.h"
 
 #ifdef WITHNUMPY
-%extend crpropa::ParticleMapsContainer{
-        PyObject *addParticles(PyObject *particleIds,
+%extend crpropa::ParticleMapsContainer {
+  PyObject *addParticles(PyObject *particleIds,
                 PyObject *energies,
                 PyObject *galacticLongitudes,
                 PyObject *galacticLatitudes,
                 PyObject *weights)
+  {
+    //ToDo: Handle strided arrays
+
+    //ToDo: Check that input objects are arrays  PyArray_Check
+    if (!PyArray_Check(particleIds))
     {
-      //ToDo: Handle strided arrays
+      std::cerr << "ParticleMapsContainer::addParticles -  require array as input for particleIds\n";
+      Py_RETURN_NONE;
+    }
+    if (!PyArray_Check(energies))
+    {
+      std::cerr << "ParticleMapsContainer::addParticles -  require array as input for energy\n";
+      Py_RETURN_NONE;
+    }
+    if (!PyArray_Check(galacticLongitudes))
+    {
+      std::cerr << "ParticleMapsContainer::addParticles -  require array as input for galacticLongitudes\n";
+      Py_RETURN_NONE;
+    }
+    if (!PyArray_Check(galacticLatitudes))
+    {
+      std::cerr << "ParticleMapsContainer::addParticles -  require array as input for galacticLatitudes\n";
+      Py_RETURN_NONE;
+    }
+    if (!PyArray_Check(weights))
+    {
+      std::cerr << "ParticleMapsContainer::addParticles -  require array as input for weights\n";
+      Py_RETURN_NONE;
+    }
 
-      //ToDo: Check that input objects are arrays  PyArray_Check
-      if (!PyArray_Check(particleIds))
-      {
-        std::cerr << "ParticleMapsContainer::addParticles -  require array as input for particleIds\n";
-        Py_RETURN_NONE;
-      }
-      if (!PyArray_Check(energies))
-      {
-        std::cerr << "ParticleMapsContainer::addParticles -  require array as input for energy\n";
-        Py_RETURN_NONE;
-      }
-      if (!PyArray_Check(galacticLongitudes))
-      {
-        std::cerr << "ParticleMapsContainer::addParticles -  require array as input for galacticLongitudes\n";
-        Py_RETURN_NONE;
-      }
-      if (!PyArray_Check(galacticLatitudes))
-      {
-        std::cerr << "ParticleMapsContainer::addParticles -  require array as input for galacticLatitudes\n";
-        Py_RETURN_NONE;
-      }
-      if (!PyArray_Check(weights))
-      {
-        std::cerr << "ParticleMapsContainer::addParticles -  require array as input for weights\n";
-        Py_RETURN_NONE;
-      }
+    PyArrayObject *particleIds_arr = PyArray_GETCONTIGUOUS((PyArrayObject*) particleIds);
+    PyArrayObject *energies_arr = PyArray_GETCONTIGUOUS((PyArrayObject*) energies);
+    PyArrayObject *galacticLongitudes_arr = PyArray_GETCONTIGUOUS((PyArrayObject*) galacticLongitudes);
+    PyArrayObject *galacticLatitudes_arr = PyArray_GETCONTIGUOUS((PyArrayObject*) galacticLatitudes);
+    PyArrayObject *weights_arr = PyArray_GETCONTIGUOUS((PyArrayObject*) weights);
 
-      int ndim = 0;
-      npy_intp dims[NPY_MAXDIMS];
+    if ((particleIds_arr == NULL) || (energies_arr == NULL) || (galacticLongitudes_arr == NULL) || (galacticLatitudes_arr == NULL) || (weights_arr == NULL))
+      Py_RETURN_NONE;
 
-      PyArrayObject *particleIds_arr = NULL;
-      PyArray_Descr *particleIds_dtype = NULL;
-      if (PyArray_GetArrayParamsFromObject(particleIds, NULL, 1,
-            &particleIds_dtype, &ndim, dims, &particleIds_arr, NULL) < 0)
-        { Py_RETURN_NONE; };
-      if (particleIds_arr == NULL)
-        Py_RETURN_NONE;
+    int intSize = 0;
+    // check integer type
+    if((PyArray_TYPE(particleIds_arr) == NPY_INT32) || (PyArray_TYPE(particleIds_arr) == NPY_UINT32))
+    {
+      intSize = 32;
+    }
+    else if((PyArray_TYPE(particleIds_arr) == NPY_INT64) || (PyArray_TYPE(particleIds_arr) == NPY_UINT64))
+    {
+      intSize = 64;
+    }
+    else
+    {
+      std::cerr << "";
+      throw std::runtime_error("ParticleMapsContainer::addParticles -  require array of type int as input for ids");
+    }
+
+    void *particleIds_dp = PyArray_DATA(particleIds_arr);
+    double *energies_dp = (double*) PyArray_DATA(energies_arr);
+    double *galacticLongitudes_dp = (double*) PyArray_DATA(galacticLongitudes_arr);
+    double *galacticLatitudes_dp = (double*) PyArray_DATA(galacticLatitudes_arr);
+    double *weights_dp= (double*) PyArray_DATA(weights_arr);
 
 
-      int intSize = 0;
-      // check integer type
-      if((PyArray_TYPE(particleIds_arr) == NPY_INT32) || (PyArray_TYPE(particleIds_arr) == NPY_UINT32))
+    npy_intp *D = PyArray_DIMS(particleIds_arr);
+    int arraySize = D[0];
+
+    for(size_t i = 0; i < arraySize; i++)
+    {
+      if (intSize == 32)
       {
-        intSize = 32;
+        $self->addParticle(((int32_t*) particleIds_dp)[i], energies_dp[i],
+            galacticLongitudes_dp[i], galacticLatitudes_dp[i], weights_dp[i]);
       }
-      else if((PyArray_TYPE(particleIds_arr) == NPY_INT64) || (PyArray_TYPE(particleIds_arr) == NPY_UINT64))
+      else if (intSize == 64)
       {
-        intSize = 64;
+        $self->addParticle(((int64_t*) particleIds_dp)[i], energies_dp[i],
+            galacticLongitudes_dp[i], galacticLatitudes_dp[i], weights_dp[i]);
       }
       else
       {
-        std::cerr << "";
-        throw std::runtime_error("ParticleMapsContainer::addParticles -  require array of type int as input for ids");
+        throw std::runtime_error("ParticleMapsContainer::addParticles - unknown int size");
       }
 
-
-
-      npy_intp *D = PyArray_DIMS(particleIds_arr);
-      int arraySize = D[0];
-
-      PyArrayObject *energies_arr = NULL;
-      PyArray_Descr *energies_dtype = NULL;
-
-      if (PyArray_GetArrayParamsFromObject(energies, NULL, 1,
-            &energies_dtype, &ndim, dims, &energies_arr,
-            NULL) < 0)
-        { Py_RETURN_NONE; };
-      if (energies_arr == NULL)
-        Py_RETURN_NONE;
-
-      PyArrayObject *galacticLongitudes_arr = NULL;
-      PyArray_Descr *galacticLongitudes_dtype = NULL;
-      if (PyArray_GetArrayParamsFromObject(galacticLongitudes, NULL, 1,
-            &galacticLongitudes_dtype, &ndim, dims, &galacticLongitudes_arr,
-            NULL) < 0)
-        { Py_RETURN_NONE; };
-      if (galacticLongitudes_arr == NULL)
-        Py_RETURN_NONE;
-
-      PyArrayObject *galacticLatitudes_arr = NULL;
-      PyArray_Descr *galacticLatitudes_dtype = NULL;
-      if (PyArray_GetArrayParamsFromObject(galacticLatitudes, NULL, 1,
-            &galacticLatitudes_dtype, &ndim, dims, &galacticLatitudes_arr,
-            NULL) < 0)
-        { Py_RETURN_NONE; };
-      if (galacticLatitudes_arr == NULL)
-        Py_RETURN_NONE;
-
-      PyArrayObject *weights_arr = NULL;
-      PyArray_Descr *weights_dtype = NULL;
-      if (PyArray_GetArrayParamsFromObject(weights, NULL, 1,
-            &weights_dtype, &ndim, dims, &weights_arr,
-            NULL) < 0)
-        { Py_RETURN_NONE; };
-      if (weights_arr == NULL)
-        Py_RETURN_NONE;
-
-      void *particleIds_dp = PyArray_DATA(particleIds_arr);
-      double *energies_dp = (double*) PyArray_DATA(energies_arr);
-      double *galacticLongitudes_dp = (double*) PyArray_DATA(galacticLongitudes_arr);
-      double *galacticLatitudes_dp = (double*) PyArray_DATA(galacticLatitudes_arr);
-      double *weights_dp= (double*) PyArray_DATA(weights_arr);
-
-      for(size_t i =0; i < arraySize; i++ )
-      {
-        if (intSize == 32)
-        {
-          $self->addParticle(((int32_t*) particleIds_dp)[i], energies_dp[i],
-              galacticLongitudes_dp[i], galacticLatitudes_dp[i], weights_dp[i]);
-        }
-        else if (intSize == 64)
-        {
-          $self->addParticle(((int64_t*) particleIds_dp)[i], energies_dp[i],
-              galacticLongitudes_dp[i], galacticLatitudes_dp[i], weights_dp[i]);
-        }
-        else
-        {
-          throw std::runtime_error("ParticleMapsContainer::addParticles - unknown int size");
-        }
-
-      }
-      Py_RETURN_TRUE;
     }
-
+    Py_RETURN_TRUE;
+  }
 
   PyObject *getMap_numpyArray(const int particleId, double energy)
   {
@@ -247,29 +205,30 @@
 			vector<double> energy;
       vector<double> galacticLongitudes;
 			vector<double> galacticLatitudes;
-      $self->getRandomParticles(N, particleId, energy, galacticLongitudes,
+      $self->getRandomParticles(N, particleId, energy, galacticLongitudes, 
           galacticLatitudes);
 
       npy_intp size = N;
-      PyObject *oId = PyArray_SimpleNew(1, &size, NPY_INT);
-      PyObject *oEnergy = PyArray_SimpleNew(1, &size, NPY_DOUBLE);
-      PyObject *oLon = PyArray_SimpleNew(1, &size, NPY_DOUBLE);
-      PyObject *oLat = PyArray_SimpleNew(1, &size, NPY_DOUBLE);
+      PyArrayObject *oId = (PyArrayObject*)PyArray_New(&PyArray_Type, 1, &size, NPY_INT, NULL, NULL, 0, NPY_ARRAY_CARRAY, NULL);
+      PyArrayObject *oEnergy = (PyArrayObject*)PyArray_New(&PyArray_Type, 1, &size, NPY_DOUBLE, NULL, NULL, 0, NPY_ARRAY_CARRAY, NULL);
+      PyArrayObject *oLon = (PyArrayObject*)PyArray_New(&PyArray_Type, 1, &size, NPY_DOUBLE, NULL, NULL, 0, NPY_ARRAY_CARRAY, NULL);
+      PyArrayObject *oLat = (PyArrayObject*)PyArray_New(&PyArray_Type, 1, &size, NPY_DOUBLE, NULL, NULL, 0, NPY_ARRAY_CARRAY, NULL);
 
-      memcpy(PyArray_DATA((PyArrayObject *) oId), &particleId[0],
+      memcpy(PyArray_DATA(oId), &particleId[0],
           particleId.size() * sizeof(int));
-      memcpy(PyArray_DATA((PyArrayObject *) oEnergy), &energy[0], energy.size()
+      memcpy(PyArray_DATA(oEnergy), &energy[0], energy.size()
           * sizeof(double));
-      memcpy(PyArray_DATA((PyArrayObject *) oLon), &galacticLongitudes[0],
+      memcpy(PyArray_DATA(oLon), &galacticLongitudes[0],
           galacticLongitudes.size() * sizeof(double));
-      memcpy(PyArray_DATA((PyArrayObject *) oLat), &galacticLatitudes[0],
+      memcpy(PyArray_DATA(oLat), &galacticLatitudes[0],
           galacticLatitudes.size() * sizeof(double));
 
       PyObject *returnList = PyList_New(4);
-      PyList_SET_ITEM(returnList, 0, oId);
-      PyList_SET_ITEM(returnList, 1, oEnergy);
-      PyList_SET_ITEM(returnList, 2, oLon);
-      PyList_SET_ITEM(returnList, 3, oLat);
+      PyList_SET_ITEM(returnList, 0, (PyObject*)oId);
+      PyList_SET_ITEM(returnList, 1, (PyObject*)oEnergy);
+      PyList_SET_ITEM(returnList, 2, (PyObject*)oLon);
+      PyList_SET_ITEM(returnList, 3, (PyObject*)oLat);
+      
       return returnList;
   }
 

--- a/python/4_lens.i
+++ b/python/4_lens.i
@@ -39,34 +39,34 @@
 
 #ifdef WITHNUMPY
 %extend crpropa::MagneticLens{
-    PyObject * transformModelVector_numpyArray(PyObject *input, double rigidity)
+  PyObject * transformModelVector_numpyArray(PyObject *input, double rigidity)
+  {
+    PyArrayObject *arr = NULL;
+    PyArray_Descr *dtype = NULL;
+    int ndim = 0;
+    npy_intp dims[NPY_MAXDIMS];
+    if (PyArray_GetArrayParamsFromObject(input, NULL, 1, &dtype, &ndim, dims, &arr, NULL) < 0)
     {
-      PyArrayObject *arr = NULL;
-      PyArray_Descr *dtype = NULL;
-      int ndim = 0;
-      npy_intp dims[NPY_MAXDIMS];
-      if (PyArray_GetArrayParamsFromObject(input, NULL, 1, &dtype, &ndim, dims, &arr, NULL) < 0)
-      {
-        Py_RETURN_NONE;
-      }
-
-      if (arr == NULL)
-      {
-        Py_RETURN_NONE;
-      }
-
-      double *dataPointer = (double*) PyArray_DATA(arr);
-      $self->transformModelVector(dataPointer, rigidity);
-      return input;
+      Py_RETURN_NONE;
     }
+
+    if (arr == NULL)
+    {
+      Py_RETURN_NONE;
+    }
+
+    double *dataPointer = (double*) PyArray_DATA(arr);
+    $self->transformModelVector(dataPointer, rigidity);
+    return input;
+  }
 };
 #else
 %extend crpropa::MagneticLens{
-    PyObject * transformModelVector_numpyArray(PyObject *input, double rigidity)
-    {
-      std::cerr << "ERROR: PARSEC was compiled without numpy support!" << std::endl;
-      Py_RETURN_NONE;
-    }
+  PyObject * transformModelVector_numpyArray(PyObject *input, double rigidity)
+  {
+    std::cerr << "ERROR: CRPropa was compiled without NumPy support!" << std::endl;
+    Py_RETURN_NONE;
+  }
 };
 #endif
 
@@ -237,32 +237,32 @@
 %extend crpropa::ParticleMapsContainer{
   PyObject *getMap_numpyArray(const int particleId, double energy)
   {
-      std::cerr << "ERROR: PARSEC was compiled without numpy support!" << std::endl;
+      std::cerr << "ERROR: CRPropa was compiled without NumPy support!" << std::endl;
       Py_RETURN_NONE;
   }
 };
 %extend crpropa::ParticleMapsContainer{
   PyObject *getParticleIds_numpyArray()
   {
-      std::cerr << "ERROR: PARSEC was compiled without numpy support!" << std::endl;
+      std::cerr << "ERROR: CRPropa was compiled without NumPy support!" << std::endl;
       Py_RETURN_NONE;
   }
 };
 %extend crpropa::ParticleMapsContainer{
   PyObject *getEnergies_numpyArray(const int pid)
   {
-      std::cerr << "ERROR: PARSEC was compiled without numpy support!" << std::endl;
+      std::cerr << "ERROR: CRPropa was compiled without NumPy support!" << std::endl;
       Py_RETURN_NONE;
   }
 };
 %extend crpropa::ParticleMapsContainer{
   PyObject *getRandomParticles_numpyArray(size_t N)
   {
-      std::cerr << "ERROR: PARSEC was compiled without numpy support!" << std::endl;
+      std::cerr << "ERROR: CRPropa was compiled without NumPy support!" << std::endl;
       Py_RETURN_NONE;
   }
 };
-#endif // with numpy
+#endif // with NumPy
 
-#endif // WITH_GALACTIC_LENSES_
+#endif // WITH_GALACTIC_LENSES
 

--- a/test/testMagneticLensPythonInterface.py
+++ b/test/testMagneticLensPythonInterface.py
@@ -60,9 +60,9 @@ class testParticleMapsContainer(unittest.TestCase):
             print("Cannot import numpy. Not testing testAddParticles!")
             return
 
-        self.assertEquals(len(self.maps.getParticleIds()), 1)
-        self.assertEquals(self.maps.getParticleIds()[0], 12)
-        self.assertEquals(len(self.maps.getEnergies(12)), 1)
+        self.assertEqual(len(self.maps.getParticleIds()), 1)
+        self.assertEqual(self.maps.getParticleIds()[0], 12)
+        self.assertEqual(len(self.maps.getEnergies(12)), 1)
 
     def testAddParticlesNumpyInterface(self):
         try:
@@ -108,11 +108,11 @@ class testParticleMapsContainer(unittest.TestCase):
         # accept int32 and int64
         ids = np.ones(N, dtype='int32')
         self.maps.addParticles(ids, energy, lons, lats, weights )
-        self.assertEquals(self.maps.getParticleIds()[0], ids[0])
+        self.assertEqual(self.maps.getParticleIds()[0], ids[0])
 
         ids = np.ones(N, dtype='int64')
         self.maps.addParticles(ids, energy, lons, lats, weights)
-        self.assertEquals(self.maps.getParticleIds()[0], ids[0])
+        self.assertEqual(self.maps.getParticleIds()[0], ids[0])
 
     def testAddParticleVectorInterface(self):
         try:
@@ -122,9 +122,9 @@ class testParticleMapsContainer(unittest.TestCase):
             return
 
         self.maps.addParticle(12, 1 * EeV, crpropa.Vector3d(1, 0, 0))
-        self.assertEquals(len(self.maps.getParticleIds()), 1)
-        self.assertEquals(self.maps.getParticleIds()[0], 12)
-        self.assertEquals(len(self.maps.getEnergies(12)), 1)
+        self.assertEqual(len(self.maps.getParticleIds()), 1)
+        self.assertEqual(self.maps.getParticleIds()[0], 12)
+        self.assertEqual(len(self.maps.getEnergies(12)), 1)
 
     def testGetRandomParticlesInterface(self):
         try:


### PR DESCRIPTION
This PR fixes #350. The tests for the magnetic lenses were failing in some cases. 
It was tested in OSX 11.4 and on Cent OS, both with  Python 3.8.3. More tests might be needed.

This quick fix draws largely from the suggestions by user @tdwiser [33631c8](https://github.com/tdwiser/CRPropa3/commit/33631c8abb3f9a93e8ef8ef6422cf7e528db8e14) suggested in #350. This might also be relevant for issue #316. 