### PR TITLE
Update share directory of interaction data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,7 +548,7 @@ add_definitions(-DCRPROPA_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
 install(TARGETS crpropa DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.h")
 install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include FILES_MATCHING PATTERN "*.h")
-install(DIRECTORY ${CMAKE_BINARY_DIR}/data/ DESTINATION share/crpropa/ PATTERN ".git" EXCLUDE)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}/data/ DESTINATION share/crpropa/ PATTERN ".git" EXCLUDE)
 
 install(DIRECTORY libs/kiss/include/ DESTINATION include)
 


### PR DESCRIPTION
When data tar balls, including a date signature, were introduced in 957bdae, the new data structure was not consistently used in the install part of the CMakeList file. This PR updates the install path.  

This should fix issue #354.