### PR TITLE
Custom magnetic fields via Python

### DIFF
--- a/include/crpropa/module/DiffusionSDE.h
+++ b/include/crpropa/module/DiffusionSDE.h
@@ -79,12 +79,12 @@ public:
 	    double getEpsilon() const;
 	    double getAlpha() const;
 	    double getScale() const;
-		ref_ptr<MagneticField> getField() const;
+		ref_ptr<MagneticField> getMagneticField() const;
 		/** get magnetic field vector at current candidate position
 		 * @param pos   current position of the candidate
 		 * @param z	 current redshift is needed to calculate the magnetic field
 		 * @return	  magnetic field vector at the position pos */
-		Vector3d getFieldAtPosition(Vector3d pos, double z) const;
+		Vector3d getMagneticFieldAtPosition(Vector3d pos, double z) const;
 	    std::string getDescription() const;
 
 };

--- a/include/crpropa/module/DiffusionSDE.h
+++ b/include/crpropa/module/DiffusionSDE.h
@@ -85,7 +85,12 @@ public:
 		 * @param z	 current redshift is needed to calculate the magnetic field
 		 * @return	  magnetic field vector at the position pos */
 		Vector3d getMagneticFieldAtPosition(Vector3d pos, double z) const;
-	    std::string getDescription() const;
+	    ref_ptr<AdvectionField> getAdvectionField() const;
+		/** get advection field vector at current candidate position
+		 * @param pos   current position of the candidate
+		 * @return	  magnetic field vector at the position pos */
+		Vector3d getAdvectionFieldAtPosition(Vector3d pos) const;
+		std::string getDescription() const;
 
 };
 /** @}*/

--- a/include/crpropa/module/DiffusionSDE.h
+++ b/include/crpropa/module/DiffusionSDE.h
@@ -79,6 +79,13 @@ public:
 	    double getEpsilon() const;
 	    double getAlpha() const;
 	    double getScale() const;
+		 /** get functions for the parameters of the class PropagationCK, similar to the set functions */
+		ref_ptr<MagneticField> getField() const;
+		/** get magnetic field vector at current candidate position
+		 * @param pos   current position of the candidate
+		 * @param z	 current redshift is needed to calculate the magnetic field
+		 * @return	  magnetic field vector at the position pos */
+		Vector3d getFieldAtPosition(Vector3d pos, double z) const;
 	    std::string getDescription() const;
 
 };

--- a/include/crpropa/module/DiffusionSDE.h
+++ b/include/crpropa/module/DiffusionSDE.h
@@ -79,7 +79,6 @@ public:
 	    double getEpsilon() const;
 	    double getAlpha() const;
 	    double getScale() const;
-		 /** get functions for the parameters of the class PropagationCK, similar to the set functions */
 		ref_ptr<MagneticField> getField() const;
 		/** get magnetic field vector at current candidate position
 		 * @param pos   current position of the candidate

--- a/include/crpropa/module/PropagationBP.h
+++ b/include/crpropa/module/PropagationBP.h
@@ -4,6 +4,7 @@
 #include "crpropa/Module.h"
 #include "crpropa/Units.h"
 #include "crpropa/magneticField/MagneticField.h"
+#include "kiss/logger.h"
 
 namespace crpropa {
 /**

--- a/include/crpropa/module/PropagationCK.h
+++ b/include/crpropa/module/PropagationCK.h
@@ -73,6 +73,8 @@ public:
 	void setMinimumStep(double minStep);
 	void setMaximumStep(double maxStep);
 
+	 /** get functions for the parameters of the class PropagationCK, similar to the set functions */
+	ref_ptr<MagneticField> getField() const;
 	double getTolerance() const;
 	double getMinimumStep() const;
 	double getMaximumStep() const;

--- a/include/crpropa/module/PropagationCK.h
+++ b/include/crpropa/module/PropagationCK.h
@@ -75,6 +75,13 @@ public:
 
 	 /** get functions for the parameters of the class PropagationCK, similar to the set functions */
 	ref_ptr<MagneticField> getField() const;
+	
+	/** get magnetic field vector at current candidate position
+	 * @param pos   current position of the candidate
+	 * @param z	 current redshift is needed to calculate the magnetic field
+	 * @return	  magnetic field vector at the position pos */
+	Vector3d getFieldAtPosition(Vector3d pos, double z) const;
+
 	double getTolerance() const;
 	double getMinimumStep() const;
 	double getMaximumStep() const;

--- a/include/crpropa/module/PropagationCK.h
+++ b/include/crpropa/module/PropagationCK.h
@@ -4,6 +4,7 @@
 #include "crpropa/Module.h"
 #include "crpropa/Units.h"
 #include "crpropa/magneticField/MagneticField.h"
+#include "kiss/logger.h"
 
 namespace crpropa {
 /**

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -407,6 +407,7 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 
 %implicitconv crpropa::ref_ptr<crpropa::Density>;
 %template(DensityRefPtr) crpropa::ref_ptr<crpropa::Density>;
+%feature("director") crpropa::Density;
 %include "crpropa/massDistribution/Density.h"
 
 %include "crpropa/Grid.h"

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -402,6 +402,7 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 
 %implicitconv crpropa::ref_ptr<crpropa::AdvectionField>;
 %template(AdvectionFieldRefPtr) crpropa::ref_ptr<crpropa::AdvectionField>;
+%feature("director") crpropa::AdvectionField;
 %include "crpropa/advectionField/AdvectionField.h"
 
 %implicitconv crpropa::ref_ptr<crpropa::Density>;

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -394,6 +394,7 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 
 %implicitconv crpropa::ref_ptr<crpropa::MagneticField>;
 %template(MagneticFieldRefPtr) crpropa::ref_ptr<crpropa::MagneticField>;
+%feature("director") crpropa::MagneticField;
 %include "crpropa/magneticField/MagneticField.h"
 
 %implicitconv crpropa::ref_ptr<crpropa::PhotonField>;

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -172,7 +172,6 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %include "crpropa/Units.h"
 %include "crpropa/Common.h"
 %include "crpropa/Cosmology.h"
-%include "crpropa/PhotonBackground.h"
 %include "crpropa/PhotonPropagation.h"
 %template(RandomSeed) std::vector<uint32_t>;
 %template(RandomSeedThreads) std::vector< std::vector<uint32_t> >;
@@ -399,6 +398,8 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 
 %implicitconv crpropa::ref_ptr<crpropa::PhotonField>;
 %template(PhotonFieldRefPtr) crpropa::ref_ptr<crpropa::PhotonField>;
+%feature("director") crpropa::PhotonField;
+%include "crpropa/PhotonBackground.h"
 
 %implicitconv crpropa::ref_ptr<crpropa::AdvectionField>;
 %template(AdvectionFieldRefPtr) crpropa::ref_ptr<crpropa::AdvectionField>;

--- a/src/module/DiffusionSDE.cpp
+++ b/src/module/DiffusionSDE.cpp
@@ -241,14 +241,7 @@ void DiffusionSDE::tryStep(const Vector3d &PosIn, Vector3d &POut, Vector3d &PosE
 		  y_n += k[j] * a[i * 6 + j] * propStep;
 
 		// update k_i = direction of the regular magnetic mean field
-		Vector3d BField(0.);
-		try {
-		  	BField = magneticField->getField(y_n, z);
-		}
-		catch (std::exception &e) {
-			KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in magneticField::getField.\n"
-					<< e.what();
-		}
+		Vector3d BField = getFieldAtPosition(y_n, z);
 
 		k[i] = BField.getUnitVector() * c_light;
 
@@ -359,8 +352,8 @@ double DiffusionSDE::getScale() const {
 }
 
 ref_ptr<MagneticField> DiffusionSDE::getField() const {
-		return magneticField;
-	}
+	return magneticField;
+}
 
 Vector3d DiffusionSDE::getFieldAtPosition(Vector3d pos, double z) const {
 	Vector3d B(0, 0, 0);

--- a/src/module/DiffusionSDE.cpp
+++ b/src/module/DiffusionSDE.cpp
@@ -251,16 +251,9 @@ void DiffusionSDE::tryStep(const Vector3d &PosIn, Vector3d &POut, Vector3d &PosE
 	}
 }
 
-void DiffusionSDE::driftStep(const Vector3d &Pos, Vector3d &LinProp, double h) const {
-	Vector3d AdvField(0.);
-	try {
-		AdvField = advectionField->getField(Pos);
-	}
-	catch (std::exception &e) {
-		KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in advectionField::getField.\n"
-				<< e.what();
-	}
-	LinProp += AdvField * h;
+void DiffusionSDE::driftStep(const Vector3d &pos, Vector3d &linProp, double h) const {
+	Vector3d advField = getAdvectionFieldAtPosition(pos);
+	linProp += advField * h;
 	return;
 }
 
@@ -364,10 +357,29 @@ Vector3d DiffusionSDE::getMagneticFieldAtPosition(Vector3d pos, double z) const 
 			B = magneticField->getField(pos, z);
 	}
 	catch (std::exception &e) {
-		KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in DiffusionSDE::getField.\n"
+		KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in DiffusionSDE::getMagneticFieldAtPosition.\n"
 				<< e.what();
 	}	
 	return B;
+}
+
+ref_ptr<AdvectionField> DiffusionSDE::getAdvectionField() const {
+	return advectionField;
+}
+
+Vector3d DiffusionSDE::getAdvectionFieldAtPosition(Vector3d pos) const {
+	Vector3d AdvField(0.);
+	try {
+		// check if field is valid and use the field vector at the
+		// position pos
+		if (advectionField.valid())
+			AdvField = advectionField->getField(pos);
+	}
+	catch (std::exception &e) {
+		KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in DiffusionSDE::getAdvectionFieldAtPosition.\n"
+				<< e.what();
+	}
+	return AdvField;
 }
 
 std::string DiffusionSDE::getDescription() const {

--- a/src/module/DiffusionSDE.cpp
+++ b/src/module/DiffusionSDE.cpp
@@ -241,7 +241,7 @@ void DiffusionSDE::tryStep(const Vector3d &PosIn, Vector3d &POut, Vector3d &PosE
 		  y_n += k[j] * a[i * 6 + j] * propStep;
 
 		// update k_i = direction of the regular magnetic mean field
-		Vector3d BField = getFieldAtPosition(y_n, z);
+		Vector3d BField = getMagneticFieldAtPosition(y_n, z);
 
 		k[i] = BField.getUnitVector() * c_light;
 
@@ -351,11 +351,11 @@ double DiffusionSDE::getScale() const {
 	return scale;
 }
 
-ref_ptr<MagneticField> DiffusionSDE::getField() const {
+ref_ptr<MagneticField> DiffusionSDE::getMagneticField() const {
 	return magneticField;
 }
 
-Vector3d DiffusionSDE::getFieldAtPosition(Vector3d pos, double z) const {
+Vector3d DiffusionSDE::getMagneticFieldAtPosition(Vector3d pos, double z) const {
 	Vector3d B(0, 0, 0);
 	try {
 		// check if field is valid and use the field vector at the

--- a/src/module/DiffusionSDE.cpp
+++ b/src/module/DiffusionSDE.cpp
@@ -364,7 +364,7 @@ Vector3d DiffusionSDE::getFieldAtPosition(Vector3d pos, double z) const {
 			B = magneticField->getField(pos, z);
 	}
 	catch (std::exception &e) {
-		KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in magneticField::getField.\n"
+		KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in DiffusionSDE::getField.\n"
 				<< e.what();
 	}	
 	return B;

--- a/src/module/DiffusionSDE.cpp
+++ b/src/module/DiffusionSDE.cpp
@@ -357,18 +357,16 @@ ref_ptr<MagneticField> DiffusionSDE::getField() const {
 
 Vector3d DiffusionSDE::getFieldAtPosition(Vector3d pos, double z) const {
 	Vector3d B(0, 0, 0);
-	// check if field is valid and use the field vector at the
-	// position pos with the redshift z
-	if (magneticField.valid()) {
-		try {
-		  	B = magneticField->getField(pos, z);
-		}
-		catch (std::exception &e) {
-			KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in magneticField::getField.\n"
-					<< e.what();
-		}
+	try {
+		// check if field is valid and use the field vector at the
+		// position pos with the redshift z
+		if (magneticField.valid())
+			B = magneticField->getField(pos, z);
 	}
-		
+	catch (std::exception &e) {
+		KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in magneticField::getField.\n"
+				<< e.what();
+	}	
 	return B;
 }
 

--- a/src/module/DiffusionSDE.cpp
+++ b/src/module/DiffusionSDE.cpp
@@ -358,7 +358,26 @@ double DiffusionSDE::getScale() const {
 	return scale;
 }
 
+ref_ptr<MagneticField> DiffusionSDE::getField() const {
+		return magneticField;
+	}
 
+Vector3d DiffusionSDE::getFieldAtPosition(Vector3d pos, double z) const {
+	Vector3d B(0, 0, 0);
+	// check if field is valid and use the field vector at the
+	// position pos with the redshift z
+	if (magneticField.valid()) {
+		try {
+		  	B = magneticField->getField(pos, z);
+		}
+		catch (std::exception &e) {
+			KISS_LOG_ERROR 	<< "DiffusionSDE: Exception in magneticField::getField.\n"
+					<< e.what();
+		}
+	}
+		
+	return B;
+}
 
 std::string DiffusionSDE::getDescription() const {
 	std::stringstream s;

--- a/src/module/PropagationBP.cpp
+++ b/src/module/PropagationBP.cpp
@@ -147,11 +147,15 @@ namespace crpropa {
 
 	Vector3d PropagationBP::getFieldAtPosition(Vector3d pos, double z) const {
 		Vector3d B(0, 0, 0);
-		// check if field is valid and use the field vector at the
-		// position pos with the redshift z
-		if (field.valid())
-			B = field->getField(pos, z);
-
+		try {
+			// check if field is valid and use the field vector at the
+			// position pos with the redshift z
+			if (field.valid())
+				B = field->getField(pos, z);
+		} catch (std::exception &e) {
+			KISS_LOG_ERROR 	<< "PropagationBP: Exception in magneticField::getField.\n"
+					<< e.what();
+		}	
 		return B;
 	}
 

--- a/src/module/PropagationBP.cpp
+++ b/src/module/PropagationBP.cpp
@@ -153,7 +153,7 @@ namespace crpropa {
 			if (field.valid())
 				B = field->getField(pos, z);
 		} catch (std::exception &e) {
-			KISS_LOG_ERROR 	<< "PropagationBP: Exception in PropagationBP::getField.\n"
+			KISS_LOG_ERROR 	<< "PropagationBP: Exception in PropagationBP::getFieldAtPosition.\n"
 					<< e.what();
 		}	
 		return B;

--- a/src/module/PropagationBP.cpp
+++ b/src/module/PropagationBP.cpp
@@ -153,7 +153,7 @@ namespace crpropa {
 			if (field.valid())
 				B = field->getField(pos, z);
 		} catch (std::exception &e) {
-			KISS_LOG_ERROR 	<< "PropagationBP: Exception in magneticField::getField.\n"
+			KISS_LOG_ERROR 	<< "PropagationBP: Exception in PropagationBP::getField.\n"
 					<< e.what();
 		}	
 		return B;

--- a/src/module/PropagationCK.cpp
+++ b/src/module/PropagationCK.cpp
@@ -133,7 +133,7 @@ Vector3d PropagationCK::getFieldAtPosition(Vector3d pos, double z) const {
 		if (field.valid())
 			B = field->getField(pos, z);
 	} catch (std::exception &e) {
-		KISS_LOG_ERROR 	<< "PropagationCK: Exception in magneticField::getField.\n"
+		KISS_LOG_ERROR 	<< "PropagationCK: Exception in PropagationCK::getField.\n"
 				<< e.what();
 	}	
 	return B;

--- a/src/module/PropagationCK.cpp
+++ b/src/module/PropagationCK.cpp
@@ -124,6 +124,10 @@ void PropagationCK::setField(ref_ptr<MagneticField> f) {
 	field = f;
 }
 
+ref_ptr<MagneticField> PropagationCK::getField() const {
+	return field;
+}
+
 void PropagationCK::setTolerance(double tol) {
 	if ((tol > 1) or (tol < 0))
 		throw std::runtime_error(

--- a/src/module/PropagationCK.cpp
+++ b/src/module/PropagationCK.cpp
@@ -51,13 +51,10 @@ void PropagationCK::tryStep(const Y &y, Y &out, Y &error, double h,
 PropagationCK::Y PropagationCK::dYdt(const Y &y, ParticleState &p, double z) const {
 	// normalize direction vector to prevent numerical losses
 	Vector3d velocity = y.u.getUnitVector() * c_light;
-	Vector3d B(0, 0, 0);
-	try {
-		B = field->getField(y.x, z);
-	} catch (std::exception &e) {
-		std::cerr << "PropagationCK: Exception in getField." << std::endl;
-		std::cerr << e.what() << std::endl;
-	}
+	
+	// get B field at particle position
+	Vector3d B = getFieldAtPosition(y.x, z);
+
 	// Lorentz force: du/dt = q*c/E * (v x B)
 	Vector3d dudt = p.getCharge() * c_light / p.getEnergy() * velocity.cross(B);
 	return Y(velocity, dudt);
@@ -126,6 +123,16 @@ void PropagationCK::setField(ref_ptr<MagneticField> f) {
 
 ref_ptr<MagneticField> PropagationCK::getField() const {
 	return field;
+}
+
+Vector3d PropagationCK::getFieldAtPosition(Vector3d pos, double z) const {
+	Vector3d B(0, 0, 0);
+	// check if field is valid and use the field vector at the
+	// position pos with the redshift z
+	if (field.valid())
+		B = field->getField(pos, z);
+
+	return B;
 }
 
 void PropagationCK::setTolerance(double tol) {

--- a/src/module/PropagationCK.cpp
+++ b/src/module/PropagationCK.cpp
@@ -127,11 +127,15 @@ ref_ptr<MagneticField> PropagationCK::getField() const {
 
 Vector3d PropagationCK::getFieldAtPosition(Vector3d pos, double z) const {
 	Vector3d B(0, 0, 0);
-	// check if field is valid and use the field vector at the
-	// position pos with the redshift z
-	if (field.valid())
-		B = field->getField(pos, z);
-
+	try {
+		// check if field is valid and use the field vector at the
+		// position pos with the redshift z
+		if (field.valid())
+			B = field->getField(pos, z);
+	} catch (std::exception &e) {
+		KISS_LOG_ERROR 	<< "PropagationCK: Exception in magneticField::getField.\n"
+				<< e.what();
+	}	
 	return B;
 }
 

--- a/src/module/PropagationCK.cpp
+++ b/src/module/PropagationCK.cpp
@@ -133,7 +133,7 @@ Vector3d PropagationCK::getFieldAtPosition(Vector3d pos, double z) const {
 		if (field.valid())
 			B = field->getField(pos, z);
 	} catch (std::exception &e) {
-		KISS_LOG_ERROR 	<< "PropagationCK: Exception in PropagationCK::getField.\n"
+		KISS_LOG_ERROR 	<< "PropagationCK: Exception in PropagationCK::getFieldAtPosition.\n"
 				<< e.what();
 	}	
 	return B;

--- a/test/testPythonExtension.py
+++ b/test/testPythonExtension.py
@@ -73,6 +73,19 @@ class testCrossLanguagePolymorphism(unittest.TestCase):
             obs.process(candidate)
             self.assertEqual(i + 1, counter.value)
 
+    def testCustomMagneticField(self):
+        class CustomMagneticField(crp.MagneticField):
+            def __init__(self, val):
+                crp.MagneticField.__init__(self)
+                self.val = val
+                
+            def getField(self, position):
+                return crp.Vector3d(self.val)
+
+            def getField(self, position, z):
+                return crp.Vector3d(self.val)
+
+
 
 class testCandidatePropertymap(unittest.TestCase):
     def setUp(self):

--- a/test/testPythonExtension.py
+++ b/test/testPythonExtension.py
@@ -153,6 +153,31 @@ class testCrossLanguagePolymorphism(unittest.TestCase):
         self.assertEqual(HIIDensity, massDensity.getHIIDensity(pos))
         self.assertEqual(H2Density, massDensity.getH2Density(pos))
 
+    def testCustomPhotonField(self):
+        class CustomPhotonField(crp.PhotonField):
+            def __init__(self, density):
+                crp.PhotonField.__init__(self)
+                self.density = density
+                self.fieldName = 'testCustomPhotonField'
+                self.isRedshiftDependent = True
+                
+            def getPhotonDensity(self, energy, z):
+                return self.density
+
+            def getFieldName(self):
+                return self.fieldName
+
+            def hasRedshiftDependence(self):
+                return self.isRedshiftDependent
+
+        photonDensity = 10
+        photonField = CustomPhotonField(photonDensity)
+        energy = 10*crp.GeV
+        z = 0
+        self.assertEqual(photonDensity, photonField.getPhotonDensity(energy, z))
+        self.assertEqual('testCustomPhotonField', photonField.getFieldName())
+        self.assertEqual(True, photonField.hasRedshiftDependence())
+
 
 class testCandidatePropertymap(unittest.TestCase):
     def setUp(self):

--- a/test/testPythonExtension.py
+++ b/test/testPythonExtension.py
@@ -87,9 +87,14 @@ class testCrossLanguagePolymorphism(unittest.TestCase):
 
         field = CustomMagneticField(crp.gauss)
         propBP = crp.PropagationBP(field, 1e-4, 1*crp.Mpc, 1*crp.Mpc)
+        propCK = crp.PropagationCK(field, 1e-4, 1*crp.Mpc, 1*crp.Mpc)
+        propSDE = crp.DiffusionSDE(field)
         pos = crp.Vector3d(-1, 0, 0)
-        self.assertEqual(field.getField(pos, 0), propBP.getFieldAtPosition(pos, 0))
-
+        z = 0
+        fieldAtPos = field.getField(pos, z)
+        self.assertEqual(fieldAtPos, propBP.getFieldAtPosition(pos, z))
+        self.assertEqual(fieldAtPos, propCK.getFieldAtPosition(pos, z))
+        self.assertEqual(fieldAtPos, propSDE.getFieldAtPosition(pos, z))
 
 
 class testCandidatePropertymap(unittest.TestCase):

--- a/test/testPythonExtension.py
+++ b/test/testPythonExtension.py
@@ -85,6 +85,11 @@ class testCrossLanguagePolymorphism(unittest.TestCase):
             def getField(self, position, z):
                 return crp.Vector3d(self.val)
 
+        field = CustomMagneticField(crp.gauss)
+        propBP = crp.PropagationBP(field, 1e-4, 1*crp.Mpc, 1*crp.Mpc)
+        pos = crp.Vector3d(-1, 0, 0)
+        self.assertEqual(field.getField(pos, 0), propBP.getFieldAtPosition(pos, 0))
+
 
 
 class testCandidatePropertymap(unittest.TestCase):

--- a/test/testPythonExtension.py
+++ b/test/testPythonExtension.py
@@ -118,17 +118,40 @@ class testCrossLanguagePolymorphism(unittest.TestCase):
 
     def testCustomMassDensity(self):
         class CustomMassDensity(crp.Density):
-            def __init__(self, val):
+            def __init__(self, density, HIDensity, HIIDensity, H2Density, nucleonDensity):
                 crp.Density.__init__(self)
-                self.val = val
+                self.density = density
+                self.HIDensity = HIDensity
+                self.HIIDensity = HIIDensity
+                self.H2Density = H2Density
+                self.nucleonDensity = nucleonDensity
                 
             def getDensity(self, position):
-                return self.val
+                return self.density
+
+            def getHIDensity(self, position):
+                return self.HIDensity
+
+            def getHIIDensity(self, position):
+                return self.HIIDensity
+
+            def getH2Density(self, position):
+                return self.H2Density
+
+            def NucleonDensity(self, position):
+                return self.nucleonDensity
 
         density = 10
-        massDensity = CustomMassDensity(density)
+        HIDensity = 5
+        HIIDensity = 2
+        H2Density = 1
+        nucleonDensity = 0.5
+        massDensity = CustomMassDensity(density, HIDensity, HIIDensity, H2Density, nucleonDensity)
         pos = crp.Vector3d(1, 0, 0)
         self.assertEqual(density, massDensity.getDensity(pos))
+        self.assertEqual(HIDensity, massDensity.getHIDensity(pos))
+        self.assertEqual(HIIDensity, massDensity.getHIIDensity(pos))
+        self.assertEqual(H2Density, massDensity.getH2Density(pos))
 
 
 class testCandidatePropertymap(unittest.TestCase):

--- a/test/testPythonExtension.py
+++ b/test/testPythonExtension.py
@@ -116,6 +116,20 @@ class testCrossLanguagePolymorphism(unittest.TestCase):
         advFieldAtPos = advField.getField(pos)
         self.assertEqual(advFieldAtPos, propSDE.getAdvectionFieldAtPosition(pos))
 
+    def testCustomMassDensity(self):
+        class CustomMassDensity(crp.Density):
+            def __init__(self, val):
+                crp.Density.__init__(self)
+                self.val = val
+                
+            def getDensity(self, position):
+                return self.val
+
+        density = 10
+        massDensity = CustomMassDensity(density)
+        pos = crp.Vector3d(1, 0, 0)
+        self.assertEqual(density, massDensity.getDensity(pos))
+
 
 class testCandidatePropertymap(unittest.TestCase):
     def setUp(self):

--- a/test/testPythonExtension.py
+++ b/test/testPythonExtension.py
@@ -94,7 +94,7 @@ class testCrossLanguagePolymorphism(unittest.TestCase):
         fieldAtPos = field.getField(pos, z)
         self.assertEqual(fieldAtPos, propBP.getFieldAtPosition(pos, z))
         self.assertEqual(fieldAtPos, propCK.getFieldAtPosition(pos, z))
-        self.assertEqual(fieldAtPos, propSDE.getFieldAtPosition(pos, z))
+        self.assertEqual(fieldAtPos, propSDE.getMagneticFieldAtPosition(pos, z))
 
 
 class testCandidatePropertymap(unittest.TestCase):

--- a/test/testPythonExtension.py
+++ b/test/testPythonExtension.py
@@ -96,6 +96,26 @@ class testCrossLanguagePolymorphism(unittest.TestCase):
         self.assertEqual(fieldAtPos, propCK.getFieldAtPosition(pos, z))
         self.assertEqual(fieldAtPos, propSDE.getMagneticFieldAtPosition(pos, z))
 
+    def testCustomAdvectionField(self):
+        class CustomAdvectionField(crp.AdvectionField):
+            def __init__(self, val):
+                crp.AdvectionField.__init__(self)
+                self.val = val
+                
+            def getField(self, position):
+                return crp.Vector3d(self.val)
+
+            def getDivergence(self, position):
+                return 0.0
+
+        constMagVec = crp.Vector3d(0*crp.nG,0*crp.nG,1*crp.nG)
+        magField = crp.UniformMagneticField(constMagVec)
+        advField = CustomAdvectionField(1)
+        propSDE = crp.DiffusionSDE(magField, advField)
+        pos = crp.Vector3d(1, 0, 0)
+        advFieldAtPos = advField.getField(pos)
+        self.assertEqual(advFieldAtPos, propSDE.getAdvectionFieldAtPosition(pos))
+
 
 class testCandidatePropertymap(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR fixes #365. Currently, CRPropa can't handle custom magnetic fields implemented in Python. This PR allows for custom magnetic fields via Python.

**Background**
To correctly implement a Python class that inherits from the wrapped C++ MagneticField class that contains virtual methods, cross-language polymorphism via directors is needed. The child Python class for the custom magnetic field should override the getField base class function. However, as we don't have enabled directors for the MagneticField class, this fails currently.

**Changes**
Inserting the decorator in the `2_headers.i` file solves the issue. For enhanced testability and synchronization between the propagation modules, I introduced getField functions for PropagationCK and DiffsuionSDE, similar to PropagationBP. I also added better handling of possible magnetic field issues during the propagation.