### PR TITLE
Deprecate DINT/EleCa

### DIFF
--- a/src/EmissionMap.cpp
+++ b/src/EmissionMap.cpp
@@ -2,6 +2,8 @@
 #include "crpropa/Random.h"
 #include "crpropa/Units.h"
 
+#include "kiss/logger.h"
+
 #include <fstream>
 
 namespace crpropa {
@@ -235,7 +237,7 @@ void EmissionMap::merge(const EmissionMap *other) {
 		ref_ptr<CylindricalProjectionMap> cpm = getMap(i->first.first, i->first.second);
 
 		if (otherpdf.size() != cpm->getPdf().size()) {
-			std::cout << "pdf size mismatch!" << std::endl;
+			throw std::runtime_error("PDF size mismatch!");
 			break;
 		}
 
@@ -263,14 +265,16 @@ void EmissionMap::load(const std::string &filename) {
 		in >> nPhi_ >> nTheta_;
 
 		if (!in.good()) {
-			std::cout << "invalid line: " << key.first << " " << key.second << " " << nPhi_ << " " << nTheta_ << std::endl;
+			KISS_LOG_ERROR << "Invalid line: " << key.first << " " << key.second << " " << nPhi_ << " " << nTheta_;
 			break;
 		}
 
-		if (nPhi != nPhi_)
-			std::cout << "Warning: nPhi mismatch: " << nPhi << " " << nPhi_ << std::endl;
-		if (nTheta != nTheta_)
-			std::cout << "Warning: nTheta mismatch: " << nTheta << " " << nTheta_ << std::endl;
+		if (nPhi != nPhi_) {
+			KISS_LOG_WARNING << "nPhi mismatch: " << nPhi << " " << nPhi_;
+		}
+		if (nTheta != nTheta_) {
+			KISS_LOG_WARNING << "nTheta mismatch: " << nTheta << " " << nTheta_;
+		}
 
 		ref_ptr<CylindricalProjectionMap> cpm = new CylindricalProjectionMap(nPhi_, nTheta_);
 		std::vector<double> &pdf = cpm->getPdf();
@@ -279,9 +283,9 @@ void EmissionMap::load(const std::string &filename) {
 
 		if (in.good()) {
 			maps[key] = cpm;
-			std::cout << "added " << key.first << " " << key.second << std::endl;
+			// std::cout << "added " << key.first << " " << key.second << std::endl;
 		} else {
-			std::cout << "invalid data in line: " << key.first << " " << key.second << " " << nPhi_ << " " << nTheta_ << std::endl;
+			KISS_LOG_WARNING << "Invalid data in line: " << key.first << " " << key.second << " " << nPhi_ << " " << nTheta_ << "\n";
 		}
 	}
 

--- a/src/PhotonPropagation.cpp
+++ b/src/PhotonPropagation.cpp
@@ -10,6 +10,8 @@
 
 #include "dint/prop_second.h"
 #include "dint/DintEMCascade.h"
+#include "kiss/string.h"
+#include "kiss/logger.h"
 
 #include <fstream>
 #include <cstdio>
@@ -29,6 +31,8 @@ void ElecaPropagation(
 		double lowerEnergyThreshold,
 		double magneticFieldStrength,
 		const std::string &background) {
+
+	KISS_LOG_WARNING << "EleCa propagation is deprecated and is no longer supported. Please use the EM* (EMPairProduction, EMInverseComptonScattering, ...) modules instead.\n";
 
 	std::ifstream infile(inputfile.c_str());
 	std::streampos startPosition = infile.tellg();
@@ -169,6 +173,8 @@ void DintPropagation(
 		double magneticFieldStrength,
 		double aCutcascade_Magfield) {
 
+	KISS_LOG_WARNING << "DINT propagation is deprecated and is no longer supported. Please use the EM* (EMPairProduction, EMInverseComptonScattering, ...) modules instead.\n";
+
 	// initialize the energy grids for DINT
 	dCVector energyGrid, energyWidth;
 	New_dCVector(&energyGrid, NUM_MAIN_BINS);
@@ -305,6 +311,8 @@ void DintElecaPropagation(
 		double crossOverEnergy,
 		double magneticFieldStrength,
 		double aCutcascade_Magfield) {
+
+	KISS_LOG_WARNING << "EleCa+DINT propagation is deprecated and is no longer supported. Please use the EM* (EMPairProduction, EMInverseComptonScattering, ...) modules instead.\n";
 
 	////////////////////////////////////////////////////////////////////////
 	//Initialize EleCa

--- a/src/module/EMCascade.cpp
+++ b/src/module/EMCascade.cpp
@@ -15,7 +15,7 @@
 namespace crpropa {
 
 EMCascade::EMCascade() : nE(170), logEmin(7), logEmax(24), dlogE(0.1) {
-	KISS_LOG_WARNING << "This module is deprecated and is no longer supported. Please use the EM* (EMPairProduction, EMInverseComptonScattering, ...) modules instead.\n";
+	KISS_LOG_WARNING << "EMCascade is deprecated and is no longer supported. Please use the EM* (EMPairProduction, EMInverseComptonScattering, ...) modules instead.\n";
 	setDistanceBinning(1000 * Mpc, 1000);
 }
 

--- a/src/module/EMCascade.cpp
+++ b/src/module/EMCascade.cpp
@@ -3,6 +3,7 @@
 #include "crpropa/Units.h"
 
 #include "dint/DintEMCascade.h"
+#include "kiss/logger.h"
 
 #include <fstream>
 #include <sstream>
@@ -14,6 +15,7 @@
 namespace crpropa {
 
 EMCascade::EMCascade() : nE(170), logEmin(7), logEmax(24), dlogE(0.1) {
+	KISS_LOG_WARNING << "This module is deprecated and is no longer supported. Please use the EM* (EMPairProduction, EMInverseComptonScattering, ...) modules instead.\n";
 	setDistanceBinning(1000 * Mpc, 1000);
 }
 

--- a/src/module/PhotonEleCa.cpp
+++ b/src/module/PhotonEleCa.cpp
@@ -4,6 +4,7 @@
 #include "EleCa/Propagation.h"
 #include "EleCa/Particle.h"
 #include "EleCa/Common.h"
+#include "kiss/logger.h"
 
 #include <vector>
 
@@ -12,7 +13,7 @@ namespace crpropa {
 PhotonEleCa::PhotonEleCa(const std::string background,
 		const std::string &outputFilename) :
 		propagation(new eleca::Propagation), saveOnlyPhotonEnergies(false) {
-	//propagation->ReadTables(getDataPath("eleca_lee.txt"));
+	KISS_LOG_WARNING << "EleCa propagation is deprecated and is no longer supported. Please use the EM* (EMPairProduction, EMInverseComptonScattering, ...) modules instead.\n";
 	propagation->ReadTables(getDataPath("EleCa/eleca.dat"));
 	propagation->InitBkgArray(background);
 	output.open(outputFilename.c_str());


### PR DESCRIPTION
This simple pull request adds deprecration warnings to calls to both DINT and EleCa.
Additionally, it changes a std::cout warning message in `EmissionMap.cpp` to a kiss warning.
