### PR TITLE
Implementation of the new PolarizedSingleModeMagneticField class (new)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add modules for first and second order Fermi acceleration
 * Make custom photon fields available in the PhotoPionProduction module.
 * Add tricubic- and nearest neighbour interpolation routines for scalar- and vectorgrids.
+* Add the new PolarizedSingleModeMagneticField class for polarized/helical single mode magnetic field models.
 
 ### Interface changes:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,6 +419,7 @@ add_library(crpropa SHARED
   src/magneticField/JF12FieldSolenoidal.cpp
   src/magneticField/MagneticField.cpp
   src/magneticField/MagneticFieldGrid.cpp
+  src/magneticField/PolarizedSingleModeMagneticField.cpp
   src/magneticField/PT11Field.cpp
   src/magneticField/turbulentField/GridTurbulence.cpp
   src/magneticField/turbulentField/HelicalGridTurbulence.cpp

--- a/include/CRPropa.h
+++ b/include/CRPropa.h
@@ -61,6 +61,7 @@
 #include "crpropa/magneticField/JF12FieldSolenoidal.h"
 #include "crpropa/magneticField/MagneticField.h"
 #include "crpropa/magneticField/MagneticFieldGrid.h"
+#include "crpropa/magneticField/PolarizedSingleModeMagneticField.h"
 #include "crpropa/magneticField/PT11Field.h"
 #include "crpropa/magneticField/QuimbyMagneticField.h"
 #include "crpropa/magneticField/TF17Field.h"

--- a/include/crpropa/magneticField/PolarizedSingleModeMagneticField.h
+++ b/include/crpropa/magneticField/PolarizedSingleModeMagneticField.h
@@ -1,0 +1,50 @@
+#ifndef CRPROPA_POLARIZEDSINGLEMODEMAGNETICFIELD_H
+#define CRPROPA_POLARIZEDSINGLEMODEMAGNETICFIELD_H
+
+#include "crpropa/magneticField/MagneticField.h"
+
+
+#include <string>
+#include <iostream>
+#include <cmath>
+#include <cstdlib>
+#include <sstream>
+
+#include "crpropa/Vector3.h"
+#include "crpropa/Referenced.h"
+#include "crpropa/Units.h"
+
+namespace crpropa {
+
+/**
+ @class PolarizedSingleModeMagneticField
+ @brief General polarized single mode magnetic field (including linear, circular and elliptic polarizations and the case of maximal helicity).
+ */
+class PolarizedSingleModeMagneticField: public MagneticField {
+private:
+	//quantities provided by the user:
+	double B_0; // Magnetic field strength in the direction of e_1 at r_0 (for flagAmplitudeRms = "amplitude"), or the RMS value of the magnetic field (for flagAmplitudeRms = "rms")
+	double wavelength; // Wavelength of the single mode (corresponds to its coherence length)
+	double sigma; // Polarization parameter
+	Vector3d r_0; // Reference position
+	Vector3d e_1; // First vector spanning the polarization plane
+	Vector3d e_2; // Second vector spanning the polarization plane
+	std::string flagAmplitudeRms; // Flag to specify whether B_0 denotes the maximum ("amplitude") or the RMS ("rms") value of the magnetic field
+	std::string flagPolarizationHelicity; // Flag to specify whether sigma denotes the standard polarization parameter ("polarization") or f_H, the fraction of maximal helicity ("helicity")
+	std::string flagMode; // Flag to specify the polarization mode; possible choices are "elliptical", "circular" or "linear"
+
+	//derived quantities:
+	Vector3d unitVector_1; // Normalized vector e_1
+	Vector3d unitVector_2; // Normalized vector e_2
+	Vector3d wavevector; // Wavevector of the mode (proportional to e_2 cross e_1)
+	double B_max; // Maximal value of the magnetic field (i.e. the amplitude/semi-major value of the mode)
+
+public:
+	PolarizedSingleModeMagneticField(const double &B_0, const double &wavelength, const double &sigma, const Vector3d &r_0, const Vector3d &e_1, const Vector3d &e_2, std::string flagAmplitudeRms, std::string flagPolarizationHelicity, std::string flagMode );
+
+	Vector3d getField(const Vector3d &position) const;
+};
+
+} // end namespace crpropa
+
+#endif // CRPROPA_POLARIZEDSINGLEMODEMAGNETICFIELD_H

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -449,6 +449,7 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %include "crpropa/magneticField/AMRMagneticField.h"
 %include "crpropa/magneticField/JF12Field.h"
 %include "crpropa/magneticField/JF12FieldSolenoidal.h"
+%include "crpropa/magneticField/PolarizedSingleModeMagneticField.h"
 %include "crpropa/magneticField/PT11Field.h"
 %include "crpropa/magneticField/TF17Field.h"
 %include "crpropa/magneticField/ArchimedeanSpiralField.h"

--- a/src/magneticField/PolarizedSingleModeMagneticField.cpp
+++ b/src/magneticField/PolarizedSingleModeMagneticField.cpp
@@ -1,0 +1,66 @@
+#include "crpropa/magneticField/PolarizedSingleModeMagneticField.h"
+
+namespace crpropa {
+
+PolarizedSingleModeMagneticField::PolarizedSingleModeMagneticField( const double &B_0, const double &wavelength, const double &sigma, const Vector3d &r_0, const Vector3d &e_1, const Vector3d &e_2, std::string flagAmplitudeRms, std::string flagPolarizationHelicity, std::string flagMode ) {
+	if (flagMode == "elliptical") {
+		if (abs(sigma) > 1)
+			throw std::runtime_error("PolarizedSingleModeMagneticField: The value of the  polarization parameter has to lie in the range [-1;+1].");
+	}
+	else if (flagMode == "circular") {
+		if (abs(sigma) != 1)
+			throw std::runtime_error("PolarizedSingleModeMagneticField: For circular polarization the value of the polarization parameter has to be equal to -1 or +1.");
+	}
+	else if (flagMode == "linear") {
+		if (abs(sigma) != 0)
+			throw std::runtime_error("PolarizedSingleModeMagneticField: For linear polarization the value of the polarization parameter has to be equal to 0.");
+	}
+	else
+		throw std::runtime_error("PolarizedSingleModeMagneticField: Wrong value for flagMode. Please choose \"elliptical\" or \"circular\" or \"linear\".");
+
+	if (e_1.dot(e_2) != 0)
+		throw std::runtime_error("PolarizedSingleModeMagneticField: e_1 and e_2 have to be orthogonal to each other.");
+
+	if (e_1.getR() == 0)
+		throw std::runtime_error("PolarizedSingleModeMagneticField: Vector e_1 cannot be zero.");
+	unitVector_1 = e_1 / e_1.getR();
+
+	if (e_2.getR() == 0)
+		throw std::runtime_error("PolarizedSingleModeMagneticField: Vector e_2 cannot be zero.");
+	unitVector_2 = e_2 / e_2.getR();
+
+	wavevector = e_2.cross(e_1);
+
+	//This check is necessary if a polarization with non-orthogonal spanning vectors is desired. This is not implemented in this version, so any corresponding modifications should be made with caution.
+	//if (wavevector.getR() == 0)
+	//        throw std::runtime_error("PolarizedSingleModeMagneticField: e_1 cannot be parallel to e_2.");
+
+	wavevector = wavevector / wavevector.getR();
+
+	if (wavelength == 0)
+		throw std::runtime_error("PolarizedSingleModeMagneticField: The correlation length cannot be zero.");
+	wavevector = wavevector * 2 * M_PI / wavelength;
+
+	if (!((flagPolarizationHelicity == "helicity") || (flagPolarizationHelicity == "polarization")))
+		throw std::runtime_error("PolarizedSingleModeMagneticField: Wrong value for flagPolarizationHelicity. Please choose \"polarization\" or \"helicity\".");
+	if (flagPolarizationHelicity == "helicity" && abs(sigma) != 1)
+		throw std::runtime_error("PolarizedSingleModeMagneticField: In helicity mode only the maximum helicity case (sigma = +1 or sigma = -1) may be chosen.");
+
+	if (flagAmplitudeRms == "amplitude")
+		B_max = B_0;
+	else if (flagAmplitudeRms == "rms")
+		B_max = sqrt(2 / (1 + sigma * sigma)) * B_0;
+	else
+		throw std::runtime_error("PolarizedSingleModeMagneticField: Wrong value for flagAmplitudeRms. Please choose \"amplitude\" or \"rms\".");
+
+	this->r_0 = r_0;
+	this->sigma = sigma;
+}
+
+Vector3d PolarizedSingleModeMagneticField::getField(const Vector3d &position) const {
+	Vector3d delta_r = position - r_0;
+
+	return B_max * (unitVector_1 * cos(wavevector.dot(delta_r)) + unitVector_2 * sigma * sin(wavevector.dot(delta_r)));
+}
+
+} //end namespace crpropa

--- a/test/testMagneticField.cpp
+++ b/test/testMagneticField.cpp
@@ -2,6 +2,7 @@
 
 #include "crpropa/magneticField/MagneticFieldGrid.h"
 #include "crpropa/magneticField/CMZField.h"
+#include "crpropa/magneticField/PolarizedSingleModeMagneticField.h"
 #include "crpropa/Grid.h"
 #include "crpropa/Units.h"
 #include "crpropa/Common.h"
@@ -177,6 +178,14 @@ TEST(testCMZMagneticField, TestAzimutalComponent){
 	EXPECT_NEAR(bVec.x, -8.339*muG, 1e-3*muG);
 	EXPECT_NEAR(bVec.y, -0.850*muG, 1e-3*muG);
 	EXPECT_DOUBLE_EQ(bVec.z, 0);
+}
+
+TEST(testPolarizedSingleModeMagneticField, SimpleTest) {
+	PolarizedSingleModeMagneticField B(2, 4, 0.5, Vector3d(1,1,1), Vector3d(0,1,0), Vector3d(1,0,0), "amplitude", "polarization", "elliptical");
+	Vector3d b = B.getField(Vector3d(1,1,2));
+	EXPECT_DOUBLE_EQ(b.x, 1);
+	EXPECT_NEAR(b.y, 0, 1E-10);
+	EXPECT_NEAR(b.z, 0, 1E-10);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This contribution adds the possibility of defining a magnetic field with a single polarization mode in CRPropa. This includes the more specific circular and linear polarizations, but also the more general elliptical one, as well as a formalism to handle magnetic helicity.