### PR TITLE
Update CRPropa download data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ endif(APPLE)
 # Download data files (interaction data, masses, decay data ...)
 # ----------------------------------------------------------------------------
 OPTION(DOWNLOAD_DATA "Download CRPropa data files" ON)
-set(CRPROPA_DATAFILE_VER "2021-11-25")
+set(CRPROPA_DATAFILE_VER "2021-11-29")
 if(DOWNLOAD_DATA)
   message("-- Downloading data file from crpropa.desy.de ~ 65 MB")
   file(DOWNLOAD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ endif(APPLE)
 # Download data files (interaction data, masses, decay data ...)
 # ----------------------------------------------------------------------------
 OPTION(DOWNLOAD_DATA "Download CRPropa data files" ON)
-set(CRPROPA_DATAFILE_VER "2021-07-30")
+set(CRPROPA_DATAFILE_VER "2021-11-25")
 if(DOWNLOAD_DATA)
   message("-- Downloading data file from crpropa.desy.de ~ 65 MB")
   file(DOWNLOAD
@@ -554,7 +554,7 @@ add_definitions(-DCRPROPA_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
 install(TARGETS crpropa DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include FILES_MATCHING PATTERN "*.h")
 install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include FILES_MATCHING PATTERN "*.h")
-install(DIRECTORY ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}/data/ DESTINATION share/crpropa/ PATTERN ".git" EXCLUDE)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/data/ DESTINATION share/crpropa/ PATTERN ".git" EXCLUDE)
 
 install(DIRECTORY libs/kiss/include/ DESTINATION include)
 

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -33,17 +33,16 @@ double TabularPhotonField::getPhotonDensity(double ePhoton, double z) const {
 }
 
 double TabularPhotonField::getRedshiftScaling(double z) const {
-	if (this->isRedshiftDependent) {
-		if (z > this->redshifts.back()) {
-			return 0.;
-		} else if (z < this->redshifts.front()) {
-			return 1.;
-		} else {
-			return interpolate(z, this->redshifts, this->redshiftScalings);
-		}
-	} else {
+	if (!this->isRedshiftDependent)
 		return 1.;
-	}
+ 
+	if (z < this->redshifts.front())
+		return 1.;
+ 
+	if (z > this->redshifts.back())
+		return 0.;
+ 
+	return interpolate(z, this->redshifts, this->redshiftScalings);
 }
 
 void TabularPhotonField::readPhotonEnergy(std::string filePath) {
@@ -90,11 +89,13 @@ void TabularPhotonField::initRedshiftScaling() {
 	for (int i = 0; i < this->redshifts.size(); ++i) {
 		double z = this->redshifts[i];
 		double n = 0.;
-		for (int j = 0; j < this->photonEnergies.size(); ++j) {
-			double e = this->photonEnergies[j];
+		for (int j = 0; j < this->photonEnergies.size()-1; ++j) {
+			double e_j = this->photonEnergies[j];
+			double e_j1 = this->photonEnergies[j+1];
+			double deltaLogE = std::log10(e_j1) - std::log10(e_j);
 			if (z == 0.)
-				n0 += getPhotonDensity(e, z);
-			n += getPhotonDensity(e, z);
+				n0 += (getPhotonDensity(e_j, 0) + getPhotonDensity(e_j1, 0)) / 2. * deltaLogE;
+			n += (getPhotonDensity(e_j, z) + getPhotonDensity(e_j1, z)) / 2. * deltaLogE;
 		}
 		this->redshiftScalings.push_back(n / n0);
 	}

--- a/src/PhotonBackground.cpp
+++ b/src/PhotonBackground.cpp
@@ -53,7 +53,7 @@ void TabularPhotonField::readPhotonEnergy(std::string filePath) {
 
 	std::string line;
 	while (std::getline(infile, line)) {
-		if (line.size() > 0)
+		if ((line.size() > 0) & (line[0] != '#') )
 			this->photonEnergies.push_back(std::stod(line));
 	}
 	infile.close();
@@ -66,7 +66,7 @@ void TabularPhotonField::readPhotonDensity(std::string filePath) {
 
 	std::string line;
 	while (std::getline(infile, line)) {
-		if (line.size() > 0)
+		if ((line.size() > 0) & (line[0] != '#') )
 			this->photonDensity.push_back(std::stod(line));
 	}
 	infile.close();
@@ -79,7 +79,7 @@ void TabularPhotonField::readRedshift(std::string filePath) {
 
 	std::string line;
 	while (std::getline(infile, line)) {
-		if (line.size() > 0)
+		if ((line.size() > 0) & (line[0] != '#') )
 			this->redshifts.push_back(std::stod(line));
 	}
 	infile.close();


### PR DESCRIPTION
This PR updates the data download to a new version (data-2021-11-25).

This data is reproducible with the current version of the crpropa-data repository. All files include now information in the header that specifies the git hash of the crpropa-data repository that was used to create them
This made small changes in CRPropa's files readers necessary. 

Furthermore, this PR improves the CRPropa internal calculation of the redshift scaling of photon target fields. 