### PR TITLE
Uniform interface for the turbulence generation

### DIFF
--- a/include/crpropa/magneticField/turbulentField/SimpleGridTurbulence.h
+++ b/include/crpropa/magneticField/turbulentField/SimpleGridTurbulence.h
@@ -21,16 +21,16 @@ namespace crpropa {
 class SimpleTurbulenceSpectrum : public TurbulenceSpectrum {
   public:
 	/**
-	 @param Brms         root mean square field strength for generated field
-	 @param lMin	 Minimum physical scale of the turbulence
-	 @param lMax	 Maximum physical scale of the turbulence
-	 @param lBendover	   the bend-over scale
-	 @param sindex	 Spectral index of the energy spectrum in the inertial
+	 @param Brms		root mean square field strength for generated field
+	 @param lMin	 	Minimum physical scale of the turbulence
+	 @param lMax	 	Maximum physical scale of the turbulence
+	 @param lBendover	the bend-over scale is set to 1000 times lMax to ensure to be in the inertial range.
+	 @param sindex	 	Spectral index of the energy spectrum in the inertial
 	 range
 	*/
 	SimpleTurbulenceSpectrum(double Brms, double lMin, double lMax,
 	                         double sIndex = 5. / 3)
-	    : TurbulenceSpectrum(Brms, lMin, lMax, 0, sIndex, 0) {}
+	    : TurbulenceSpectrum(Brms, lMin, lMax, 1000 * lMax, sIndex, 0) {}
 	~SimpleTurbulenceSpectrum() {}
 
 	/**

--- a/include/crpropa/magneticField/turbulentField/SimpleGridTurbulence.h
+++ b/include/crpropa/magneticField/turbulentField/SimpleGridTurbulence.h
@@ -19,18 +19,18 @@ namespace crpropa {
  @brief Defines the energy spectrum of simple power-law turbulence
  */
 class SimpleTurbulenceSpectrum : public TurbulenceSpectrum {
+	const int constScaleBendover = 1000; 	// define the bandover scale as 1000 * lMax to ensure k * lBendover >> 1. The bendover scale is necessary for the implementation of PlaneWaveTurbulence. 
   public:
 	/**
 	 @param Brms		root mean square field strength for generated field
 	 @param lMin	 	Minimum physical scale of the turbulence
 	 @param lMax	 	Maximum physical scale of the turbulence
-	 @param lBendover	the bend-over scale is set to 1000 times lMax to ensure to be in the inertial range.
-	 @param sindex	 	Spectral index of the energy spectrum in the inertial
-	 range
+	 @param lBendover	the bend-over scale is set to 1000 times lMax to ensure to be in the inertial range. This should not be changed.
+	 @param sindex	 	Spectral index of the energy spectrum in the inertial range
 	*/
 	SimpleTurbulenceSpectrum(double Brms, double lMin, double lMax,
 	                         double sIndex = 5. / 3)
-	    : TurbulenceSpectrum(Brms, lMin, lMax, 1000 * lMax, sIndex, 0) {}
+	    : TurbulenceSpectrum(Brms, lMin, lMax, constScaleBendover * lMax, sIndex, 0) {}
 	~SimpleTurbulenceSpectrum() {}
 
 	/**

--- a/include/crpropa/magneticField/turbulentField/TurbulentField.h
+++ b/include/crpropa/magneticField/turbulentField/TurbulentField.h
@@ -12,7 +12,7 @@ namespace crpropa {
 
 /**
  @class TurbulenceSpectrum
- @brief Defines the energy spectrum of turbulence
+ @brief Defines the energy spectrum of turbulence parametrizied by A(k) ~ k^q /(1 + k^2)^{(s + q)/2 + 1}
  */
 class TurbulenceSpectrum : public Referenced {
   private:

--- a/include/crpropa/magneticField/turbulentField/TurbulentField.h
+++ b/include/crpropa/magneticField/turbulentField/TurbulentField.h
@@ -74,7 +74,8 @@ class TurbulenceSpectrum : public Referenced {
 	General energy spectrum for synthetic turbulence models (not normalized!)
 	with normalized ^k = k*lBendover
 	*/
-	virtual double energySpectrum(double kHat) const {
+	virtual double energySpectrum(double k) const {
+		double kHat = k * lBendover;
 		return std::pow(kHat, qIndex) /
 				       std::pow(1.0 + kHat * kHat,
 			                (sIndex + qIndex) / 2.0 + 1.0);

--- a/src/magneticField/turbulentField/GridTurbulence.cpp
+++ b/src/magneticField/turbulentField/GridTurbulence.cpp
@@ -52,7 +52,7 @@ void GridTurbulence::initTurbulence() {
 	// double kMax = 2*M_PI / lMin; // * 2 * spacing.x; // spacing.x / lMin;
 	double kMin = spacing.x / spectrum.getLmax();
 	double kMax = spacing.x / spectrum.getLmin();
-	auto lambda = spectrum.getLbendover() / spacing.x * 2 * M_PI;
+	auto lambda = 1 / spacing.x * 2 * M_PI;
 
 	Vector3f n0(1, 1, 1); // arbitrary vector to construct orthogonal base
 

--- a/src/magneticField/turbulentField/PlaneWaveTurbulence.cpp
+++ b/src/magneticField/turbulentField/PlaneWaveTurbulence.cpp
@@ -130,7 +130,7 @@ PlaneWaveTurbulence::PlaneWaveTurbulence(const TurbulenceSpectrum &spectrum,
 	double Ak2_sum = 0; // sum of Ak^2 over all k
 	for (int i = 0; i < Nm; i++) {
 		double k = this->k[i];
-		double Gk = spectrum.energySpectrum(k);
+		double Gk = spectrum.energySpectrum(k) * (k * k);
 		Ak[i] = Gk * delta_k0 * k;
 		Ak2_sum += Ak[i];
 

--- a/src/magneticField/turbulentField/PlaneWaveTurbulence.cpp
+++ b/src/magneticField/turbulentField/PlaneWaveTurbulence.cpp
@@ -130,7 +130,8 @@ PlaneWaveTurbulence::PlaneWaveTurbulence(const TurbulenceSpectrum &spectrum,
 	double Ak2_sum = 0; // sum of Ak^2 over all k
 	for (int i = 0; i < Nm; i++) {
 		double k = this->k[i];
-		double Gk = spectrum.energySpectrum(k) * (k * k);
+		double kHat = k * spectrum.getLbendover();
+		double Gk = spectrum.energySpectrum(k) * (1 + kHat * kHat);	// correct different implementation in TD 13 (eq. 5, missing + 1 in the denuminators exponent)
 		Ak[i] = Gk * delta_k0 * k;
 		Ak2_sum += Ak[i];
 

--- a/src/magneticField/turbulentField/PlaneWaveTurbulence.cpp
+++ b/src/magneticField/turbulentField/PlaneWaveTurbulence.cpp
@@ -71,7 +71,7 @@ double hsum_double_avx(__m256d v) {
 	vlow = _mm_add_pd(vlow, vhigh);              // reduce down to 128
 
 	__m128d high64 = _mm_unpackhi_pd(vlow, vlow);
-	return _mm_cvtsd_f65(_mm_add_sd(vlow, high64)); // reduce to scalar
+	return _mm_cvtsd_f64(_mm_add_sd(vlow, high64)); // reduce to scalar
 }
 #endif // defined(ENABLE_FAST_WAVES)
 


### PR DESCRIPTION
Dear all,

with this pullrequest we want to provide a fix to the issue of the non-uniform spectral index handling, as described in #387.
Analyzing the problem, we made two changes:

First, to solve the problem for the PlaneWaveTurbulence method using SimpleTurbulenceSpectrum that was shown in #387, we effectively removed the "+1" in the exponent in the denominator of the formula of the power spectrum, to be accordant to the Tautz and Dosch 2013 paper, as suggested in the discussion of the issue.

Second, we found that for a uniform handling, it would be good to also change the argument that is given to energySpectrum() in the general case of TurbulenceSpectrum. Instead of giving it k^ = k * l_bendover, we put the multiplication with the bendoverscale inside of the function to have the same argument (just k) as in SimpleTurbulenceSpectrum.

We tested the combinations of the turbulence models (SimpleTurbulenceSpectrum and TurbulenceSpectrum) with the available methods (PlaneWaveTurbulence and gridbased GridTurbulence and SimpleGridTurbulence) and found them working as expected, producing the right spectral behaviour, as shown in the plots below, where the spectrum for s=5/3. is shown reweighted with 11/3. On the left the PlaneWaveMethod is shown and on the right the gridbased methods.

![fixed](https://user-images.githubusercontent.com/32835331/154966391-17f97437-0e65-4918-bfa1-a859bcfdea8f.png)

While testing the FastWaves optimization for the PlaneWaveTurbulence method, we found a minor typo preventing it from being built, that we fixed within this PR.

Thank you in advance,
@JulienDoerner , @LeanderSchlegel