### PR TITLE
Log observer time evolution

### DIFF
--- a/include/crpropa/Grid.h
+++ b/include/crpropa/Grid.h
@@ -76,7 +76,7 @@ public:
 	Vector3d origin;  	// Position of the lower left front corner of the volume
 	Vector3d spacing; 	// Spacing vector between gridpoints
 	bool reflective;	// using reflective repetition of the grid instead of periodic
-	interpolationType ipol;	// Interpolation tpye used between grid points
+	interpolationType ipol;	// Interpolation type used between grid points
 
 	/** Constructor for cubic grid
 	 @param	origin	Position of the lower left front corner of the volume
@@ -117,7 +117,7 @@ public:
 		reflective = b;
 	}
 
-	/** set the type of interpolation between gridpoints.
+	/** set the type of interpolation between grid points.
 	 * @param i: interpolationType (TRILINEAR, TRICUBIC, NEAREST_NEIGHBOUR) */
 	void setInterpolationType(interpolationType i){
 		ipol = i;

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -291,8 +291,9 @@ public:
 	 @param min		minimum time
 	 @param dist	time interval for detection
 	 @param numb	number of time intervals
+	 @param log     log scaling
 	 */
-	ObserverTimeEvolution(double min, double dist, double numb);
+	ObserverTimeEvolution(double min, double dist, double numb, bool log = false);
 	void addTime(const double &position);
 	const std::vector<double>& getTimes() const;
 	DetectionState checkDetection(Candidate *candidate) const;

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -303,6 +303,7 @@ public:
 	 */
 	ObserverTimeEvolution(double min, double max, double numb, bool log = false);
 	void addTime(const double &position);
+	void addTimeRange(double min, double max, double numb, bool log = false);
 	const std::vector<double>& getTimes() const;
 	DetectionState checkDetection(Candidate *candidate) const;
 	std::string getDescription() const;

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -291,9 +291,17 @@ public:
 	 @param min		minimum time
 	 @param dist	time interval for detection
 	 @param numb	number of time intervals
-	 @param log     log scaling
+	 @param 
 	 */
-	ObserverTimeEvolution(double min, double dist, double numb, bool log = false);
+	ObserverTimeEvolution(double min, double dist, double numb);
+	/** Constructor
+	 @param min		minimum time
+	 @param max	    maximum time
+	 @param numb	number of time intervals
+	 @param log     log or lin (default) scaling
+	 @param 
+	 */
+	ObserverTimeEvolution(double min, double max, double numb, bool log = false);
 	void addTime(const double &position);
 	const std::vector<double>& getTimes() const;
 	DetectionState checkDetection(Candidate *candidate) const;

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -278,7 +278,7 @@ public:
 /**
  @class ObserverTimeEvolution
  @brief Observes the time evolution of the candidates (phase-space elements)
- This observer is very useful if the time evolution of the particle density is needed. It detects all candidates in regular time intervals and limits the nextStep of candidates to prevent overshooting of detection intervals.
+ This observer is very useful if the time evolution of the particle density is needed. It detects all candidates in lin-spaced, log-spaced, or user-defined time intervals and limits the nextStep of candidates to prevent overshooting of detection intervals.
  */
 class ObserverTimeEvolution: public ObserverFeature {
 private:
@@ -291,18 +291,21 @@ public:
 	 @param min		minimum time
 	 @param dist	time interval for detection
 	 @param numb	number of time intervals
-	 @param 
+	 @param
 	 */
 	ObserverTimeEvolution(double min, double dist, double numb);
 	/** Constructor
 	 @param min		minimum time
 	 @param max	    maximum time
 	 @param numb	number of time intervals
-	 @param log     log or lin (default) scaling
+	 @param log     log (input: true) or lin (input: false) scaling between min and max with numb steps
 	 @param 
 	 */
-	ObserverTimeEvolution(double min, double max, double numb, bool log = false);
+	ObserverTimeEvolution(double min, double max, double numb, bool log);
+	// add a new time step to the detection time list of the observer
 	void addTime(const double &position);
+	// using log or lin spacing of times in the range between min and
+	// max for observing particles
 	void addTimeRange(double min, double max, double numb, bool log = false);
 	const std::vector<double>& getTimes() const;
 	DetectionState checkDetection(Candidate *candidate) const;

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -323,13 +323,20 @@ std::string ObserverParticleIdVeto::getDescription() const {
 // ObserverTimeEvolution --------------------------------------------------------
 ObserverTimeEvolution::ObserverTimeEvolution() {}
 
-ObserverTimeEvolution::ObserverTimeEvolution(double min, double dist, double numb, bool log) {
+ObserverTimeEvolution::ObserverTimeEvolution(double min, double dist, double numb) {
+  	
+	for (size_t i = 0; i < numb; i++) {
+		addTime(min + i * dist);
+	}
+}
+
+ObserverTimeEvolution::ObserverTimeEvolution(double min, double max, double numb, bool log) {
   	
 	for (size_t i = 0; i < numb; i++) {
 		if (log == true) {
-			addTime(min * pow(dist / min, i / (numb - 1.0)));
+			addTime(min * pow(max / min, i / (numb - 1.0)));
 		} else {
-			addTime(min + i * dist);
+			addTime(min + i * (max - min) / numb);
 		}
 	}
 }

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -324,21 +324,13 @@ std::string ObserverParticleIdVeto::getDescription() const {
 ObserverTimeEvolution::ObserverTimeEvolution() {}
 
 ObserverTimeEvolution::ObserverTimeEvolution(double min, double dist, double numb) {
-  	
-	for (size_t i = 0; i < numb; i++) {
-		addTime(min + i * dist);
-	}
+	double max = min + numb * dist;
+	bool log = false;
+	addTimeRange(min, max, numb, log);
 }
 
 ObserverTimeEvolution::ObserverTimeEvolution(double min, double max, double numb, bool log) {
-  	
-	for (size_t i = 0; i < numb; i++) {
-		if (log == true) {
-			addTime(min * pow(max / min, i / (numb - 1.0)));
-		} else {
-			addTime(min + i * (max - min) / numb);
-		}
-	}
+	addTimeRange(min, max, numb, log);
 }
 
 
@@ -381,14 +373,22 @@ DetectionState ObserverTimeEvolution::checkDetection(Candidate *c) const {
 
 			return DETECTED;
 		}
-
 	}
 	return NOTHING;
-
 }
 
 void ObserverTimeEvolution::addTime(const double& t) {
 	detList.push_back(t);
+}
+
+void ObserverTimeEvolution::addTimeRange(double min, double max, double numb, bool log) {
+	for (size_t i = 0; i < numb; i++) {
+		if (log == true) {
+			addTime(min * pow(max / min, i / (numb - 1.0)));
+		} else {
+			addTime(min + i * (max - min) / numb);
+		}
+	}
 }
 
 const std::vector<double>& ObserverTimeEvolution::getTimes() const {
@@ -404,7 +404,7 @@ std::string ObserverTimeEvolution::getDescription() const {
 }
 
 // ObserverSurface--------------------------------------------------------------
-ObserverSurface::ObserverSurface(Surface* _surface) : surface(_surface) { };
+ObserverSurface::ObserverSurface(Surface* _surface) : surface(_surface) { }
 
 DetectionState ObserverSurface::checkDetection(Candidate *candidate) const
 {
@@ -418,12 +418,12 @@ DetectionState ObserverSurface::checkDetection(Candidate *candidate) const
 			return NOTHING;
 		else
 			return DETECTED;
-};
+}
 
 std::string ObserverSurface::getDescription() const {
 	std::stringstream ss;
 	ss << "ObserverSurface: << " << surface->getDescription();
 	return ss.str();
-};
+}
 
 } // namespace crpropa

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -324,13 +324,11 @@ std::string ObserverParticleIdVeto::getDescription() const {
 ObserverTimeEvolution::ObserverTimeEvolution() {}
 
 ObserverTimeEvolution::ObserverTimeEvolution(double min, double dist, double numb, bool log) {
-  	if (log == true) {
-		for (size_t i = 0; i <= numb; i++) {
-			double time = min * pow(dist / min, i / (numb - 1.0));
-			addTime(time);
-		}
-	} else {
-		for (size_t i = 0; i < numb; i++) {
+  	
+	for (size_t i = 0; i < numb; i++) {
+		if (log == true) {
+			addTime(min * pow(dist / min, i / (numb - 1.0)));
+		} else {
 			addTime(min + i * dist);
 		}
 	}

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -323,10 +323,17 @@ std::string ObserverParticleIdVeto::getDescription() const {
 // ObserverTimeEvolution --------------------------------------------------------
 ObserverTimeEvolution::ObserverTimeEvolution() {}
 
-ObserverTimeEvolution::ObserverTimeEvolution(double min, double dist, double numb) {
-  for (size_t i = 0; i < numb; i++) {
-    addTime(min + i * dist);
-  }
+ObserverTimeEvolution::ObserverTimeEvolution(double min, double dist, double numb, bool log) {
+  	if (log == true) {
+		for (size_t i = 0; i <= numb; i++) {
+			double time = min * pow(dist / min, i / (numb - 1.0));
+			addTime(time);
+		}
+	} else {
+		for (size_t i = 0; i < numb; i++) {
+			addTime(min + i * dist);
+		}
+	}
 }
 
 

--- a/test/testBreakCondition.cpp
+++ b/test/testBreakCondition.cpp
@@ -267,6 +267,43 @@ TEST(ObserverFeature, TimeEvolution) {
   EXPECT_TRUE(c.hasProperty("Detected"));
 }
 
+TEST(ObserverFeature, TimeEvolutionLog) {
+  Observer obs;
+  obs.setDeactivateOnDetection(false);
+  obs.setFlag("Detected", "Detected");
+  // usage of a log scaling for the observer
+  bool log = true;
+  obs.add(new ObserverTimeEvolution(5, 5, 2, log));
+  Candidate c;
+  c.setNextStep(10);
+  c.setTrajectoryLength(3);
+  
+  // no detection, limit next step
+  obs.process(&c);
+  EXPECT_TRUE(c.isActive());
+
+  // limit step
+  EXPECT_DOUBLE_EQ(2, c.getNextStep());
+  
+  // detection one
+  c.setCurrentStep(0.1);
+  c.setTrajectoryLength(5);
+  obs.process(&c);
+  EXPECT_TRUE(c.isActive());
+  EXPECT_TRUE(c.hasProperty("Detected"));
+
+  // delete property
+  c.removeProperty("Detected");
+  EXPECT_FALSE(c.hasProperty("Detected"));
+
+  // detection two
+  c.setCurrentStep(0.1);
+  c.setTrajectoryLength(10.05);
+  obs.process(&c);
+  EXPECT_TRUE(c.isActive());
+  EXPECT_TRUE(c.hasProperty("Detected"));
+}
+
 //** ========================= Boundaries =================================== */
 TEST(PeriodicBox, high) {
 	// Tests if the periodical boundaries place the particle back inside the box and translate the initial position accordingly.


### PR DESCRIPTION
Dear all,

with this pull request, I want to provide the possibility to use a logarithmic scaling of the ObserverTimeEvolution, which is especially useful if you want to resolve different time scales in your simulations. The feature has proven useful in numerous studies (running diffusion coefficients, lightcurves in sources, ...) over the past few years, which is why I'd like to share it. 

The functionality of the linear observer remains unchanged:
`ObserverTimeEvolution(min, dist, numb)`

With constructor overloading, I implemented the log-scaling in analogy to numpy.logspace:
`ObserverTimeEvolution(min, max, numb, True)`

Test to verify the feature are implemented.

Best,
Patrick