### PR TITLE
Normalization of vector axis in function getRotataed of Vector3.h

### DIFF
--- a/include/crpropa/Vector3.h
+++ b/include/crpropa/Vector3.h
@@ -204,7 +204,7 @@ public:
 
 	// rotate the vector around a given axis by a given angle
 	Vector3<T> getRotated(const Vector3<T> &axis, T angle) const {
-		Vector3<T> u = axis;
+		Vector3<T> u = axis/axis.getR();
 		T c = cos(angle);
 		T s = sin(angle);
 		Vector3<T> Rx(c + u.x * u.x * (1 - c), u.x * u.y * (1 - c) - u.z * s,


### PR DESCRIPTION
Dear all, 

I have fixed a bug present in the function getRotated() of Vector3.h. All the details and tests can be found in the presentation

[ConeEmission_Targeting_issues.pdf](https://github.com/CRPropa/CRPropa3/files/8879677/ConeEmission_Targeting_issues.pdf)

I tried to included this modification in the function randVectorAroundMean() of Random.cpp instead of Vector3.h. 
I ran a speed test to check the impact of these two different modifications on code performance. Here the result where Method 1 corresponds to the change in Vector3.h and Method 2 corresponds to the change in Random.cpp.

[speed-test.pdf](https://github.com/CRPropa/CRPropa3/files/8879696/speed-test.pdf)

For a large number of simulated particles the two method do not differ greatly. Therefore I suggest to modify the function getRotated() in Vector3.h in order to make this function mathematically correct and usable without further modifications. 

Thank you. 
