### PR TITLE
Inheriting weights from parent particles

### DIFF
--- a/include/crpropa/Candidate.h
+++ b/include/crpropa/Candidate.h
@@ -80,6 +80,7 @@ public:
 	 Weights are calculated for each tracked secondary.
 	 */
 	void setWeight(double weight);
+    void updateWeight(double weight);
 	double getWeight() const;
 
 	/**

--- a/include/crpropa/Candidate.h
+++ b/include/crpropa/Candidate.h
@@ -57,7 +57,7 @@ public:
 		Vector3d position = Vector3d(0, 0, 0),
 		Vector3d direction = Vector3d(-1, 0, 0),
 		double z = 0,
-		double weight = 1
+		double weight = 1.
 	);
 
 	/**
@@ -119,8 +119,8 @@ public:
 	 */
 	void addSecondary(Candidate *c);
 	inline void addSecondary(ref_ptr<Candidate> c) { addSecondary(c.get()); };
-	void addSecondary(int id, double energy, double weight = 1);
-	void addSecondary(int id, double energy, Vector3d position, double weight = 1);
+	void addSecondary(int id, double energy, double w = 1.);
+	void addSecondary(int id, double energy, Vector3d position, double w = 1.);
 	void clearSecondaries();
 
 	std::string getDescription() const;

--- a/src/Candidate.cpp
+++ b/src/Candidate.cpp
@@ -7,7 +7,7 @@
 namespace crpropa {
 
 Candidate::Candidate(int id, double E, Vector3d pos, Vector3d dir, double z, double weight) :
-		redshift(z), trajectoryLength(0), weight(1), currentStep(0), nextStep(0), active(true), parent(0) {
+		redshift(z), trajectoryLength(0), weight(weight), currentStep(0), nextStep(0), active(true), parent(0) {
 	ParticleState state(id, E, pos, dir);
 	source = state;
 	created = state;
@@ -82,8 +82,7 @@ void Candidate::setWeight(double w) {
 }
 
 void Candidate::updateWeight(double w) {
-    double w_0 = this -> getWeight();
-    weight = w_0 * w;
+    weight*=w;
 }
 
 void Candidate::setCurrentStep(double lstep) {
@@ -129,12 +128,11 @@ void Candidate::addSecondary(Candidate *c) {
 	secondaries.push_back(c);
 }
 
-void Candidate::addSecondary(int id, double energy, double weight) {
+void Candidate::addSecondary(int id, double energy, double w) {
 	ref_ptr<Candidate> secondary = new Candidate;
 	secondary->setRedshift(redshift);
 	secondary->setTrajectoryLength(trajectoryLength);
-    secondary->setWeight(this -> getWeight());
-    secondary->updateWeight(weight);
+    secondary->setWeight(weight*w);
     secondary->source = source;
 	secondary->previous = previous;
 	secondary->created = previous;
@@ -145,12 +143,11 @@ void Candidate::addSecondary(int id, double energy, double weight) {
 	secondaries.push_back(secondary);
 }
 
-void Candidate::addSecondary(int id, double energy, Vector3d position, double weight) {
+void Candidate::addSecondary(int id, double energy, Vector3d position, double w) {
 	ref_ptr<Candidate> secondary = new Candidate;
 	secondary->setRedshift(redshift);
 	secondary->setTrajectoryLength(trajectoryLength - (current.getPosition() - position).getR() );
-	secondary->setWeight(this -> getWeight());
-    secondary->updateWeight(weight);
+	secondary->setWeight(weight*w);
 	secondary->source = source;
 	secondary->previous = previous;
 	secondary->created = previous;

--- a/src/Candidate.cpp
+++ b/src/Candidate.cpp
@@ -81,6 +81,11 @@ void Candidate::setWeight(double w) {
 	weight = w;
 }
 
+void Candidate::updateWeight(double w) {
+    double w_0 = this -> getWeight();
+    weight = w_0 * w;
+}
+
 void Candidate::setCurrentStep(double lstep) {
 	currentStep = lstep;
 	trajectoryLength += lstep;
@@ -128,8 +133,9 @@ void Candidate::addSecondary(int id, double energy, double weight) {
 	ref_ptr<Candidate> secondary = new Candidate;
 	secondary->setRedshift(redshift);
 	secondary->setTrajectoryLength(trajectoryLength);
-	secondary->setWeight(weight);
-	secondary->source = source;
+    secondary->setWeight(this -> getWeight());
+    secondary->updateWeight(weight);
+    secondary->source = source;
 	secondary->previous = previous;
 	secondary->created = previous;
 	secondary->current = current;
@@ -143,7 +149,8 @@ void Candidate::addSecondary(int id, double energy, Vector3d position, double we
 	ref_ptr<Candidate> secondary = new Candidate;
 	secondary->setRedshift(redshift);
 	secondary->setTrajectoryLength(trajectoryLength - (current.getPosition() - position).getR() );
-	secondary->setWeight(weight);
+	secondary->setWeight(this -> getWeight());
+    secondary->updateWeight(weight);
 	secondary->source = source;
 	secondary->previous = previous;
 	secondary->created = previous;

--- a/src/module/Acceleration.cpp
+++ b/src/module/Acceleration.cpp
@@ -6,7 +6,7 @@
 namespace crpropa {
 
 AbstractAccelerationModule::AbstractAccelerationModule(double _stepLength)
-    : crpropa::Module(), stepLength(_stepLength) {}
+	: crpropa::Module(), stepLength(_stepLength) {}
 
 
 void AbstractAccelerationModule::add(StepLengthModifier *modifier) {
@@ -15,8 +15,8 @@ void AbstractAccelerationModule::add(StepLengthModifier *modifier) {
 
 
 void AbstractAccelerationModule::scatter(
-    crpropa::Candidate *candidate,
-    const crpropa::Vector3d &scatter_center_velocity) const {
+	crpropa::Candidate *candidate,
+	const crpropa::Vector3d &scatter_center_velocity) const {
 	// particle momentum in lab frame
 	const double E = candidate->current.getEnergy();
 	const crpropa::Vector3d p = candidate->current.getMomentum();
@@ -26,7 +26,7 @@ void AbstractAccelerationModule::scatter(
 	const double gamma = 1. / sqrt(1 - beta * beta);
 	const double Ep = gamma * (E - scatter_center_velocity.dot(p));
 	const crpropa::Vector3d pp = (p - scatter_center_velocity* E /
-	    (crpropa::c_light * crpropa::c_light)) * gamma;
+		(crpropa::c_light * crpropa::c_light)) * gamma;
 
 	// scatter into random direction
 	const crpropa::Vector3d pp_new = crpropa::Random::instance().randVector() * pp.getR();
@@ -34,7 +34,7 @@ void AbstractAccelerationModule::scatter(
 	// transform back
 	const double E_new = gamma * (Ep + scatter_center_velocity.dot(pp_new));
 	const crpropa::Vector3d p_new = (pp_new + scatter_center_velocity * Ep /
-	    (crpropa::c_light * crpropa::c_light)) * gamma;
+		(crpropa::c_light * crpropa::c_light)) * gamma;
 
 	// update candidate properties
 	candidate->current.setEnergy(E_new);
@@ -63,9 +63,9 @@ void AbstractAccelerationModule::process(crpropa::Candidate *candidate) const {
 
 
 SecondOrderFermi::SecondOrderFermi(double scatterVelocity, double stepLength,
-                                   unsigned int sizeOfPitchangleTable)
-    : AbstractAccelerationModule(stepLength),
-      scatterVelocity(scatterVelocity) {
+								   unsigned int sizeOfPitchangleTable)
+	: AbstractAccelerationModule(stepLength),
+	  scatterVelocity(scatterVelocity) {
 	setDescription("SecondOrderFermi Acceleration");
 	angle.resize(sizeOfPitchangleTable);
 	angleCDF.resize(sizeOfPitchangleTable);
@@ -90,8 +90,8 @@ crpropa::Vector3d SecondOrderFermi::scatterCenterVelocity(crpropa::Candidate *ca
 
 
 DirectedFlowOfScatterCenters::DirectedFlowOfScatterCenters(
-    const Vector3d &scatterCenterVelocity)
-    : __scatterVelocity(scatterCenterVelocity) {}
+	const Vector3d &scatterCenterVelocity)
+	: __scatterVelocity(scatterCenterVelocity) {}
 
 
 double DirectedFlowOfScatterCenters::modify(double steplength, Candidate* candidate)
@@ -102,9 +102,9 @@ double DirectedFlowOfScatterCenters::modify(double steplength, Candidate* candid
 
 
 DirectedFlowScattering::DirectedFlowScattering(
-    crpropa::Vector3d scatterCenterVelocity, double stepLength)
-    : __scatterVelocity(scatterCenterVelocity),
-      AbstractAccelerationModule(stepLength) {
+	crpropa::Vector3d scatterCenterVelocity, double stepLength)
+	: __scatterVelocity(scatterCenterVelocity),
+	  AbstractAccelerationModule(stepLength) {
 
 	// In a directed field of scatter centers, the probability to encounter a
 	// scatter center depends on the direction of the candidate.
@@ -114,16 +114,16 @@ DirectedFlowScattering::DirectedFlowScattering(
 
 
 crpropa::Vector3d DirectedFlowScattering::scatterCenterVelocity(
-    crpropa::Candidate *candidate) const { // does not depend on candidate here.
+	crpropa::Candidate *candidate) const { // does not depend on candidate here.
 	return __scatterVelocity;
 }
 
 
 QuasiLinearTheory::QuasiLinearTheory(double referenecEnergy,
-                                     double turbulenceIndex,
-                                     double minimumRigidity)
-    : __referenceEnergy(referenecEnergy), __turbulenceIndex(turbulenceIndex),
-      __minimumRigidity(minimumRigidity) {}
+									 double turbulenceIndex,
+									 double minimumRigidity)
+	: __referenceEnergy(referenecEnergy), __turbulenceIndex(turbulenceIndex),
+	  __minimumRigidity(minimumRigidity) {}
 
 
 double QuasiLinearTheory::modify(double steplength, Candidate* candidate)
@@ -131,26 +131,26 @@ double QuasiLinearTheory::modify(double steplength, Candidate* candidate)
 	if (candidate->current.getRigidity() < __minimumRigidity)
 	{
 		return steplength * std::pow(__minimumRigidity /
-		    (__referenceEnergy / eV), 2. - __turbulenceIndex);
+			(__referenceEnergy / eV), 2. - __turbulenceIndex);
 	}
 	else
 	{
 		return steplength * std::pow(candidate->current.getRigidity() /
-		    (__referenceEnergy / eV), 2. - __turbulenceIndex);
+			(__referenceEnergy / eV), 2. - __turbulenceIndex);
 	}
 }
 
 
 ParticleSplitting::ParticleSplitting(Surface *surface, int numSplits,
 		int	crossingThreshold, double minWeight, std::string counterid)
-    : surface(surface), crossingThreshold(crossingThreshold),
-      numSplits(numSplits), minWeight(minWeight), counterid(counterid){};
+	: surface(surface), crossingThreshold(crossingThreshold),
+	  numSplits(numSplits), minWeight(minWeight), counterid(counterid){};
 
 void ParticleSplitting::process(Candidate *candidate) const {
 	const double currentDistance =
-	    surface->distance(candidate->current.getPosition());
+		surface->distance(candidate->current.getPosition());
 	const double previousDistance =
-	    surface->distance(candidate->previous.getPosition());
+		surface->distance(candidate->previous.getPosition());
 
 	if (currentDistance * previousDistance > 0)
 		// candidate remains on the same side
@@ -167,7 +167,7 @@ void ParticleSplitting::process(Candidate *candidate) const {
 	if (num_crossings % crossingThreshold != 0)
 		return;
 
-	candidate->setWeight(candidate->getWeight() / numSplits);
+	candidate->updateWeight(1. / numSplits);
 
 	for (size_t i = 1; i < numSplits; i++) {
 		// No recursive split as the weights of the secondaries created

--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -77,15 +77,14 @@ void EMDoublePairProduction::performInteraction(Candidate *candidate) const {
 	Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());
 
 	double f = Ee / E;
-	double w0 = candidate->getWeight();
 
 	if (haveElectrons) {
 		if (random.rand() < pow(1 - f, thinning)) {
-			double w = w0 / pow(1 - f, thinning);
+			double w = 1. / pow(1 - f, thinning);
 			candidate->addSecondary( 11, Ee / (1 + z), pos, w);
 		} 
 		if (random.rand() < pow(f, thinning)) {
-			double w = w0 / pow(f, thinning);
+			double w = 1. / pow(f, thinning);
 			candidate->addSecondary(-11, Ee / (1 + z), pos, w);
 		}
 	}

--- a/src/module/EMInverseComptonScattering.cpp
+++ b/src/module/EMInverseComptonScattering.cpp
@@ -191,10 +191,9 @@ void EMInverseComptonScattering::performInteraction(Candidate *candidate) const 
 	// add up-scattered photon
 	double Esecondary = E - Enew;
 	double f = Enew / E;
-	double w0 = candidate->getWeight();
 	if (havePhotons) {
 		if (random.rand() < pow(1 - f, thinning)) {
-			double w = w0 / pow(1 - f, thinning);
+			double w = 1. / pow(1 - f, thinning);
 			Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());
 			candidate->addSecondary(22, Esecondary / (1 + z), pos, w);
 		}

--- a/src/module/EMPairProduction.cpp
+++ b/src/module/EMPairProduction.cpp
@@ -205,14 +205,13 @@ void EMPairProduction::performInteraction(Candidate *candidate) const {
 
 	// sample random position along current step
 	Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());
-	double w0 = candidate->getWeight();
 	// apply sampling
 	if (random.rand() < pow(f, thinning)) {
-		double w = w0 / pow(f, thinning);
+		double w = 1. / pow(f, thinning);
 		candidate->addSecondary(11, Ep / (1 + z), pos, w);
 	}
 	if (random.rand() < pow(1 - f, thinning)){
-		double w = w0 / pow(1 - f, thinning);
+		double w = 1. / pow(1 - f, thinning);
 		candidate->addSecondary(-11, Ee / (1 + z), pos, w);	
 	}
 }

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -125,17 +125,16 @@ void EMTripletPairProduction::performInteraction(Candidate *candidate) const {
 	// For our purposes, me << E0 --> p0~E0 --> alpha = E0*eps*(costheta - 1) >= 100
 	double Epp = 5.7e-1 * pow(eps / mec2, -0.56) * pow(E / mec2, 0.44) * mec2;
 
-	double w0 = candidate->getWeight();
 	double f = Epp / E;
 
 	if (haveElectrons) {
 		Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());
 		if (random.rand() < pow(1 - f, thinning)) {
-			double w = w0 / pow(1 - f, thinning);
+			double w = 1. / pow(1 - f, thinning);
 			candidate->addSecondary(11, Epp / (1 + z), pos, w);
 		}
 		if (random.rand() < pow(f, thinning)) {
-			double w = w0 / pow(f, thinning);
+			double w = 1. / pow(f, thinning);
 			candidate->addSecondary(-11, Epp / (1 + z), pos, w);
 		}
 	}

--- a/src/module/SynchrotronRadiation.cpp
+++ b/src/module/SynchrotronRadiation.cpp
@@ -132,7 +132,6 @@ void SynchrotronRadiation::process(Candidate *candidate) const {
 	double dE = step * dEdx;
 
 	// apply energy loss and limit next step
-	double w0 = candidate->getWeight();
 	double E = candidate->current.getEnergy();
 	candidate->current.setEnergy(E - dE);
 	candidate->limitNextStep(limit * E / dEdx);
@@ -191,7 +190,7 @@ void SynchrotronRadiation::process(Candidate *candidate) const {
 	for (int i = 0; i < energies.size(); i++) {
 		double Ephoton = energies[i];
 		double f = Ephoton / (E - dE0);
-		double w = w0 * w1 / pow(f, thinning);
+		double w = w1 / pow(f, thinning);
 
 		// thinning procedure: accepts only a few random secondaries
 		if (random.rand() < pow(f, thinning)) {

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -197,6 +197,17 @@ TEST(Candidate, property) {
 	EXPECT_EQ("bar", value);
 }
 
+TEST(Candidate, weight) {
+    Candidate candidate;
+    EXPECT_EQ (1., candidate.getWeight());
+    
+    candidate.setWeight(5.);
+    EXPECT_EQ (5., candidate.getWeight());
+    
+    candidate.updateWeight(3.);
+    EXPECT_EQ (15., candidate.getWeight());
+}
+
 TEST(Candidate, addSecondary) {
 	Candidate c;
 	c.setRedshift(5);

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -1,8 +1,8 @@
 /** Unit tests for core features of CRPropa
-  	Candidate
-  	ParticleState
-  	Random
-  	Common functions
+	Candidate
+	ParticleState
+	Random
+	Common functions
  */
 
 #include "crpropa/Candidate.h"
@@ -201,22 +201,28 @@ TEST(Candidate, addSecondary) {
 	Candidate c;
 	c.setRedshift(5);
 	c.setTrajectoryLength(23);
+	c.setWeight(3.);
 	c.previous.setId(nucleusId(56,26));
 	c.previous.setEnergy(1000);
 	c.previous.setPosition(Vector3d(1,2,3));
 	c.previous.setDirection(Vector3d(0,0,1));
 
 	c.addSecondary(nucleusId(1,1), 200);
-	Candidate s = *c.secondaries[0];
+	c.addSecondary(nucleusId(1,1), 200, 5.);
+	Candidate s1 = *c.secondaries[0];
+	Candidate s2 = *c.secondaries[1];
 
-	EXPECT_EQ(nucleusId(1,1), s.current.getId());
-	EXPECT_EQ(200, s.current.getEnergy());
-
-	EXPECT_EQ(5, s.getRedshift());
-	EXPECT_EQ(23, s.getTrajectoryLength());
-	EXPECT_EQ(1000, s.created.getEnergy());
-	EXPECT_TRUE(Vector3d(1,2,3) == s.created.getPosition());
-	EXPECT_TRUE(Vector3d(0,0,1) == s.created.getDirection());
+	EXPECT_EQ(nucleusId(1,1), s1.current.getId());
+	EXPECT_EQ(200, s1.current.getEnergy());
+	EXPECT_EQ(5, s1.getRedshift());
+	EXPECT_EQ(23, s1.getTrajectoryLength());
+	EXPECT_EQ(1000, s1.created.getEnergy());
+	EXPECT_EQ(3., s1.getWeight());
+	EXPECT_TRUE(Vector3d(1,2,3) == s1.created.getPosition());
+	EXPECT_TRUE(Vector3d(0,0,1) == s1.created.getDirection());
+	
+	EXPECT_EQ(15., s2.getWeight());
+	
 }
 
 TEST(Candidate, serialNumber) {


### PR DESCRIPTION
### Issue
Primary candidate weights, e.g. calculated and set by the `SourceTargetedEmission` feature, have not been properly inherited to their secondaries. The secondaries were always created with a default value of weight=1. This could have led to wrong particle spectra etc., when the targeting method was used in combination with non-electromagnetic interactions.[1]

### Solution
Change the behavior of the `addSecondary` method of the `Candidate` class, so that secondary particles will inherit their parents weights on default. 

### Details
 - Fix in the candidate's constructor, which ignored any weight that was given in the constructor.
 - Fixed the setWeight call in addSecondary to set the secondary's weight to w*w_0, where w_0 is the parent particle's weight at creation of the secondary and w is an optional factor for the secondary weight which defaults to w=1.
 - In addition to the `setWeight` method an `updateWeight` method was introduced. Which changes a candidate's weight by multiplication without the need of a getWeight call. --> Used in the acceleration module.
 - Including simple tests of the set/update/getWeight methods and weight inheritance.

### Test
The issue was first noticed by Simone Rossoni, who provided us with some test cases. Additional checks and suggestions for the implementation came from @avvliet.
To illustrate the test here are some before and after plots:
The figure [energy-spectrum-targeted-master.pdf](https://github.com/CRPropa/CRPropa3/files/9103342/energy-spectrum-targeted-int-B.pdf) shows results for a test simulation defined in [targeted-int.txt](https://github.com/CRPropa/CRPropa3/files/9103375/targeted-int.txt), where the weights of the output file have been included. For comparison a run without targeting [2] was done, which lead to the following spectra [energy-spectrum-not-targeted-int-B.pdf](https://github.com/CRPropa/CRPropa3/files/9103405/energy-spectrum-not-targeted-int-B.pdf).
The last plot shows now a run including targeting done with the fixes proposed in this PR [energy-spectrum-targeted-int-B.pdf](https://github.com/CRPropa/CRPropa3/files/9103417/energy-spectrum-targeted-int-B.pdf).

A simpler test can be done based on this jupyter notebook [Target.zip](https://github.com/CRPropa/CRPropa3/files/9103464/Target.zip). Here, a proxy for a not working weight inheritance are weights = 1. After the fix no weights equal to one are found in the output.


[1] In all EM* and the Synchrotronradiation module the inheritance was manually implemented due to the thinning procedures.
[2] Emitting all particles at the source in a cone with the same opening angle as the targeting method, to get similar statistics.
