### PR TITLE
Update testing environments

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,21 +8,21 @@ jobs:
       fail-fast: false
       matrix:
         config:
+         - name: "ubuntu-22"
+           os: ubuntu-22.04
+           cxx: "g++-11"
+           cc: "gcc-11"
+           fc: "gfortran-11"
+           swig_builtin: "On" #uses swig 4.0.2
+           py: "/usr/bin/python3" # python 3.10
+           cov: "On"
          - name: "ubuntu-20"
-           os: ubuntu-latest
+           os: ubuntu-20.04
            cxx: "g++-9"
            cc: "gcc-9"
            fc: "gfortran-9"
            swig_builtin: "Off" #uses swig 4.0.1
-           py: "/usr/bin/python3"
-           cov: "On"
-         - name: "ubuntu-18_py3"
-           os: ubuntu-18.04
-           cxx: "g++-7"
-           cc: "gcc-7"
-           fc: "gfortran-7"
-           swig_builtin: "Off" #uses swig 3.x
-           py: "/usr/bin/python3"
+           py: "/usr/bin/python3" #python 3.8
          - name: "ubuntu-18_py2"
            os: ubuntu-18.04
            cxx: "g++-7"
@@ -56,7 +56,7 @@ jobs:
           make test
       - name: Archive test results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: "test-report_${{matrix.config.name}}"
           path: build/Testing/Temporary/LastTest.log

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,5 @@
 name: crpropa-testing
-on: [push]
+on: [push, pull_request]
 
 jobs:
   linux:
@@ -32,7 +32,7 @@ jobs:
            py: "/usr/bin/python2"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Preinstall
         run: |
           sudo apt-get update

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,14 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-         - name: "ubuntu-22"
-           os: ubuntu-22.04
-           cxx: "g++-11"
-           cc: "gcc-11"
-           fc: "gfortran-11"
-           swig_builtin: "On" #uses swig 4.0.2
-           py: "/usr/bin/python3" # python 3.10
-           cov: "On"
          - name: "ubuntu-20"
            os: ubuntu-20.04
            cxx: "g++-9"
@@ -60,5 +52,47 @@ jobs:
         with:
           name: "test-report_${{matrix.config.name}}"
           path: build/Testing/Temporary/LastTest.log
-    
+runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+         - name: "ubuntu-22"
+           os: ubuntu-22.04
+           cxx: "g++-11"
+           cc: "gcc-11"
+           fc: "gfortran-11"
+           swig_builtin: "On" #uses swig 4.0.2
+           py: "/usr/bin/python3" # python 3.10
+           cov: "On"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Preinstall
+        run: |
+          sudo apt-get update
+          sudo apt-get install libmuparser-dev python python-numpy python-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
+      - name: Set up the build
+        env:
+          CXX: ${{ matrix.config.cxx }}
+          CC: ${{ matrix.config.cc }}
+          FC: ${{ matrix.config.fc }}
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native
+      - name: Build CRPropa
+        run: |
+          cd build
+          make
+      - name: Run tests
+        run: |
+          cd build
+          make test
+      - name: Archive test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: "test-report_${{matrix.config.name}}"
+          path: build/Testing/Temporary/LastTest.log    
   

--- a/.github/workflows/testing_OSX.yaml
+++ b/.github/workflows/testing_OSX.yaml
@@ -1,5 +1,5 @@
 name: crpropa-testing_OSX
-on: [push]
+on: [push, pull_request]
 jobs:
   mac:
     runs-on: ${{ matrix.config.os }}
@@ -16,7 +16,7 @@ jobs:
             py: "/usr/bin/python"
     steps:
      - name: Checkout repository
-       uses: actions/checkout@v2
+       uses: actions/checkout@v3
      - name: Preinstall
        run: |
          brew install hdf5 fftw cfitsio muparser libomp
@@ -42,7 +42,7 @@ jobs:
          make test
      - name: Archive test results
        if: always()
-       uses: actions/upload-artifact@v2
+       uses: actions/upload-artifact@v3
        with:
          name: "test-report_${{matrix.config.name}}"
          path: build/Testing/Temporary/LastTest.log

--- a/.github/workflows/testing_OSX.yaml
+++ b/.github/workflows/testing_OSX.yaml
@@ -7,25 +7,15 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: "macos-12"
-            os: macos-12
-            cxx: "clang++"
-            cc: "clang"
-            fc: "gfortran-11"
-            swig_builtin: "On" #uses swig 4.0.2
-            py: "/usr/local/bin/python3" # python 3.11
-            pylib: "/usr/local/lib/libpython3.11.dylib"
-            pyhdr: "/usr/local/include/python3.11"
           - name: "macos-11"
             os: macos-11
             cxx: "clang++"
             cc: "clang"
             fc: "gfortran-11"
             swig_builtin: "On" #uses swig 4.0.2
-            py: "/usr/local/bin/python3" # python 3.11
-            pylib: "/usr/local/lib/libpython3.11.dylib"
-            pyhdr: "/usr/local/include/python3.11"
-
+            py: "/usr/bin/python3" # python 3.11
+            #pylib: "/usr/local/lib/libpython3.11.dylib"
+            #pyhdr: "/usr/local/include/python3.11"
     steps:
      - name: Checkout repository 
        uses: actions/checkout@v3 
@@ -41,7 +31,7 @@ jobs:
        run: |
         mkdir build
         cd build
-        cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=${{ matrix.config.py }} -DPYTHON_LIBRARY=${{ matrix.config.pylib }} -DPYTHON_INCLUDE_PATH=${{ matrix.config.pyhdr }}  -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=avx
+        cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=avx
      - name: Build CRPropa
        run: |
          cd build

--- a/.github/workflows/testing_OSX.yaml
+++ b/.github/workflows/testing_OSX.yaml
@@ -7,13 +7,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - name: "macos-12"
+            os: macos-12
+            cxx: "clang++"
+            cc: "clang"
+            fc: "gfortran-11"
+            swig_builtin: "On" #uses swig 4.0.2
+            py: "/usr/bin/python" # python 3.11
           - name: "macos-11"
             os: macos-11
             cxx: "clang++"
             cc: "clang"
             fc: "gfortran-11"
             swig_builtin: "On" #uses swig 4.0.2
-            py: "/usr/bin/python"
+            py: "/usr/bin/python" # python 3.11
     steps:
      - name: Checkout repository
        uses: actions/checkout@v3

--- a/.github/workflows/testing_OSX.yaml
+++ b/.github/workflows/testing_OSX.yaml
@@ -13,19 +13,24 @@ jobs:
             cc: "clang"
             fc: "gfortran-11"
             swig_builtin: "On" #uses swig 4.0.2
-            py: "/usr/bin/python" # python 3.11
+            py: "/usr/local/bin/python3" # python 3.11
+            pylib: "/usr/local/lib/libpython3.11.dylib"
+            pyhdr: "/usr/local/include/python3.11"
           - name: "macos-11"
             os: macos-11
             cxx: "clang++"
             cc: "clang"
             fc: "gfortran-11"
             swig_builtin: "On" #uses swig 4.0.2
-            py: "/usr/bin/python" # python 3.11
+            py: "/usr/local/bin/python3" # python 3.11
+            pylib: "/usr/local/lib/libpython3.11.dylib"
+            pyhdr: "/usr/local/include/python3.11"
+
     steps:
-     - name: Checkout repository
-       uses: actions/checkout@v3
-     - name: Preinstall
-       run: |
+     - name: Checkout repository 
+       uses: actions/checkout@v3 
+     - name: Preinstall 
+       run: | 
          brew install hdf5 fftw cfitsio muparser libomp
      - name: Set up the build
        env:
@@ -36,7 +41,7 @@ jobs:
        run: |
         mkdir build
         cd build
-        cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=avx
+        cmake .. -DENABLE_PYTHON=True -DPYTHON_EXECUTABLE=${{ matrix.config.py }} -DPYTHON_LIBRARY=${{ matrix.config.pylib }} -DPYTHON_INCLUDE_PATH=${{ matrix.config.pyhdr }}  -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=avx
      - name: Build CRPropa
        run: |
          cd build

--- a/.github/workflows/testing_OSX.yaml
+++ b/.github/workflows/testing_OSX.yaml
@@ -13,9 +13,7 @@ jobs:
             cc: "clang"
             fc: "gfortran-11"
             swig_builtin: "On" #uses swig 4.0.2
-            py: "/usr/bin/python3" # python 3.11
-            #pylib: "/usr/local/lib/libpython3.11.dylib"
-            #pyhdr: "/usr/local/include/python3.11"
+            py: "/usr/bin/python"
     steps:
      - name: Checkout repository 
        uses: actions/checkout@v3 

--- a/.github/workflows/testing_ubuntu22.yml
+++ b/.github/workflows/testing_ubuntu22.yml
@@ -8,27 +8,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
-         - name: "ubuntu-20"
-           os: ubuntu-20.04
-           cxx: "g++-9"
-           cc: "gcc-9"
-           fc: "gfortran-9"
-           swig_builtin: "Off" #uses swig 4.0.1
-           py: "/usr/bin/python3" #python 3.8
-         - name: "ubuntu-18_py2"
-           os: ubuntu-18.04
-           cxx: "g++-7"
-           cc: "gcc-7"
-           fc: "gfortran-7"
-           swig_builtin: "Off" #uses swig 3.x
-           py: "/usr/bin/python2"
+         - name: "ubuntu-22"
+           os: ubuntu-22.04
+           cxx: "g++-11"
+           cc: "gcc-11"
+           fc: "gfortran-11"
+           swig_builtin: "On" #uses swig 4.0.2
+           py: "/usr/bin/python3" #python 3.10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python3-dev python-dev python3-numpy python-numpy python3-setuptools python-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
+          sudo apt-get install libmuparser-dev python python-numpy python-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
       - name: Set up the build
         env:
           CXX: ${{ matrix.config.cxx }}
@@ -52,3 +45,4 @@ jobs:
         with:
           name: "test-report_${{matrix.config.name}}"
           path: build/Testing/Temporary/LastTest.log
+  

--- a/.github/workflows/testing_ubuntu22.yml
+++ b/.github/workflows/testing_ubuntu22.yml
@@ -1,4 +1,4 @@
-name: crpropa-testing
+name: crpropa-testing_ubuntu22
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/testing_ubuntu22.yml
+++ b/.github/workflows/testing_ubuntu22.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python python-numpy python-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
+          sudo apt-get install libmuparser-dev python3 python3-numpy python3-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
       - name: Set up the build
         env:
           CXX: ${{ matrix.config.cxx }}


### PR DESCRIPTION
This PR updates the automated tests to more recent ubuntu versions. Ubuntu-22 is now included in the test matrix.
The Ubuntu-18 test will only work until 2023-04-01. However, I kept it in the test until then as some people are still using ubuntu-18.

I was not able to update to macos-12. So I removed it again from the mac test matrix. Maybe @rafaelab can at some point help with updating the test.

Also some of the github actions are updated.

Tests should now also be triggered for a PR and not only for a push. --> We get the test results before merging into master.