### PR TITLE
Fix Acceleration module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,15 @@
 # CRPropa NEXT
 
 ### Bug fixes:
-
+* Synchronized signature of ParticleSplitting constructor
 
 ### New features:
 * new candidate property tagOrigin to trace back which source or which interaction created the candidate
 
 ### Interface changes:
-
+* Weight column in hdf-Output is now called "W", which is the same as for TextOutput.
 
 ### Features that are deprecated and will be removed after this release
-
 
 ### New plugins and resources linked on the webpages:
 

--- a/doc/pages/example_notebooks/acceleration/first_order_fermi_acceleration.ipynb
+++ b/doc/pages/example_notebooks/acceleration/first_order_fermi_acceleration.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,9 +72,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'simulation' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/rest/CRPropa3/doc/pages/example_notebooks/acceleration/first_order_fermi_acceleration copy.ipynb Cell 6\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell://ssh-remote%2Bt20/rest/CRPropa3/doc/pages/example_notebooks/acceleration/first_order_fermi_acceleration%20copy.ipynb#W5sdnNjb2RlLXJlbW90ZQ%3D%3D?line=0'>1</a>\u001b[0m simulation\u001b[39m.\u001b[39madd(crpropa\u001b[39m.\u001b[39mSimplePropagation(\u001b[39m1E-4\u001b[39m \u001b[39m*\u001b[39mcrpropa\u001b[39m.\u001b[39mparsec, \u001b[39m.5\u001b[39m \u001b[39m*\u001b[39mcrpropa\u001b[39m.\u001b[39mparsec))\n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bt20/rest/CRPropa3/doc/pages/example_notebooks/acceleration/first_order_fermi_acceleration%20copy.ipynb#W5sdnNjb2RlLXJlbW90ZQ%3D%3D?line=1'>2</a>\u001b[0m obs1 \u001b[39m=\u001b[39m crpropa\u001b[39m.\u001b[39mObserver()\n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bt20/rest/CRPropa3/doc/pages/example_notebooks/acceleration/first_order_fermi_acceleration%20copy.ipynb#W5sdnNjb2RlLXJlbW90ZQ%3D%3D?line=2'>3</a>\u001b[0m obs1\u001b[39m.\u001b[39madd(crpropa\u001b[39m.\u001b[39mObserverSurface(crpropa\u001b[39m.\u001b[39mPlane(crpropa\u001b[39m.\u001b[39mVector3d(\u001b[39m-\u001b[39mupstreamSize, \u001b[39m0\u001b[39m, \u001b[39m0\u001b[39m), crpropa\u001b[39m.\u001b[39mVector3d(\u001b[39m1.\u001b[39m, \u001b[39m0\u001b[39m, \u001b[39m0\u001b[39m))))\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'simulation' is not defined"
+     ]
+    }
+   ],
    "source": [
     "simulation.add(crpropa.SimplePropagation(1E-4 *crpropa.parsec, .5 *crpropa.parsec))\n",
     "obs1 = crpropa.Observer()\n",
@@ -103,27 +115,162 @@
     "simulation.setShowProgress(True)\n",
     "simulation.run(source, 10000)\n",
     "output1.close()\n",
-    "output2.close()\n"
+    "output2.close()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import numpy as np\n",
+    "import pylab as plt\n",
+    "from scipy import optimize\n",
+    "\n",
+    "with h5py.File('shock_downstream.h5', 'r') as data:\n",
+    "    E = data['CRPROPA3']['E'] * 1E18\n",
+    "    bin_edges = 10**np.linspace(15, 21)\n",
+    "    bin_width = bin_edges[1:] - bin_edges[:-1]\n",
+    "    bin_center = bin_edges[:-1] + 0.5 * bin_width\n",
+    "\n",
+    "    H = np.histogram(E, bins=bin_edges)\n",
+    "\n",
+    "    J = H[0] / bin_width\n",
+    "\n",
+    "    dJ = J / np.sqrt(H[0])\n",
+    "\n",
+    "    fig = plt.figure(figsize=(6, 6))\n",
+    "    sp = fig.add_subplot(111)\n",
+    "    sp.loglog()\n",
+    "    sp.errorbar(bin_center, J * bin_center**2, xerr=bin_width/2, yerr=dJ * bin_center**2, ls='None')\n",
+    "    sp.set_xlabel('$E$ / eV')\n",
+    "    sp.set_ylim(1e18, 1e21)\n",
+    "    sp.set_ylabel('$J\\cdot E^2$ [a.u.]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "yielding the expected $J\\propto E^{-2}$ relationship."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Due to the power law nature of the acceleration the simulations may become quite time consuming if large energy gains are of interest. Particle splitting, i.e. inverse thinning, can be used here to reduce the simulation effort. \n",
+    "\n",
+    "The example below shows how that can be done. It is important to take the weights of the candidates into account, which makes small changes in the analysis part necessaray."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "Text(0,0.5,'$J\\\\cdot E^2$ [a.u.]')"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "crpropa::ModuleList: Number of Threads: 8\n",
+      "Run ModuleList\n",
+      "  Started Wed Feb  1 10:32:56 2023 : [\u001b[1;32m Finished \u001b[0m] 100%    Needed: 00:00:00  - Finished at Wed Feb  1 10:32:56 2023\n",
+      "\r"
+     ]
+    }
+   ],
+   "source": [
+    "import crpropa\n",
+    "scatter_velocity = 0.1 * crpropa.c_light\n",
+    "step_length = 0.5 * crpropa.parsec\n",
+    "\n",
+    "flow_direction = crpropa.Vector3d(1., 0, 0) * scatter_velocity\n",
+    "yzsize = 100. * crpropa.parsec\n",
+    "\n",
+    "\n",
+    "upstream_velocity = flow_direction\n",
+    "upstreamSize = 10000. * crpropa.parsec\n",
+    "upstreamGeometry = crpropa.ParaxialBox(crpropa.Vector3d(-1 * upstreamSize, -.5 * yzsize, -.5 * yzsize),\n",
+    "                         crpropa.Vector3d(upstreamSize, yzsize, yzsize))\n",
+    "upstream_scatter_module = crpropa.DirectedFlowScattering(upstream_velocity, step_length)\n",
+    "upstream = crpropa.RestrictToRegion(upstream_scatter_module, upstreamGeometry)\n",
+    "\n",
+    "\n",
+    "downstreamSize = 100. * crpropa.parsec\n",
+    "downstream_velocity = flow_direction * 1./4\n",
+    "downstreamGeometry = crpropa.ParaxialBox(crpropa.Vector3d(0, -.5 * yzsize, -.5 * yzsize),\n",
+    "                           crpropa.Vector3d(downstreamSize, yzsize, yzsize))\n",
+    "downstream_scatter_module = crpropa.DirectedFlowScattering(downstream_velocity, step_length)\n",
+    "downstream = crpropa.RestrictToRegion(downstream_scatter_module, downstreamGeometry)\n",
+    " \n",
+    "simulation = crpropa.ModuleList()\n",
+    "simulation.add(upstream)\n",
+    "simulation.add(downstream)\n",
+    "simulation.add(crpropa.ReflectiveBox(crpropa.Vector3d(-upstreamSize * 2, -yzsize /2, -yzsize /2),\n",
+    "    crpropa.Vector3d(upstreamSize * 2 + downstreamSize * 2, yzsize, yzsize)))\n",
+    "\n",
+    "simulation.add(crpropa.SimplePropagation(1E-4 *crpropa.parsec, .5 *crpropa.parsec))\n",
+    "obs1 = crpropa.Observer()\n",
+    "obs1.add(crpropa.ObserverSurface(crpropa.Plane(crpropa.Vector3d(-upstreamSize, 0, 0), crpropa.Vector3d(1., 0, 0))))\n",
+    "obs1.setDeactivateOnDetection(True)\n",
+    "output1 = crpropa.HDF5Output('shock_upstream_splitting.h5', crpropa.Output.Event3D)\n",
+    "output1.enable(crpropa.Output.WeightColumn) #weights needs to be stored\n",
+    "obs1.onDetection(output1)\n",
+    "simulation.add(obs1)\n",
+    "\n",
+    "obs2 = crpropa.Observer()\n",
+    "obs2.add(crpropa.ObserverSurface(crpropa.Plane(crpropa.Vector3d(downstreamSize, 0, 0), crpropa.Vector3d(1., 0, 0))))\n",
+    "\n",
+    "obs2.setDeactivateOnDetection(True)\n",
+    "output2 = crpropa.HDF5Output('shock_downstream_splitting.h5', crpropa.Output.Event3D)\n",
+    "output2.enable(crpropa.Output.WeightColumn) #weights needs to be stored\n",
+    "obs2.onDetection(output2)\n",
+    "simulation.add(obs2)\n",
+    "\n",
+    "# Splitting of candidates with the following parameters\n",
+    "crossingThreshold = 50\n",
+    "numSplits = 3\n",
+    "minWeight = 0.01\n",
+    "counterid = \"ParticleSplittingCounter\"\n",
+    "#shock_surface = crpropa.Plane(crpropa.Vector3d(0., 0, 0), crpropa.Vector3d(1., 0, 0))\n",
+    "#split = crpropa.ParticleSplitting(shock_surface, crossingThreshold, numSplits, minWeight, counterid)\n",
+    "#simulation.add(split)\n",
+    "\n",
+    "\n",
+    "source = crpropa.Source()\n",
+    "source.add(crpropa.SourcePosition(crpropa.Vector3d(-10. * crpropa.parsec, 0, 0)))\n",
+    "source.add(crpropa.SourceParticleType(crpropa.nucleusId(1, 1)))\n",
+    "source.add(crpropa.SourceEnergy(1E16 * crpropa.eV))\n",
+    "source.add(crpropa.SourceIsotropicEmission())\n",
+    "\n",
+    "\n",
+    "# Execute simulation\n",
+    "simulation.setShowProgress(True)\n",
+    "simulation.run(source, 1) #Note the reduced number of primary particles\n",
+    "output1.close()\n",
+    "output2.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_23668/2023190340.py:18: RuntimeWarning: invalid value encountered in true_divide\n",
+      "  dJ = J / np.sqrt(H_count[0])\n"
+     ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAasAAAGaCAYAAACxN2xlAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3U9zG9ee3vHnmWSdoeXsY1NjbzOXlPNnG5HOwqVFUqScrFMiXdncctWUaL+ByNQsXN5kQnpmPxJ5s1F5kZC666SuSN+1XKKdF2CRd/bJL4s+TYFgA2ig0cBB4/upYkFGN9BtdhEPzjm/c9oRIQAAcvZn8z4BAABGIawAANkjrAAA2SOsAADZI6wAANkjrAAA2SOsMBW2d+Z9DriJa5InrstkCCtMC3+A+eGa5InrMgHCCgCQPcIKAJA9wgoAkD2zNuDkbPPLA4AJRYTr7kvLCgCQvX887xPoAlqnAFCfXbtBdY2WFQAge7SsJmD7gaQH8z4PAFhktg/TP19ExIuh+9KFNbmywILfIQDUV3YDUmABAOgUwgoAkD3CCgCQPcIKAJA9wgoAkD3CCgCQPcIKAJA9wgoAkD3CCgCQPcIKAJA91gacAGsDAsjNtyevr//95ebHczyT+lgbcEZYGxBALj746ofrf//yzWdzPJPRWBsQANBJhBUAIHuEFQAge4QVACB7hBUAIHuEFQAge4QVACB7hBUAIHuEFQAge50OK9trts9sR3rcGLDPvu3H8zhHAMBonQ4rSUeSHqUlPZ5IOrG9Vm60vS9pX9LWnM4PAFBDZ8MqhdJpRJxLUkQcSzqWtFvuExF7EbEp6WI+ZwkAqCPrsLJ9Ynt1wLYV2we2L9PPUe++EXEeEbt9L3sr6U6b5wwAmL7sbhFie0vSJ5J2JK0M2fVMRfA8kXQlaU/Sme31iBjUUtpI+wEAFkhWYZVaRkeSzlV0za0N2G9H0qqk9bKbz/ZzSZcqxqC2K15zJOk4dQcCABZIVt2AEXEREY6IdUnPhuy6Lem8DKr02itJh6oolrB9IOkiImhVAcACyiqsxrAh6VXF82fSdQtN6d9Hks4IKgBYXFl1A9ZhuxzHuqrY/DY9rkq6SEH1jK4/AF307clrfffyp1vPf/DVD/rt/Y8W5vb2dSxcWOldNd+vFduuAyxNAN6StFXeQjk5TeXq5TyrLRXhds/2rqTdiDjtf+M0TrYzlf8DAIBsV/WQHUbEYf+TixhWdayk1pSH7ZS6Bmt1D6Zf3o1foO2Y+AwBYMlFxL26+3Y1rKq6CAGgU77c/Pi6q++Dr364fv6Xbz6b1ym1ZhELLMpxqfcrtq327QMA6ICFa1lFxJXtK70Lpl5302OryyfZfiDpQZvHAICus10OrbyIiBfD9l24sEpOVZSv99tQMZ+q1W7A9Et9YftRm8cBgC6LiNpFa4vYDSgVE4ZX0tJMkq4Xrl1TsVgtAKBDsmtZ9dzCo+zS20jljVflmn8RcWz7XNKR7T0VBRX76fHJDM6RbkAAaGicbkBH5FN9nSb8Xg7YfD0/qmf/A0kPVSx4e6zi3lUzqwQsS9dz+h0CWE6LVA1Yzn1N9xqsJauWVQqa2iefbgHSfxsQAEDHLOqYFQBgiWTVsloUjFkBQHPLULo+V5SuA0Bzy1C6DgBYIoQVACB7dANOgDErAGiOMauWMWYFAM0xZgUA6BTCCgCQPcIKAJA9wgoAkD0KLCZANSCAKt+evL7+d3m7eQxGNWDLqAYEUOW7lz9d/5uwGo1qQABApxBWAIDsEVYAgOwRVgCA7FFgMQGqAQGgOaoBW0Y1IAA0N041IGEFAGNgLtV8EFYAMAbmUs0HBRYAgOwRVgCA7BFWAIDsEVYAgOwRVgCA7FENOAEmBQNAc0wKbhmTgoHuYz5V+5gUDAB9xg0f5lPlhbACsBQIn8VGWAFAA9+evL4RhL3PE4rTQzUgACB7hBUAIHt0AwJAA19ufnzd3ffBVz/ceB7TQ8sKAJA9WlYAFg5zoJYPYQVg4VCGvnwIqwmw3BIANDfOckuMWU0gIl6Ms0wIgMX37cnrGwUUUlFQ0dslifFExE76GRpUEi0rADPEWBMmRVgBmBnGmjApugEBoIYvNz/WL998duO5X775jNCdEVpWACTRRYe8EVYAJHWzi27QIrMffPWDfnv/o878fy4DugEBANmjZQV0EF166BrCCuigLnbpTWLQIrP9hRLIH92AwJJre7Jr+f7TOMYsJuYy+TdPnQ4r22u2z2xHetyo2OfA9uWg7cAi4YMWXdX1bsAjSdsRcW57S9KJ7fWIOJeKoJKkiHjP9qqks7T9Yo7nDNzCGBSWXWfDyvaapNMymCLi2PaxpN30I0k7EeG0/cL287Rtbx7nDAwKpTbHoMpxnUFjOk2DcprjRqPOdRpmcQyML+uwsn0iabeqpWN7RdK+pIfpqVNJe+W+KaR2+172VtKd9PoNSf3v+0bS5tT+B4AxNQ2lOh+044YPxRrIQXZhlbrrPpG0I2llyK5nKoLniaQrFa2hUd14G3rXalpJr+t1kd4TmJlhE1f/5Yd39L9/fnvr+SYTWrsePnSZdlNWYZXGjY4knasIjrUB++1IWpXUO/70XNKlitbWdsVrjiQdR8Rxz9PDwhBLatwPu3l+OPLBfFvXw3hZZRVWqUVkSbL9WAPCSkUYnZdBlV57lW7kdes+U6mQ4iIieseirnS7FXVHRVchlkB/hVxV6+a7lz8NbMVUtYiG7d+GQR/Mv73/0UyOD8xKVmE1hg1JhxXPn0lFC63sCkwtqpOI6N//laQV2ysRUXYHrqto1WEKBnVvVXVtSRr6IT/ue03y/ChttWLqFCCMO9jff3511sgj4JCzhQurVFgh3R5vkt61ilYlXaSgetbX9SfpuiV2rKLbcDdVDz5UEViYg/918eutOUKlOmHSlqrz+u7lT3M9p6rwaTqWVSfg6hyDrkm0YeHCSu+67n6t2HYdYKnab0vSlu3efU4jYlOSImK7nBSsYoxsmzlWy+lfrb6vZ7v/WtLtD9tvT15XtsbK10yz5HtQ62aRWj2MGaENixhWdayk1pRH7RgRvfOuBkpFHbfGwzBYb/dWHYNCQboZJuOYJDDG/YDtD5ImY1mDtjf90GeNPOTI9quKpw8rhm06G1ZVXYSNpF/ejV+g7Zj2cZbZuOFW9z2n8R5lC6vqfSc5xrQm2s5zcizdfWgqIu7V3XcRw6r86v1+xbbVvn2AqZnmB3IXusq68P+AxbFwC9mmyr0rvQumXnfTY6vjTrYfpDJ54JYvNz++1cop/7tq9XEWmS1+B+UPloftw/TzYNS+i9iykoqllapWSN9QMZ9q6t2AvSLihaQXth+1eRwstkUqipiVQb8TWmnLKSJq1wEsalg9U1Hlt1WWpafS8zVJT+d6ZkAyiw/dSQJxniFKEGFS2YVVCh3pXZfeRqoYuepZpPbY9rmkI9t7KroF99Pjkxmc4wNJI5utQK9BFXlNPsAnLc4ActAznPIi9VgNlFVYpQm/Z31PH6THU/WsiB4R62kZpa9VrPF3LOlR212A6dh0AwJ92piojG5b2G7AFDQj50b17F9rjhTaNWgpHz6kBmM8CxhPVmEFLItFCnGCFTkgrCbAmBWWyThrBv7yzWeskIHaFnbMalEwZnVTGytPAOi+ccasFm5SMABg+dCyAjCWWaxLOK5BRT7fnrym1d8RtKwAANkb2bKyfV/S8ykfNyQ9jIjfT/l9Z4ICCwBoro0Ci/dUTMqdBkv6Nyom8i4kCiyA+eovp29jdRC0r41JwRERn054PrfY/n/Tei8Ay4cQWj51xqwuJH0/5eMequXbeADI37cnr2/dMuWDr37gViG4ZWTLKiJ+lvTFNA8aEVN9PwBAt1G6PgEKLACguWxWsLD9RNKHEfEf2jzOrFFgAUxHjnO2MDs5rbp+T0XlX6fCCsDiYUHexdZqWEXE5ui9AKB9VBAuNlawAABkj7ACAGSPasAJUA0IDMbYEOqaWTWg7V9r7BYR8U+bHCc3VAMCg0OJsSHUNctqwF9ULEpbZVXF+n9HDY8BIEOEEmapUVhFxPqw7bafSzpocgwAANousNiRtNfyMQAAHddqWEXElYqJwQAATKxpgcVfDtl8R9KmFvi+VQCAPDQtsDjX4AILqbjRIgUWAIBGmobVFxoeVhcR8bLhMQAAS65pNeDh6L26h0nBANBcNrcI6SomBQNAc+NMCmZtQABA9loNK9tPbP99m8cAAHRf2y2re5K2Wz4GAKDjuPkiACB7jFkBALJHWAEAsjeVbsC07NKgNQDfRsR/n8ZxAADLqenagH8u6VTSmoqllSI9Su9WtriQRFgBACbWtBtwX9JdFcsufaoiqHZVLGD7dfpvbhECAGikaTfgQ0mPI+JvJcn2haQ3EfF7SS9t35H0uWhZAQAaaNqy6r/9x4WKLsHSHyRtNDxGdmw/6FnTCgAwAduH6WfkWqtNw+pc0mrPfx+r6P4rdfJ+VhHxYpw1rQAAt0XETvoZuoit1DysDlWMUZWeSbLtn2z/QcVt7U8bHgMAsOQahVW6Rci9nv/+k4puv18kvacizB42OQYAAI3nWUXEz33/fa6i+w8AgKkY2bKy/aHtv5rmQW3/le0PpvmeAIDuqtMNuKpiPtU07etm1SAAAAPV7Qa07f+qd6tTAAAwM+OMWX3R2lkAWGq/vf/RvE8BmRsZVhHxUqzODqBFX25+PO9TQOY6H0K212zv235csW3F9pHtS9tvbHdutQ0A6IJOh5XtfRXFHFsDdnkp6SIi3pO0LenE9uqAfQEAc9LpsIqIvYjYVLFm4Q2pFbUWEXtp33MVq22wSjwAZCbrsLI9sKWTuvAOUhfeZerOG7dV1B9iV7q51iEAIANTuVPwNNnekvSJinUFhy2CeybpjqQnKkJmT9KZ7fWIuNWSqvBK0qrt1Z7919J7AQAyklXLKrWMjlSsLzgwcGzvqGgB3Y+Ip2mNwnUV4VZrAnNEXKlYJf4gtdIeqwiqOkEHAJihrMIqIi4iwhGxrmIF90G2JZ2ncabytVcqFs4dVExR5VF6fKl3QUVYAUBmsusGrGlDRTD1O5OKFlqdrsAUcNeL7qbqwfVpnSQAYDrqLGT7l7b/xvYz2/+uYvv/aOfUBp5POY5VNbb0Nj3WKpKwvdbz7yNJz2uOdwEAZmhoWNm+r+JuwO9LupT017b/S99us55Ieyc9/lqx7UaApcnAb1Sc49cVE383ygnBKuZb9d5IEgCQiVHdgN9I2o6I35VP2H5u+0lEfD3kdfO2IhXzrDRk3lREPJX0tM4bpqIObmUPAFNi+1XF04epaO6GUWG11htUkhQRD23/N9v/KSL+TnmuxD718vP0y7vxC7Qd0z4OACyLiLg3eq/CqDGrH23/84oDfCHp39r+95Jm/YFdjku9X7FttW8fAEAHjAqrHUm/s/03/Rsi4qGk/9jKWQ2RKvgGrTRxNz22WiRh+4HtqmpEAEBNtg/Tz4NR+w7tBkzzmP7C9m8GbN9ORRizdqrqwo4NFYUSra5CEREvJL2w/WjkzgCAShFRuw6g1qTgiPjR9gcDtr2se7ApeiZpJS3NJOm6DH1NxaoUAIAOGWdS8BvbuxHxt62djW7MfSq79DZSxchVOQcqIo5tn0s6sr2noltwPz0+afP80jk+kDSy2QoAGKxnOOVF6rEaaJywqqz6s/1PJCki/mGM96o+QDHh96zv6YP0eKqe1SYiYt32gaSvVZSqH0t61HYXYDo23YAA0NA43YDTWG7pE0n/U9I/6t+QxrM+rNsaS0FTuxQ+TeJlIi8AdFzbC9mu6V3LCACAiSzqQrZzxZgVADTX1pgVEsasAKC5qZeuAwAwT+O2rLZtS9KriPhjC+cDAMAt44bVptLKESm0zpXW4bP9zyLi/0z17AAA0BhhFRF/lpZduqcitNZ08666F7avJL1SUcr+o6oXm114FFgAQHOtFVhExI8qQuj7dKA/VxFea5I+VRFem+mns7fPoMACAJqb2aTgiPiTpJfp568lyfaHKsLrExWhVbkILgAAdU29dD0ifpb0s6TfSfpq2u8PAFg+lK4DALLHpOAJUGABAM2xgkXLKLAAgOZYwQIA0CmEFQAge4QVACB7hBUAIHtTDavyFvcAAEzT1KoB09JLb22fRcS/mNb75ojSdQBobp6l65Z0OeX3zA6l6wDQ3MzWBuw76J/EGBgAoAWECwAge4QVACB7hBUAIHuEFQAge4QVACB7rLo+AeZZAUBz3CKkZcyzAoDmWplnZfv/SjpLPyeSziPil7HPDgCAMY3TsvqjpHvpZ0eSbF9J+oOkU0nnkl5FxD9M+yQBAMutdlhFxLok2f6NisD6VNJv0uOnkiJtv1DR8jqMiD9O+4QBAMtn7DGriPhR0o+SvpeuF7C9J2lT0rqk+5LuStq1fRAR/3l6pwsAWEaNCyzSmoAv048kyfaapK9VBNZZRPxd0+MAAJZXK/OsIuI8IrYl/V7SF20cAwCwPNqeFPxc0lrLxwAAdNwsVrC4msExAAAd1nZYbUt61fIxAAAd11pY2f5Q0h1JB20dAwCwHFpbbikiflZR0t45rA0IAM2xNmDLWBsQAJobZ21AbhECAMgeYQUAyB5hBQDIHmEFAMgeYQUAyB5hBQDIHmEFAMgeYQUAyB5hBQDIXufDyvaa7X3bjyu2rdo+sX1p+43t2rOpAQCz0+mwsr0vaV/S1oBdTiQdRMR7kjZV3Nl40L4AgDnpdFhFxF5EbEq66N9me1XSakQcp30vJD1TEVoAgIxkHVapi251wLYV2wepC+/S9tGgfaukcDovu/5sr0j6XNLRVE4eADA12a26nrrhPpG0I2llyK5nKu6X9UTF3Yj3JJ3ZXk9BNFJErKdALO+5tR4R55OfPQCgDVm1rFLL6EjShiq67nr225G0Kul+RDyNiENJ6yrCbX+M4x1JOo8Ip9d/b3utwf8CAKAFWYVVRFxEhCNiXcX40SDbKkLmuhUUEVeSDjW4mOIG2xuSNiJiL73+PB2zdtgBAGYjq7Aaw4akVxXPn0nXLTQAQEcsXFilQgipGKfq9zY9jgyriDiV9LavwGJX0sHQFwIAZi67Aosa7qTHXyu23QiwNM9qS0V43bO9K2k3BZVUlKkfpP3eStovS9n7pVBj0jAATIntqh6yw1SHcMMihlUdK1Ixz0pFlWClVDVYa15V+uXd+AXajgbnCABLLSLu1d134boBa6rqIgQALKhFbFmV41LvV2xb7dunFbYfSHrQ5jEAoOtsl71VLyLixbB9Fy6sIuLK9pWqiyjupsdak4IbnMMLSS9sP2rzOADQZRFRuw5gUbsBT1WUr/fbkHSR5lwBADpiUcPqmaSV3hXS08oTa5Iqq/kAAIsru27AnuWOyi69jVTeeFWu+RcRx7bPJR3Z3lNRULGfHp/M4BwZswKAhhZ2zCpNzD3re7qcpHuqnjLztAjtgaSvVZSqH0t6NIsuQMasAKC5ccassgqrFDQeY/9dFatOAAA6LKuwWhR0AwJAcwvbDbgo6AYEgOaWoXQdALBECCsAQPYIKwBA9hizmgAFFgDQHAUWLaPAAgCao8ACANAphBUAIHuEFQAge4xZTYACCwBojgKLllFgAQDNUWABAOgUwgoAkD3CCgCQPcIKAJA9wgoAkD2qASdA6ToANEfpessoXQeA5ihdBwB0CmEFAMgeYQUAyB5hBQDIHmEFAMgeYQUAyB6l6xNgnhUANMc8q5YxzwoAmmOeFQCgUwgrAED2CCsAQPYIKwBA9ggrAED2CCsAQPYIKwBA9ggrAED2CCsAQPYIKwBA9lhuaQKsDQgAzbE2YMtYGxAAmmNtQABApxBWAIDsEVYAgOwRVgCA7BFWAIDsEVYAgOwRVgCA7BFWAIDsEVYAgOx1Pqxsr9net/247/kt21Hx82Ze5woAqNbp5ZZs70tak7Qq6aB3W0QcS3Lf/geSCCsAyEynwyoi9iTJ9smofW1vSFqNiN3WTwwAMJasuwFtn9heHbBtxfaB7cv0czRo35qOJBFUAJCh7FpWtrckfSJpR9LKkF3PJN2R9ETSlaQ9SWe21yPiYsxjPpZ0Ou7rAACzkVVYpZbRkaRzSRcqxpuq9ttRMQ61HhHn6bnnki4l7UvaHvPQuyrCDgCQoay6ASPiIiIcEeuSng3ZdVvSeRlU6bVXkg4lbY1zTNtrKsaqjic5ZwBA+7IKqzFsSHpV8fyZdN1Cq+ueipYcACBTCxdWtstxrKuKzW/T4zhhdVdFlyMAIFNZjVnVdCc9/lqx7UaApXlWWyrC657tXUm7EXHas9uq3oXcQGmcrPYtmLvs25PX1//+cvPjOZ4JgEVmu6qH7DAiDvufXMSwqmNFup5nNbRwIiJqFWOkX96NX6DtmPQEF9l3L3+6/jdhBWBSEXGv7r4L1w1YU1UXIQBgQS1iy6rssnu/Yttq3z6tsP1A0oM2jwEAXWe77K16EREvhu27cGEVEVe2r1RdRHE3PbZaMJF+qS9sP2rzOADQZRFRuw5gUbsBT1WUr/fbkHSR5lwBADpiUcPqmaSVtDSTpOvJvWuSmNwLAB2TXTdgCh3pXZfeRipvvCrX7ouIY9vnko5s76koqNhPj09mcI6MWQFAQws7ZpUm/J71PV3eh+pU0mb5ZESsp/tPfa2iVP1Y0qNZdAEyZgUAzY0zZpVVWKWg8cgd3+2/K27rAQCdt6hjVgCAJZJVy2pRMGYFAM0t7JjVomDMCgCaW4Z5VgCAJULLCrV8e/L6xgK2pQ+++kG/vf8RC9oCaBVhNQHGrACgOcasWsaYFQA0t7DzrJCvLzc/vu7q++CrH66f/+Wbz+Z1SgCWCAUWAIDsEVYAgOzRDTgBCiwAoDkKLFpGgQUANMekYABApxBWAIDsEVYAgOwRVgCA7BFWAIDsUQ04AUrXAaA5StdbRuk6ADQ3Tum6I6LNc+k02/zyAGBCEeG6+zJmBQDIHi0rTIXtVxFxb97ngXe4JnniukyGlhUAIHuEFQAge4QVACB7hBUAIHuEFablcPQumDGuSZ64LhOgGhAAkD1aVgCA7BFWmDrba7b3bT8esv3E9pv0szrrc1w2w66J7dV0PS7T9ai9BA4ml67Jme1IjxsV+xyk61K5fZmwNiCmyva+pDVJq5IOKravSTqStB0R5zM+vaU06ppIOpG0FxGb6YvDke23EXE8y/NcQtd/B7a3JJ3YXi//LmwfSFJEvJeuy1nafjHHc54bxqzQCtsnkk4i4mnf82eSnvBBOHtV1yR9CL7pXaMttb7uRsTuHE5zKaQvbbu9v2PbR5Lels/Zjr7rciDpKiL2Zn7CGaAbEDek7qDKbjnbKz3dEpe2j8bpwrO9ouIbfnmcy/StH0O0eU3St/TzsusvXaPPVXzrxxBNrktEnFd8GXgr6U56/Yak/hbUG6W/n2VENyCUuiA+kbQjaWXIrmcq/pieSLqStKfxuibK9dA2e7qczmz/gZbWTTO8JoqI9fTBW3YRrtNFW63l67KR9lN676u+7RfpPZcSLaslV45RqPhDGfjhlr55r0q6HxFPI+JQ0rqKP6pxW0d70vW3+kMV3+SRzPqapO6n89TltC7p+9RNhR5tXpd0DY77vrQNC8OlQ1gtuYi4iAhHxLqkZ0N23VbxgXb9jTsirlSEzVbNw12o6HPv/cb4RsUfNpJZXpPU3bRRjoOk93qm8b+AdF5b1yW1aC/6xqKudLsVdUdFV+FSIqxQ14akVxXPn0nX3zqHSi2plTQuUrqrId9SMVTja4JW1L4uqUV1VlE08Uq3/1bWJS1t9yxhhZF6/mD6+9Cld9/06n4wPpX0fXrfVRV9/08aneASmtY1iYhTSW/7Cix2VV3ijhHGuS4pqJ6lbsIbUkvsWKmFm7plH2qJrwthhTrK7ohfK7bd+KNME0/fqPh2+XWaZHo9mTF9g3xr+1LF/B7mW01matdE0qak7XRNziTtU/AysVrXJf3+t1TMaYuen5Nyn4jYTvteqviCt72sc6wkqgExPSvSdRgNnQeSSnaZw9O+WtckfQBuzuqkoJX0ZcCjduRv5R1aVpiWqm4PzBfXJE9clwkQVqij7Gt/v2Lbat8+mA2uSZ64Li0hrDBSGuy9UvWA/d30uLR96fPANckT16U9hBXqOlUxQN9vQ8UcEbo2Zo9rkieuSwsIK9T1TMW8j+tJjamcdk1FiS1mj2uSJ65LC1h1HeUfklRUHe2kx1cqVpu46NnvTMUf3J6Kro5ylYMP+bY4XVyTPHFd5oewWnJpEuPlgM2nEbHZt/+BismJKyq+JT7ij2+6uCZ54rrMF2EFAMgeY1YAgOwRVgCA7BFWAIDsEVYAgOwRVgCA7BFWAIDsEVYAgOwRVkAH9d7ED+gCwgqYsb47ww76GXlL+iHvv6qG90xKdxeO3vXthux7kPZdGbUvMClWsABmKK0td6ZiZe6jQftFxGGDYzxWsbr3xIumpsB7o4plhCr2vZT0atR+QBPc1h6YrXvp8ahJII3weUSsN3mDiLiwfS5pw/bKoDXtUstrRdJBk+MBo9ANCMxW2fp41cabp5bbtN67DKCdIfvsSlKTVhxQB2EFzNaaJEXEeUvv/7mGdC+O6Xl63K3amMaoNiS11UIErhFWwIykD/dVSW0FlSRtRMTpOC+wvWL7yPal7Te296XrW7SfSlodUPDxMD3SBYjWMWYFzE45XvXWdtVtz6WiUGGiSr70nuMG1aqKgo+3Km4UeFfS4zROtasiiDZUtK72+l6+q6KQo83wBSRRDQjMTKrS2x+x23sNwupA0sE44ZHmY230Htf2joqQei8irlK1nyLivZ7XldWCTyOiP8SAqaMbEJidsrjibkR4wE+T+VH3xgyqcszpWNId22V3X3l79rL191zSSl9rsBzHogsQM0FYAbNzT9JVRFyM3HNMqYT82QTnI0lbKlpJ5U+5+kU5TlUG0nbPa7cknbfx/wJUIayAGUgtlhW1VLKuogpw0vLxzQGtvKfSdeXihVJBRSqPXxWtKswQYQXMxlp6bGvNvtUJWjllcK4N3atwoHddgZ9LzVbZAMZFWAGz8Ul6nHrlXOoCHLuV01Oa/nX/un7JMa4CAAAA1UlEQVSpnL33uTKYtlV0ATIJGDNFNSAwA7bPVLRgnkr6dcBu5+POkUrvfSJpe5LijJ7SdUl6omIB3HUVq1Zs965M0VM5KBVdh2OfKzApwgqYAdt1/tB2x+1aS62foyaLyKb32FcRROWk5YP+c0ktuCMVRSLv3XojoEWEFbDA0pyot6zNh64jrIAFZvus6QrrwCKgwAJYUH0TeIFOI6yAxTVRFSCwiAgrYHF9QkUelgVjVgCA7NGyAgBkj7ACAGSPsAIAZI+wAgBkj7ACAGSPsAIAZO//Awt7ulBZuje5AAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY8AAAGACAYAAABVzO4yAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAUBklEQVR4nO3df6xkZ3kf8O+DLZNA2yU4IVD/CLbWMmxqYsMWaCPaBNJ4XbIiSS1hQ1BCtl1MSpuqrVRboEJboahqSaUQGnsTDE5UDJaFwKYGN2pQ12qcxgshxGAcbQiIJaR2MGwhaQomb/+4s2S4vnd3Xu+cPTPnfj7SyOe8c+bc5/Hc3e+eOee8U621AECPJ4xdAADrR3gA0E14ANBNeADQTXgA0E14ANBNeADQTXgA0G3lw6OqLq6qt1fV7XNjF1bV+6rq5qq6fsz6AHaiUcJj9pf+Q1V1/6bxfVX1YFUdPREKrbVPt9YObNrFZUlub639dJIrzlDZAMyMdeTxziT75geq6qwkb0tyVZI9Sa6tqj3bvP63khyoqt9I8qEB6wRgC6OER2vtcJJHNg0/P8nR2ZHG15K8O8nLttnFq5O8sbX24iQvHa5SALZy9tgFzDkvyefm1o8leUFVnZvkzUmuqKobWms/l42jjTdV1SuSfGarnVXVwSQHk+TJT37y8571rGcNWTvA5HzkIx/5k9bad2313CqFx5Zaa19Mct2msfuTXH2K1x1KcihJ9u7d244cOTJYjQBTVFWf3e65Vbra6vNJLphbP382BsCKWaXwuC/JJVV1UVWdk+SaJHeMXBMAWxjrUt1bk9yb5NKqOlZVB1prjyZ5XZK7kzyQ5LbW2ifGqA+AkxvlnEdr7dptxu9Kcteyfk5V7U+yf/fu3cvaJQBZrY+tlq61dmdr7eCuXbvGLgVgUiYdHgAMQ3gA0E14ANBt0uFRVfur6tDx48fHLgVgUiYdHk6YAwxj0uEBwDCEBwDdhAcA3YQHAN2EBwDdJh0eLtUFGMakw8OlugDDmHR4ADAM4QFAN+EBQDfhAUA34QFAt0mHh0t1AYYx6fBwqS7AMCYdHgAMQ3gA0E14ANBNeADQTXgA0E14ANBNeADQbdLh4SZBgGFMOjzcJAgwjEmHBwDDEB4AdBMeAHQTHgB0Ex4AdBMeAHQTHgB0Ex4AdJt0eLjDHGAYkw4Pd5gDDGPS4QHAMIQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdJh0eZtUFGMakw8OsugDDmHR4ADAM4QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAt0mHh6+hBRjGpMPD19ACDGPS4QHAMIQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdzh67gFOpqouTvD7Jrtba1bOxFyV5ZTbq39Na+9sjlgiw44xy5FFVN1fVQ1V1/6bxfVX1YFUdrarrk6S19unW2oH57Vpr97TWrkvygSS3nLnKp+3lN92bl99079hlAGtgrI+t3plk3/xAVZ2V5G1JrkqyJ8m1VbXnFPt5RZJ3DVEgANsbJTxaa4eTPLJp+PlJjs6ONL6W5N1JXrbdPqrqwiTHW2tfGa5SALaySifMz0vyubn1Y0nOq6pzq+rGJFdU1Q1zzx9I8o7tdlZVB6vqSFUdefjhh4epGGCHWvkT5q21Lya5bovxN57idYeSHEqSvXv3tmGqA9iZVunI4/NJLphbP382BsCKWaXwuC/JJVV1UVWdk+SaJHeMXBMAWxjrUt1bk9yb5NKqOlZVB1prjyZ5XZK7kzyQ5LbW2ifGqA+AkxvlnEdr7dptxu9Kcteyfk5V7U+yf/fu3cvaJQBZrY+tlq61dmdr7eCuXbvGLgVgUiYdHgAMQ3gA0E14ANBt0uFRVfur6tDx48fHLgVgUiYdHk6YAwxj0uEBwDCEBwDdhAcA3YQHAN0mHR6utgIYxqTDw9VWAMOYdHgAMAzhAUA34QFAN+EBQDfhAUA34QFAt0mHh/s8AIYx6fBwnwfAMCYdHgAMQ3gA0O3sRTaqqqcusNlftNa+fHrlALAOFgqPJH80e9RJtjkryYWnXRFn1Mtvuveby5/8wv/5lrH3vOZvjVITsPoWDY8HWmtXnGyDqvqdJdQDwBpYNDwW+Seof6auofmjC0ccwKIWOmHeWvvz7Z6rqqefapuxuM8DYBjLuNrq7UvYxyDc5wEwjNMOj9baS5dRCADrw30eAHRb9IR5kqSq/vVW4621f7uccgBYB13hkeRP55a/LcmPJHlgeeUAsA66wqO19pb59ar6j0nuXmpFAKy80z3n8aQk5y+jEADWR+85j99L0marZyX5riTOdwDsML3nPH5kbvnRJP+7tfboEusBYA30nvP47Oaxqnp6a+2Pl1cSAKtu0neYm54EYBiTvsPc9CQAw+g955Gq+o4kl2TjPo8kSWvt8DKLAmC19V5t9Q+T/Gw2Ls/9WJIXJrk3yYuXXhkAK6v3Y6ufTfI3k3y2tfaDSa5I8uVlFwXAausNjz8/8b0dVfXE1tqnkly6/LIAWGW95zyOVdVTkrwvya9X1ZeSPObyXQCmrfc+jx+bLb6pqj6cZFeSDy29KgBWWvfVVie01v7HMgsBYH0sdM6jqj66jG0AmIZFjzyeXVUfP8nzlY2PsADYARYNj2ctsM03TqcQANbHQuGx1YSIAOxcy5gYcWWZGBFgGJMODxMjAgxj0uEBwDBOGR5V9feq6per6vLZ+sHBqwJgpS1ywvynk7w2yRuq6qlJLh+0IgBW3iIfW32ltfbl1tq/TPLD2ZhVF4AdbJHw+K8nFlpr1yf51eHKAWAdnDI8Wmvvr6rvnVt/67AlAbDqFr3a6tdOLMy+TTBz609aakUArLxFw6Pmln9m03P3LKkWANbEouHR5pZr03PuFQHYYRadGPHpVfVTSX43jw2P9tjNAZiyRcPjTUmel+TVSc6vqk8meSDJp5J85zClAbCqFp1V99D8elWdn+SyJM9JcniAugBYYY/ra2hba8eSHEvyweWWA8A6cLIbgG6PKzyq6sKq2nziHIAdojs8qurbk/yvJE9bfjkArIPucx6ttf+b5BkD1ALAmnDOA4Bukw4P32EOMIyFwqOqfr6qfqqqnltVTxy6qGXxHeYAw1j0nMfRJC9M8o+SPLuq/jjJx2eP+5Icbq39v2FKBGDVLHqH+X+eX6+qi/KXd5i/NslNVfXa1trdyy8RgFXzeO8w/8Mkf5jkjiSpqmck+UAS4QGwAyzlhHlr7QtJ3rWMfQGw+pZ2tVVr7S3L2hcAq23Sl+oCMAzhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAt7PHLuBUquriJK9Psqu1dvVs7AlJ/l2Sv5bkSGvtlhFLBNhxRjnyqKqbq+qhqrp/0/i+qnqwqo5W1fVJ0lr7dGvtwKZdvCzJ+Um+nuTYmakagBPG+tjqnUn2zQ9U1VlJ3pbkqiR7klxbVXu2ef2lSX6ztfbPk7x2wDoB2MIo4dFaO5zkkU3Dz09ydHak8bUk787GEcZWjiX50mz5G8NUCcB2VumE+XlJPje3fizJeVV1blXdmOSKqrph9tx7k1xZVW9NcnirnVXVwao6UlVHHn744UELB9hpVv6EeWvti0mu2zT2Z0k2nwfZ/LpDSQ4lyd69e9tgBQLsQKt05PH5JBfMrZ8/GwNgxaxSeNyX5JKquqiqzklyTZI7Rq4JgC2MdanurUnuTXJpVR2rqgOttUeTvC7J3UkeSHJba+0TY9QHwMmNcs6jtXbtNuN3JblrWT+nqvYn2b979+5l7RKArNbHVkvXWruztXZw165dY5cCMCmTDg8AhiE8AOgmPADoJjwA6Dbp8Kiq/VV16Pjx42OXAjApkw4PV1sBDGPS4QHAMIQHAN2EBwDdhAcA3SYdHq62AhjGpMPD1VYAw5h0eAAwDOEBQDfhAUA34QFAN+EBQLdJh4dLdQGGMenwcKkuwDAmHR4ADEN4ANBNeADQTXgA0E14ANBNeADQTXgA0G3S4eEmQYBhTDo83CQIMIxJhwcAwxAeAHQTHgB0Ex4AdBMeAHQTHgB0Ex4AdBMeAHQTHgB0m3R4mJ4EYBiTDg/TkwAMY9LhAcAwhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3SYdHiZGBBjGpMPDxIgAw5h0eAAwDOEBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQDfhAUA34QFAN+EBQLdJh4evoQUYxqTDw9fQAgxj0uEBwDCEBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3YQHAN2EBwDdhAcA3VY+PKrq4qp6e1XdPjf2A1V1T1XdWFU/MF51ADvTKOFRVTdX1UNVdf+m8X1V9WBVHa2q65Oktfbp1tqBTbtoSb6a5NuSHDszVQNwwlhHHu9Msm9+oKrOSvK2JFcl2ZPk2qras83r72mtXZXkXyX5NwPWCcAWRgmP1trhJI9sGn5+kqOzI42vJXl3kpdt8/q/mC1+KckTBysUgC2dPXYBc85L8rm59WNJXlBV5yZ5c5IrquqG1trPVdWPJ7kyyVOS/OJWO6uqg0kOzla/WlUPzj29K8nxbdZPLM+PfWeSP3mcfW3+WT3bbDW+SO3bLS/Ux23XddW46Daj9PI46jzVNr19bF5f59+v+fVlvycnq3ORbaby+7Xdc2P18j3bPtNaG+WR5JlJ7p9bvzrJr8ytvyrJLw70sw9tt35iedPYkWX9rJ5tthpfpPaT9DRKH1PqpbePKf1+naT+035PznQvq/r7tWq9nOyxSldbfT7JBXPr58/GhnDnSdbv3GabZf2snm22Gl+k9pMtP16n08d2z61jL719bF5f59+v+fVlvyeL7seflceuD9nLtmqWTGdcVT0zyQdaa39jtn52kt9P8pJshMZ9SV7RWvvEKAXOqaojrbW9Y9dxuqbSR6KXVTSVPhK9LGKsS3VvTXJvkkur6lhVHWitPZrkdUnuTvJAkttWIThmDo1dwJJMpY9EL6toKn0kejml0Y48AFhfq3TOA4A1ITwA6CY8AOgmPBY0pQkat+nlCVX15qp6a1X95Jj1LWqbPl40ez9+pap+c8z6emzTy4VV9b7ZXHDXj1lfj2162VNVt1XVL1XV1WPWt6iq+tGq+uWqek9V/fBs7MlVdcts/JVj17iobXp5zPvUZYibR9blkeTmJA9l7mbF2fi+JA8mOZrk+k3P3T63/HeTfDAbc3XtXvNefizJLUl+PslL1rWPubEfTfKaNX9PXprkJ2bL71nzXv5FkhfNlu9Ysz6+I8nbZ8uvSrJ/jd+Tb/ay1fvU9fPHbH7sR5K/k+S5+dY73c9K8gdJLk5yTpLfTbJnq//RSZ4w++93J/kva97L9Sf+sn28v0yr0Mfc2G1J/uqavyfnJvlwkt9I8uo17+Vp2Zj49D8k+Z9r1sdbkjx3tnxDkstny+9aw/fkm71s9T71PHb0x1ZtQhM0nm4v2ZhL7Euz5W8MU+WpLaGPVNWFSY631r4yXKWntoReXp3kja21F2fjKGQ0S/iz8lBr7R9n4x8ppzP/1Wnp6aM2/PskH2ytfXS27bFszH6RjPyx/xJ6OS07Ojy2sdUEjedV1blVdWNmEzQmSVX9eFXdlOTXss0EjSNbuJck701yZVW9NcnhM1znqfT0kSQHkrzjTBbYoaeXDyX5p7Pxz5zZMhfS82flmVV1KMmvZuPoY5Vs2UeSf5Lkh5JcXVUnpgt9b5J/UFW/lIGn/3icFu7lJH9+FrJKs+qutNbaF5Nct2nsvdn4ZVor2/TyZ9n4S3dtbNXHbPyNI5RzWrZ5T+7PxoSha2WbXj6Tv5zlei201n4hyS9sGvvTbBwRrpVtetnyz8+iHHk81pmcoHFoU+llKn0kellFU+kjOYO9CI/Hui/JJVV1UVWdk+SaJHeMXNPjNZVeptJHopdVNJU+kjPZy5hXC4z9SHJrki8k+Xo2Phs8MBv/+9mY4fcPkrx+7Dp3Ui9T6UMvq/mYSh+r0IuJEQHo5mMrALoJDwC6CQ8AugkPALoJDwC6CQ8AugkPALoJDwC6CQ9Ykqp6TVV9oao+Nve4bIvtbqyq719wnx+uqis3jf2z2ayuMBrhActzWZI3tNYun3v83hbbvTDJby24z1uzMT/RvGtm4zAa4QHL85wkHzvZBlX17CS/31p7zBduVdVPVNVvz45Ybqqqs5LcnuSls0nuUlXPTPLXk9yz7OKhh/CA5fneJO+Y+8hqq++vuCobX/L0LWah8vIk399auzwb3+b4ytbaI0l+e/a6ZOOo47ZmUjpG5sugYAmq6oIkD7fWnnOKTa/M1l8m9JIkz0tyX1UlybcneWj23ImPrt4/++9afWkX0yQ8YDkuS/LAyTaoqicleUpr7Y+2ejrJLa21rb4O9P1J/lNVPTfJk1prHzntauE0+dgKluM5ST51im1+MMmHt3nuv2fj+6WfliRV9dSq+p4kaa19dfa6m+NEOStCeMByXJbkVXPnO36nqv7Kpm22PN+RJK21TyZ5Q5L/VlUfT/LrSZ4xt8mtSb4vwoMV4cug4Aypqo8meUFr7etj1wKnS3gA0M3HVgB0Ex4AdBMeAHQTHgB0Ex4AdBMeAHQTHgB0Ex4AdPv/ONozkbsGjA0AAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 432x432 with 1 Axes>"
       ]
@@ -140,62 +287,59 @@
     "import pylab as plt\n",
     "from scipy import optimize\n",
     "\n",
-    "%matplotlib inline\n",
+    "with h5py.File('shock_downstream_splitting.h5', 'r') as data:\n",
+    "    E = data['CRPROPA3']['E'] * 1E18\n",
+    "    w = data['CRPROPA3']['weight']\n",
+    "    bin_edges = 10**np.linspace(15, 21)\n",
+    "    bin_width = bin_edges[1:] - bin_edges[:-1]\n",
+    "    bin_center = bin_edges[:-1] + 0.5 * bin_width\n",
     "\n",
-    "data = h5py.File('shock_downstream.h5','r')\n",
+    "    H = np.histogram(E, bins=bin_edges, weights=w)\n",
+    "    H_count = np.histogram(E, bins=bin_edges)\n",
     "\n",
-    "E = data['CRPROPA3']['E'] * 1E18\n",
-    "bin_edges = 10**np.linspace(15, 21)\n",
-    "bin_width = bin_edges[1:] - bin_edges[:-1]\n",
-    "bin_center = bin_edges[:-1] + 0.5 * bin_width\n",
+    "    J = H[0] / bin_width\n",
     "\n",
-    "H = np.histogram(data['CRPROPA3']['E'] * 1E18, bins=bin_edges)\n",
+    "    dJ = J / np.sqrt(H_count[0])\n",
     "\n",
-    "J = H[0] / bin_width\n",
-    "\n",
-    "dJ = np.sqrt(H[0]) / bin_width\n",
-    "\n",
-    "fig = plt.figure(figsize=(6, 6))\n",
-    "sp = fig.add_subplot(111)\n",
-    "sp.loglog()\n",
-    "sp.errorbar(bin_center, J * bin_center**2, xerr=bin_width/2, yerr=dJ * bin_center**2, ls='None')\n",
-    "sp.set_xlabel('$E$ / eV')\n",
-    "sp.set_ylabel('$J\\cdot E^2$ [a.u.]')\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "yielding the expected $J\\propto E^{-2}$ relationship."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Due to the power law nature of the acceleration the simulations may become quite time consuming if large energy gains are of interest. Particle splitting, i.e. inverse thinning, can be used here to reduce the simulation effort. In the example above, adding the following code enables particle splitting at the shock front."
+    "    fig = plt.figure(figsize=(6, 6))\n",
+    "    sp = fig.add_subplot(111)\n",
+    "    sp.loglog()\n",
+    "    sp.errorbar(bin_center, J * bin_center**2, xerr=bin_width/2, yerr=dJ * bin_center**2, ls='None')\n",
+    "    sp.set_xlabel('$E$ / eV')\n",
+    "    sp.set_ylim(1e15, 1e18)\n",
+    "    sp.set_ylabel('$J\\cdot E^2$ [a.u.]')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['EnergyScale', 'LengthScale', 'OutputType', 'SEED_000', 'SEED_001', 'SEED_002', 'SEED_003', 'SEED_004', 'SEED_005', 'SEED_006', 'SEED_007', 'Version']\n"
+     ]
+    }
+   ],
    "source": [
-    "shock_surface = crpropa.Plane(crpropa.Vector3d(0., 0, 0), crpropa.Vector3d(1., 0, 0))\n",
-    "split = crpropa.ParticleSplitting(shock_surface)\n",
-    "simulation.add(split)\n",
-    "output2.enable(output2.WeightColumn)\n",
-    "output1.enable(output2.WeightColumn)"
+    "with h5py.File('shock_downstream_splitting.h5', 'r') as data:\n",
+    "    print([a for a in (data['CRPROPA3']).attrs])"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the different normalizations of the flux due the difference in the number of injected particles."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "crp_docu",
    "language": "python",
    "name": "python3"
   },
@@ -209,7 +353,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.9.2"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "c416687c884a42c367c2f4b19e8bea2627679ca3202fbf20d972b7cd00ee0b77"
+   }
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/include/crpropa/module/Acceleration.h
+++ b/include/crpropa/module/Acceleration.h
@@ -152,9 +152,9 @@ class ParticleSplitting : public Module {
 
 	public:
 	/// @params surface               The surface to monitor
-	/// @params crossing_threshold    Number of crossings after which a particle is split
-	/// @params num_splits            Number of particles the candidate is split into
-	/// @params min_weight            Minimum weight to consider. Particles with
+	/// @params crossingThreshold    Number of crossings after which a particle is split
+	/// @params numSplits            Number of particles the candidate is split into
+	/// @params minWeight            Minimum weight to consider. Particles with
 	///                               a lower weight are not split again.
 	/// @params counterid             An unique string to identify the particle
 	///                               property used for counting. Useful if

--- a/include/crpropa/module/HDF5Output.h
+++ b/include/crpropa/module/HDF5Output.h
@@ -82,7 +82,7 @@ class HDF5Output: public Output {
 		double P1x;
 		double P1y;
 		double P1z;
-		double weight;
+		double W;
 		std::string tag;
 		unsigned char propertyBuffer[propertyBufferSize];
 	} OutputRow;

--- a/src/module/Acceleration.cpp
+++ b/src/module/Acceleration.cpp
@@ -141,8 +141,8 @@ double QuasiLinearTheory::modify(double steplength, Candidate* candidate)
 }
 
 
-ParticleSplitting::ParticleSplitting(Surface *surface, int numSplits,
-		int	crossingThreshold, double minWeight, std::string counterid)
+ParticleSplitting::ParticleSplitting(Surface *surface, int	crossingThreshold, 
+	int numSplits, double minWeight, std::string counterid)
 	: surface(surface), crossingThreshold(crossingThreshold),
 	  numSplits(numSplits), minWeight(minWeight), counterid(counterid){};
 

--- a/src/module/HDF5Output.cpp
+++ b/src/module/HDF5Output.cpp
@@ -163,7 +163,7 @@ void HDF5Output::open(const std::string& filename) {
 		H5Tinsert(sid, "P1z", HOFFSET(OutputRow, P1z), H5T_NATIVE_DOUBLE);
 	}
 	if (fields.test(WeightColumn))
-		H5Tinsert(sid, "weight", HOFFSET(OutputRow, weight), H5T_NATIVE_DOUBLE);
+		H5Tinsert(sid, "W", HOFFSET(OutputRow, W), H5T_NATIVE_DOUBLE);
 	
 	if (fields.test(CandidateTagColumn)) 
 		H5Tinsert(sid, "tag", HOFFSET(OutputRow, tag), H5T_C_S1);
@@ -296,7 +296,7 @@ void HDF5Output::process(Candidate* candidate) const {
 	r.P1y = v.y;
 	r.P1z = v.z;
 
-	r.weight= candidate->getWeight();
+	r.W= candidate->getWeight();
 
 	r.tag = candidate->getTagOrigin();
 


### PR DESCRIPTION
The signature of ParticleSplitting's constructor definition differe in the .h and the .cpp files. This is problematic when the constructor is used with positional arguments.

This PR fixes it.

Furthermore: 
 * The Example notebook was updated to include a full example including the particle splitting.
 * The weighting column in the HDFOutput was set from "weight" to "W". This synchronizes the column naming with the TextOutput.