### PR TITLE
Improved performance of PropagationBP

### DIFF
--- a/include/crpropa/module/PropagationBP.h
+++ b/include/crpropa/module/PropagationBP.h
@@ -110,10 +110,10 @@ public:
 	 * @param h		 current step size
 	 * @param p		 current particle state
 	 * @param z		 current red shift
-	 * @param m		 current mass of the candidate
 	 * @param q		 current charge of the candidate 
+	 * @param m		 current mass of the candidate
 	 */
-	void tryStep(const Y &y, Y &out, Y &error, double h, ParticleState &p, double z, double m, double q) const;
+	void tryStep(const Y &y, Y &out, Y &error, double h, ParticleState &p, double z, double q, double m) const;
 
 	/** Set functions for the parameters of the class PropagationBP */
 

--- a/src/module/PropagationBP.cpp
+++ b/src/module/PropagationBP.cpp
@@ -6,7 +6,7 @@
 
 namespace crpropa {
 	void PropagationBP::tryStep(const Y &y, Y &out, Y &error, double h,
-			ParticleState &particle, double z, double m, double q) const {
+			ParticleState &particle, double z, double q, double m) const {
 		out = dY(y.x, y.u, h, z, q, m);  // 1 step with h
 
 		Y outHelp = dY(y.x, y.u, h/2, z, q, m);  // 2 steps with h/2
@@ -95,7 +95,7 @@ namespace crpropa {
 
 			// try performing step until the target error (tolerance) or the minimum/maximum step size has been reached
 			while (true) {
-				tryStep(yIn, yOut, yErr, step, current, z, m, q);
+				tryStep(yIn, yOut, yErr, step, current, z, q, m);
 				r = yErr.u.getR() / tolerance;  // ratio of absolute direction error and tolerance
 				if (r > 1) {  // large direction error relative to tolerance, try to decrease step size
 					if (step == minStep)  // already minimum step size

--- a/src/module/PropagationBP.cpp
+++ b/src/module/PropagationBP.cpp
@@ -87,7 +87,7 @@ namespace crpropa {
 		// if minStep is the same as maxStep the adaptive algorithm with its error
 		// estimation is not needed and the computation time can be saved:
 		if (minStep == maxStep){
-			tryStep(yIn, yOut, yErr, step, current, z, m, q);
+			yOut = dY(yIn.x, yIn.u, step, z, q, m);
 		} else {
 			step = clip(candidate->getNextStep(), minStep, maxStep);
 			newStep = step;

--- a/test/testPropagation.cpp
+++ b/test/testPropagation.cpp
@@ -3,14 +3,7 @@
 #include "crpropa/module/SimplePropagation.h"
 #include "crpropa/module/PropagationBP.h"
 #include "crpropa/module/PropagationCK.h"
-#include "crpropa/Grid.h"
-#include "crpropa/Units.h"
-#include "crpropa/Common.h"
-#include "crpropa/GridTools.h"
-#include "crpropa/magneticField/turbulentField/TurbulentField.h"
-#include "crpropa/magneticField/turbulentField/GridTurbulence.h"
 #include "crpropa/magneticField/turbulentField/PlaneWaveTurbulence.h"
-#include "crpropa/magneticField/turbulentField/SimpleGridTurbulence.h"
 
 #include "gtest/gtest.h"
 

--- a/test/testPropagation.cpp
+++ b/test/testPropagation.cpp
@@ -485,12 +485,11 @@ TEST(testPropagationBP, gyration) {
 }
 
 
-// Test the that the optimization for same step sizes works
-TEST(testPropagationBP, sameStepOptimization) {
-
+// Test the that the optimization for fixed step sizes works
+TEST(testPropagationBP, fixedStepOptimization) {
 	// particle 1 with fixed step sizes
-	double fixeded_step = pc;
-	PropagationBP propa1(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), fixeded_step);
+	double fixed_step = pc;
+	PropagationBP propa1(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), fixed_step);
 	ParticleState p1;
 	p1.setId(nucleusId(1, 1));
 	p1.setEnergy(100 * EeV);
@@ -506,7 +505,7 @@ TEST(testPropagationBP, sameStepOptimization) {
 	// particle 2 with different min and max steps. The tolerance is chosen such that particle 2 will be
 	// propagated with the same step as particle 1, however not using the optimization for fixed step sizes
 	double tolerance = 1;
-	PropagationBP propa2(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), tolerance, fixeded_step, 1.1*fixeded_step);
+	PropagationBP propa2(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), tolerance, fixed_step, 1.1*fixed_step);
 	ParticleState p2;
 	p2.setId(nucleusId(1, 1));
 	p2.setEnergy(100 * EeV);

--- a/test/testPropagation.cpp
+++ b/test/testPropagation.cpp
@@ -495,7 +495,9 @@ TEST(testPropagationBP, gyration) {
 // Test the that the optimization for same step sizes works
 TEST(testPropagationBP, sameStepOptimization) {
 
-	PropagationBP propa1(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), pc);
+	// particle 1 with fixed step sizes
+	double fixeded_step = pc;
+	PropagationBP propa1(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), fixeded_step);
 	ParticleState p1;
 	p1.setId(nucleusId(1, 1));
 	p1.setEnergy(100 * EeV);
@@ -508,7 +510,10 @@ TEST(testPropagationBP, sameStepOptimization) {
 		propa1.process(&c1);
 	}
 
-	PropagationBP propa2(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), 1, pc, 1.1*pc);
+	// particle 2 with different min and max steps. The tolerance is chosen such that particle 2 will be
+	// propagated with the same step as particle 1, however not using the optimization for fixed step sizes
+	double tolerance = 1;
+	PropagationBP propa2(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), tolerance, fixeded_step, 1.1*fixeded_step);
 	ParticleState p2;
 	p2.setId(nucleusId(1, 1));
 	p2.setEnergy(100 * EeV);

--- a/test/testPropagation.cpp
+++ b/test/testPropagation.cpp
@@ -3,6 +3,14 @@
 #include "crpropa/module/SimplePropagation.h"
 #include "crpropa/module/PropagationBP.h"
 #include "crpropa/module/PropagationCK.h"
+#include "crpropa/Grid.h"
+#include "crpropa/Units.h"
+#include "crpropa/Common.h"
+#include "crpropa/GridTools.h"
+#include "crpropa/magneticField/turbulentField/TurbulentField.h"
+#include "crpropa/magneticField/turbulentField/GridTurbulence.h"
+#include "crpropa/magneticField/turbulentField/PlaneWaveTurbulence.h"
+#include "crpropa/magneticField/turbulentField/SimpleGridTurbulence.h"
 
 #include "gtest/gtest.h"
 
@@ -481,6 +489,44 @@ TEST(testPropagationBP, gyration) {
 	EXPECT_DOUBLE_EQ(2 / 3., dirX * dirX + dirY * dirY);  // constant momentum in the perpendicular plane to background magnetic field field
 	EXPECT_DOUBLE_EQ(1 / 3., dirZ * dirZ);  // constant momentum parallel to the background magnetic field
 	EXPECT_DOUBLE_EQ(100 * step * step / 3., posZ * posZ);  // constant velocity parallel to the background magnetic field
+}
+
+
+// Test the that the optimization for same step sizes works
+TEST(testPropagationBP, sameStepOptimization) {
+
+	PropagationBP propa1(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), pc);
+	ParticleState p1;
+	p1.setId(nucleusId(1, 1));
+	p1.setEnergy(100 * EeV);
+	p1.setPosition(Vector3d(0, 0, 0));
+	p1.setDirection(Vector3d(1, 1, 1));
+	Candidate c1(p1);
+	c1.setNextStep(0);
+	// Nine new steps to have finally propagated the particle ten times
+	for (int i = 0; i < 9; i++){
+		propa1.process(&c1);
+	}
+
+	PropagationBP propa2(new PlaneWaveTurbulence(TurbulenceSpectrum(gauss, pc, 100*pc), 10, 1), 1, pc, 1.1*pc);
+	ParticleState p2;
+	p2.setId(nucleusId(1, 1));
+	p2.setEnergy(100 * EeV);
+	p2.setPosition(Vector3d(0, 0, 0));
+	p2.setDirection(Vector3d(1, 1, 1));
+	Candidate c2(p2);
+	c1.setNextStep(0);
+	// Nine new steps to have finally propagated the particle ten times
+	for (int i = 0; i < 9; i++){
+		propa2.process(&c2);
+	}
+
+	EXPECT_DOUBLE_EQ(c1.current.getDirection().x, c2.current.getDirection().x);
+	EXPECT_DOUBLE_EQ(c1.current.getDirection().y, c2.current.getDirection().y);
+	EXPECT_DOUBLE_EQ(c1.current.getDirection().z, c2.current.getDirection().z);
+	EXPECT_DOUBLE_EQ(c1.current.getPosition().x, c2.current.getPosition().x);
+	EXPECT_DOUBLE_EQ(c1.current.getPosition().y, c2.current.getPosition().y);
+	EXPECT_DOUBLE_EQ(c1.current.getPosition().z, c2.current.getPosition().z);
 }
 
 


### PR DESCRIPTION
**Description**
This pull request improves the behavior of the PropagationBP module in CRPropa for fixed step sizes, resulting in a speed improvement of up to a factor of 3. In addition, I have implemented a test to verify the correct behavior of my changes in the module. I also manually checked the output files and compared them to the current master.

**Performance comparison**:
simulation time with grid-less turbulence:
master:  75.05±0.11 s
this PR:  25.43±0.02 s

simulation time with grid turbulence:
master:  82.04±0.23 s
this PR:  57.16±0.22 s

_Code to reproduce_:
```
import crpropa as crp

sim = crp.ModuleList()

# magnetic turbulence
turbulence_method = 'PW' # or 'grid'
b_field = crp.MagneticFieldList()
turbulence_spectrum = crp.SimpleTurbulenceSpectrum(1e-6*crp.gauss, crp.pc, 100*crp.pc)
if turbulence_method == 'grid':
    max_trajectory = 2e8*crp.pc
    grid_properties = crp.GridProperties(crp.Vector3d(0.,0.,0.), 256, crp.pc/2)
    turbulence = crp.SimpleGridTurbulence(turbulence_spectrum, grid_properties, 1)
else:  
    max_trajectory = 2e6*crp.pc
    turbulence = crp.PlaneWaveTurbulence(turbulence_spectrum, 10**3, 1)
b_field.addField(turbulence)

# propagation
prop_bp = crp.PropagationBP(b_field, crp.pc)
sim.add(prop_bp)
sim.add(crp.MaximumTrajectoryLength(max_trajectory))

# output
output = crp.TextOutput('output_'+turbulence_method+'.txt', crp.Output.Trajectory3D)

# observer
obs = crp.Observer()
n_obs = 3
dist = max_trajectory/n_obs
time_observer = crp.ObserverTimeEvolution(0, dist, n_obs)
obs.add(time_observer)
obs.setDeactivateOnDetection(False)
obs.onDetection(output)
sim.add(obs)

# source
source = crp.Source()
source.add(crp.SourcePosition(crp.Vector3d(0)))
source.add(crp.SourceParticleType(crp.nucleusId(1, 1)))
source.add(crp.SourceEnergy(1e16*crp.eV))
source.add(crp.SourceDirection(crp.Vector3d(1,0,0)))

# run simulation
sim.setShowProgress(True)
sim.run(source, 1, True)
```