### PR TITLE
Variant improvements

### DIFF
--- a/include/crpropa/Variant.h
+++ b/include/crpropa/Variant.h
@@ -4,8 +4,9 @@
 // Licensed under a LGPL-2 or later license                   -
 //-------------------------------------------------------------
 
-#ifndef VARIANT_HH
-#define VARIANT_HH
+#ifndef CRPROPA_VARIANT_H
+#define CRPROPA_VARIANT_H
+
 
 #include <iostream>
 #include <string>
@@ -228,4 +229,4 @@ std::ostream& operator <<(std::ostream& os, const Variant &v);
 
 } // namespace crpropa 
 
-#endif // VARIANT_HH
+#endif // CRPROPA_VARIANT

--- a/include/crpropa/Variant.h
+++ b/include/crpropa/Variant.h
@@ -7,16 +7,19 @@
 #ifndef CRPROPA_VARIANT_H
 #define CRPROPA_VARIANT_H
 
-
-#include <iostream>
-#include <string>
-#include <cstring>
-#include <typeinfo>
-#include <sstream>
+#include <complex>
+#include <cstdint>
 #include <cstdlib>
-#include <stdexcept>
+#include <cstring>
+#include <iostream>
 #include <limits>
-#include <stdint.h>
+#include <string>
+#include <sstream>
+#include <stdexcept>
+#include <typeinfo>
+
+#include "crpropa/Vector3.h"
+
 
 // Helper to set POD type methods to variant
 #define VARIANT_ADD_TYPE_DECL_POD(NAME, TYPE, VALUE) \

--- a/include/crpropa/Variant.h
+++ b/include/crpropa/Variant.h
@@ -1,5 +1,5 @@
 //-------------------------------------------------------------
-// Based on Variant.hh in the Physics eXtension Library (PXL) -
+// Based on Variant.hh of the Physics eXtension Library (PXL) -
 // http://vispa.physik.rwth-aachen.de/                        -
 // Licensed under a LGPL-2 or later license                   -
 //-------------------------------------------------------------
@@ -21,50 +21,122 @@
 #include "crpropa/Vector3.h"
 
 
-// Helper to set POD type methods to variant
-#define VARIANT_ADD_TYPE_DECL_POD(NAME, TYPE, VALUE) \
-	bool is ## NAME() const { return (type == TYPE); } \
-	operator VALUE () const { return to ## NAME(); } \
-	VALUE &as ## NAME() { check(TYPE); return data._##NAME; } \
-	const VALUE &as ## NAME() const	{ check(TYPE); return data._##NAME; } \
-	static Variant from ## NAME(const VALUE &a) { return Variant(a); } \
-	VALUE to ## NAME() const; \
-	Variant &operator = (const VALUE &a) { clear(); type = TYPE; data._##NAME = a; return *this; } \
-	bool operator != (const VALUE &a) const { check(TYPE); return data._##NAME != a; } \
-	bool operator == (const VALUE &a) const { check(TYPE); return data._##NAME == a; } \
-	Variant(const VALUE &a) { data._ ## NAME = a; type = TYPE; }
 
-// Helper to set pointer type methods to variant
-#define VARIANT_ADD_TYPE_DECL_PTR_BASE(NAME, TYPE, VALUE) \
-	bool is ## NAME() const { return (type == TYPE); } \
-	VALUE &as ## NAME() { check(TYPE); return *data._##NAME; } \
-	const VALUE &as ## NAME() const	{ check(TYPE); return *data._##NAME; } \
-	static Variant from ## NAME(const VALUE &a) { return Variant(a); } \
+// defines copy constructor X(const X&), isX(), asX(), fromX(), toX(), op(), op=, op==, op!=
+#define VARIANT_ADD_TYPE_DECL_POD(NAME, TYPE, VALUE, FIELD) \
+	Variant(const VALUE& v) { \
+		data._t_##FIELD = v; \
+		type = TYPE;  \
+	} \
+	bool is##NAME() const { \
+		return type == TYPE; \
+	} \
+	VALUE& as##NAME() { \
+		check(TYPE); \
+		return data._t_##FIELD; \
+	} \
+	const VALUE& as##NAME() const { \
+		check(TYPE); \
+		return data._t_##FIELD; \
+	} \
+	static Variant from##NAME(const VALUE& v) { \
+		return Variant(v); \
+	} \
+	VALUE to##NAME() const; \
+	operator VALUE() const { \
+		return to##NAME(); \
+	} \
+	Variant& operator=(const VALUE& v) { \
+		clear(); \
+		type = TYPE; \
+		data._t_##FIELD = v; \
+		return *this; \
+	} \
+	bool operator==(const VALUE& v) const { \
+		check(TYPE); \
+		return data._t_##FIELD == v; \
+	} \
+	bool operator!=(const VALUE& v) const { \
+		check(TYPE); \
+		return data._t_##FIELD != v; \
+	} \
 
-// Helper to set pointer type methods to variant
-#define VARIANT_ADD_TYPE_DECL_PTR(NAME, TYPE, VALUE) \
-	bool operator != (const VALUE &a) const { check(TYPE); return *data._##NAME != a; } \
-	bool operator == (const VALUE &a) const { check(TYPE); return *data._##NAME == a; } \
-	VARIANT_ADD_TYPE_DECL_PTR_BASE(NAME, TYPE, VALUE) \
-	Variant &operator =(const VALUE &a) { if (type != TYPE) { clear(); data._##NAME = new VALUE; } type = TYPE; (*data._##NAME) = a; return *this; } \
-	Variant(const VALUE &a) { data._ ## NAME = new VALUE(a); type = TYPE; }
+// defines isX(), asX(), fromX()
+#define VARIANT_ADD_TYPE_DECL_PTR_BASE(NAME, TYPE, VALUE, FIELD) \
+	bool is##NAME() const { \
+		return type == TYPE; \
+	} \
+	VALUE& as##NAME() { \
+		check(TYPE); \
+		return *data._t_##FIELD; \
+	} \
+	const VALUE& as##NAME() const { \
+		check(TYPE); \
+		return *data._t_##FIELD; \
+	} \
+	static Variant from##NAME(const VALUE& v) { \
+		return Variant(v); \
+	} \
 
-namespace crpropa
-{
+// defines isX(), asX(), fromX(), and copy constructor X(const X&), op=, op==, op!=
+#define VARIANT_ADD_TYPE_DECL_PTR(NAME, TYPE, VALUE, FIELD) \
+	VARIANT_ADD_TYPE_DECL_PTR_BASE(NAME, TYPE, VALUE, FIELD) \
+	Variant(const VALUE& v) { \
+		data._t_##FIELD = new VALUE(v); \
+		type = TYPE; \
+	} \
+	Variant& operator=(const VALUE& v) { \
+		if (type != TYPE) { \
+			clear(); \
+			data._t_##FIELD = new VALUE();\
+		} \
+		type = TYPE; \
+		(*data._t_##FIELD) = v; \
+		return *this; \
+	} \
+	bool operator==(const VALUE& v) const { \
+		check(TYPE); \
+		return *data._t_##FIELD == v; \
+	} \
+	bool operator!=(const VALUE& v) const { \
+		return !(*this == v); \
+	} \
+
+#define VARIANT_ADD_ITER_DECL_PTR(NAME, TYPE, FIELD) \
+	typedef FIELD##_t::iterator FIELD##_iterator; \
+	typedef FIELD##_t::const_iterator FIELD##_const_iterator; \
+	inline FIELD##_iterator begin##NAME() { \
+		check(TYPE); \
+		return data._t_##FIELD->begin(); \
+	} \
+	inline FIELD##_iterator end##NAME() { \
+		check(TYPE); \
+		return data._t_##FIELD->end(); \
+	} \
+	inline FIELD##_const_iterator begin##NAME() const { \
+		check(TYPE); \
+		return data._t_##FIELD->begin(); \
+	} \
+	inline FIELD##_const_iterator end##NAME() const { \
+		check(TYPE); \
+		return data._t_##FIELD->end(); \
+	}                                                                                
+
+
+
+namespace crpropa {
 
 /**
  @class Variant
  @brief storage container for data types as e.g. int, float, string, etc.
 
- Allows storage of multiple data types in one base class. Used to construct a
- map of `arbitrary' data types.
-
+ Allows storage of multiple data types in one base class. Used to construct a map of `arbitrary' data types.
+ Note that most default C++ types allow default conversions from `Variant` to the corresponding type.
+ Types that require an explicit call via `toTargetType()` are: complex (float and double), Vector3, and vector<Variant>.
  */
-class Variant
-{
+class Variant {
 public:
-	enum Type
-	{
+	enum Type {
 		TYPE_NONE = 0,
 		TYPE_BOOL,
 		TYPE_CHAR,
@@ -77,144 +149,154 @@ public:
 		TYPE_UINT64,
 		TYPE_FLOAT,
 		TYPE_DOUBLE,
-		TYPE_STRING
+		TYPE_LONGDOUBLE,
+		TYPE_COMPLEXF,
+		TYPE_COMPLEXD,
+		TYPE_STRING,
+		TYPE_VECTOR3F,
+		TYPE_VECTOR3D,
+		TYPE_VECTOR3C,
+		TYPE_VECTOR
 	};
 
-	class bad_conversion: public std::exception
-	{
-		std::string msg;
-	public:
-		const char* what() const throw ()
-		{
-			return msg.c_str();
-		}
-		bad_conversion(Type f, Type t)
-		{
-			msg = "Variant: bad conversion from '";
-			msg += Variant::getTypeName(f);
-			msg += "' to '";
-			msg += Variant::getTypeName(t);
-			msg += "'";
-		}
-		~bad_conversion() throw ()
-		{
-		}
+	class bad_conversion: public std::exception {
+		protected:
+			std::string msg;
+		public:
+			const char* what() const throw () {
+				return msg.c_str();
+			}
+
+			bad_conversion(Type f, Type t) {
+				msg = "Variant: bad conversion from '";
+				msg += Variant::getTypeName(f);
+				msg += "' to '";
+				msg += Variant::getTypeName(t);
+				msg += "'";
+			}
+
+			~bad_conversion() throw () {
+			}
 	};
 
-	Variant();
-	~Variant();
-
-	Variant(const Variant& a);
-
-	const std::type_info& getTypeInfo() const;
-
-	const char * getTypeName() const
-	{
-		return getTypeName(type);
-	}
-
-	static Type toType(const std::string &name);
-
-	static const char *getTypeName(Type type);
-
-	// copy the data to buffer via memcpy. Returns the size of the data
-	size_t copyToBuffer(void* buffer);
-	/// returns size of used data type in bytes
-	size_t getSize() const;
-
-	template<class T>
-	T to() const
-	{
-		throw bad_conversion(type, TYPE_NONE);
-	}
-
-	Type getType() const
-	{
-		return type;
-	}
-
-	bool operator ==(const Variant &a) const;
-
-	bool operator !=(const Variant &a) const;
-
-	Variant &operator =(const Variant &a)
-	{
-		copy(a);
-		return *this;
-	}
-
-	bool isValid()
-	{
-		return (type != TYPE_NONE);
-	}
-
-	VARIANT_ADD_TYPE_DECL_POD(Bool, TYPE_BOOL, bool)
-
-	VARIANT_ADD_TYPE_DECL_POD(Char, TYPE_CHAR, char)
-
-	VARIANT_ADD_TYPE_DECL_POD(UChar, TYPE_UCHAR, unsigned char)
-
-	VARIANT_ADD_TYPE_DECL_POD(Int16, TYPE_INT16, int16_t)
-
-	VARIANT_ADD_TYPE_DECL_POD(UInt16, TYPE_UINT16, uint16_t)
-
-	VARIANT_ADD_TYPE_DECL_POD(Int32, TYPE_INT32, int32_t)
-
-	VARIANT_ADD_TYPE_DECL_POD(UInt32, TYPE_UINT32, uint32_t)
-
-	VARIANT_ADD_TYPE_DECL_POD(Int64, TYPE_INT64, int64_t)
-
-	VARIANT_ADD_TYPE_DECL_POD(UInt64, TYPE_UINT64, uint64_t)
-
-	VARIANT_ADD_TYPE_DECL_POD(Float, TYPE_FLOAT, float)
-
-	VARIANT_ADD_TYPE_DECL_POD(Double, TYPE_DOUBLE, double)
-
-	VARIANT_ADD_TYPE_DECL_PTR(String, TYPE_STRING, std::string)
-	Variant(const char *s);
-	std::string toString() const;
-	static Variant fromString(const std::string &str, Type type);
-	operator std::string() const
-	{
-		return toString();
-	}
-	bool operator !=(const char *a) const
-	{
-		check(TYPE_STRING);
-		return data._String->compare(a) != 0;
-	}
-
-	// clear pointer based data types
-	void clear();
+	typedef std::complex<float> complex_f;
+	typedef std::complex<double> complex_d;
+	typedef Vector3<std::complex<double>> Vector3c;
+	typedef std::vector<Variant> vector_t;
 
 protected:
 	Type type;
 
-	union
-	{
-		bool _Bool;
-		char _Char;
-		unsigned char _UChar;
-		int16_t _Int16;
-		uint16_t _UInt16;
-		int32_t _Int32;
-		uint32_t _UInt32;
-		int64_t _Int64;
-		uint64_t _UInt64;
-		double _Double;
-		float _Float;
-		std::string *_String;
+	union {
+		bool _t_bool;
+		char _t_char;
+		unsigned char _t_uchar;
+		int16_t _t_int16;
+		uint16_t _t_uint16;
+		int32_t _t_int32;
+		uint32_t _t_uint32;
+		int64_t _t_int64;
+		uint64_t _t_uint64;
+		float _t_float;
+		double _t_double;
+		long double _t_ldouble;
+		complex_f* _t_complex_f;
+		complex_d* _t_complex_d;
+		std::string* _t_string;
+		Vector3f* _t_vector3f;
+		Vector3d* _t_vector3d;
+		Vector3c* _t_vector3c;
+		vector_t* _t_vector;
 	} data;
 
+
+public:
+	Variant();
+	Variant(Type t);
+	Variant(const Variant& v);
+	Variant(const char* s);
+	~Variant();
+	inline Type getType() const {
+		return type;
+	}
+	const char* getTypeName() const;
+	static const char* getTypeName(Type t);
+	const std::type_info& getTypeInfo() const;
+	static Type toType(const std::string& name);		
+	std::string toString(const std::string& delimiter = "\t") const;
+	std::complex<float> toComplexFloat() const;
+	std::complex<double> toComplexDouble() const;
+	Vector3f toVector3f() const;
+	Vector3d toVector3d() const;
+	Vector3c toVector3c() const;
+	vector_t toVector() const;
+	static Variant fromString(const std::string& str, Type type);
+	void clear(Type t = TYPE_NONE);
+	bool isValid() const;
+	size_t size() const;
+	size_t getSizeOf() const;
+	size_t getSize() const;
+	void resize(size_t i);
+	size_t copyToBuffer(void* buffer);
+	operator std::string() const {
+		return toString();
+	}
+	Variant& operator=(const Variant& v);
+	bool operator==(const Variant& v) const;
+	bool operator!=(const Variant& v) const;
+	bool operator!=(const char* a) const;
+	Variant& operator[](size_t i);
+	inline Variant& operator[](int i) {
+		return operator[]((size_t) i);
+	}
+	const Variant& operator[](size_t i) const;
+	const Variant& operator[](int i) const {
+		return operator[]((size_t) i);
+	}
+	operator vector_t&();
+	operator const vector_t&() const;
+
+
+	template<class T>
+	T to() const {
+		throw bad_conversion(type, TYPE_NONE);
+	}
+
+	// automatically-generated functions	
+	VARIANT_ADD_TYPE_DECL_POD(Bool, TYPE_BOOL, bool, bool)
+	VARIANT_ADD_TYPE_DECL_POD(Char, TYPE_CHAR, char, char)
+	VARIANT_ADD_TYPE_DECL_POD(UChar, TYPE_UCHAR, unsigned char, uchar)
+	VARIANT_ADD_TYPE_DECL_POD(Int16, TYPE_INT16, int16_t, int16)
+	VARIANT_ADD_TYPE_DECL_POD(UInt16, TYPE_UINT16, uint16_t, uint16)
+	VARIANT_ADD_TYPE_DECL_POD(Int32, TYPE_INT32, int32_t, int32)
+	VARIANT_ADD_TYPE_DECL_POD(UInt32, TYPE_UINT32, uint32_t, uint32)
+	VARIANT_ADD_TYPE_DECL_POD(Int64, TYPE_INT64, int64_t, int64)
+	VARIANT_ADD_TYPE_DECL_POD(UInt64, TYPE_UINT64, uint64_t, uint64)
+	VARIANT_ADD_TYPE_DECL_POD(Float, TYPE_FLOAT, float, float)
+	VARIANT_ADD_TYPE_DECL_POD(Double, TYPE_DOUBLE, double, double)
+	VARIANT_ADD_TYPE_DECL_POD(LongDouble, TYPE_LONGDOUBLE, long double, ldouble)
+	VARIANT_ADD_TYPE_DECL_PTR(ComplexFloat, TYPE_COMPLEXF, std::complex<float>, complex_f)
+	VARIANT_ADD_TYPE_DECL_PTR(ComplexDouble, TYPE_COMPLEXD, std::complex<double>, complex_d)
+	VARIANT_ADD_TYPE_DECL_PTR(String, TYPE_STRING, std::string, string)
+	VARIANT_ADD_TYPE_DECL_PTR(Vector3f, TYPE_VECTOR3F, Vector3f, vector3f)
+	VARIANT_ADD_TYPE_DECL_PTR(Vector3d, TYPE_VECTOR3D, Vector3d, vector3d)
+	VARIANT_ADD_TYPE_DECL_PTR(Vector3c, TYPE_VECTOR3C, Vector3c, vector3c)
+	VARIANT_ADD_TYPE_DECL_PTR(Vector, TYPE_VECTOR, vector_t, vector)
+	VARIANT_ADD_ITER_DECL_PTR(Vector, TYPE_VECTOR, vector)
+		
 private:
-	void copy(const Variant &a);
+	void copy(const Variant& v);
 	void check(const Type t) const;
 	void check(const Type t);
 };
 
 #define VARIANT_TO_DECL(NAME, VALUE) \
-	template<> inline VALUE Variant::to<VALUE>() const { return to ## NAME(); } \
+	template<> inline VALUE Variant::to<VALUE>() const { \
+		return to##NAME(); \
+	} \
 
+// declare type conversion functions
+// not implemented for Vector3 and complex_*
 VARIANT_TO_DECL(Bool, bool)
 VARIANT_TO_DECL(Char, char)
 VARIANT_TO_DECL(UChar, unsigned char)
@@ -225,10 +307,27 @@ VARIANT_TO_DECL(UInt32, uint32_t)
 VARIANT_TO_DECL(Int64, int64_t)
 VARIANT_TO_DECL(UInt64, uint64_t)
 VARIANT_TO_DECL(Float, float)
-VARIANT_TO_DECL(String, std::string)
 VARIANT_TO_DECL(Double, double)
+VARIANT_TO_DECL(LongDouble, long double)
+VARIANT_TO_DECL(String, std::string)
+VARIANT_TO_DECL(Vector, Variant::vector_t)
 
 std::ostream& operator <<(std::ostream& os, const Variant &v);
+
+
+/**
+ Taken from PXL
+ https://git.rwth-aachen.de/3pia/pxl/pxl/-/blob/master/core/include/pxl/core/Functions.hh
+ */
+template <class T> 
+inline void safeDelete(T*& p) {
+	if (p) {
+		delete p;
+		p = 0;
+	}
+}
+
+
 
 } // namespace crpropa 
 

--- a/src/Candidate.cpp
+++ b/src/Candidate.cpp
@@ -141,6 +141,10 @@ void Candidate::addSecondary(int id, double energy, double w, std::string tagOri
 	secondary->setRedshift(redshift);
 	secondary->setTrajectoryLength(trajectoryLength);
 	secondary->setWeight(weight * w);
+	secondary->setTagOrigin(tagOrigin);
+	for (PropertyMap::const_iterator it = properties.begin(); it != properties.end(); ++it) {
+		secondary->setProperty(it->first, it->second);		
+	}
 	secondary->source = source;
 	secondary->previous = previous;
 	secondary->created = previous;
@@ -148,7 +152,6 @@ void Candidate::addSecondary(int id, double energy, double w, std::string tagOri
 	secondary->current.setId(id);
 	secondary->current.setEnergy(energy);
 	secondary->parent = this;
-	secondary->setTagOrigin(tagOrigin);
 	secondaries.push_back(secondary);
 }
 
@@ -157,6 +160,10 @@ void Candidate::addSecondary(int id, double energy, Vector3d position, double w,
 	secondary->setRedshift(redshift);
 	secondary->setTrajectoryLength(trajectoryLength - (current.getPosition() - position).getR());
 	secondary->setWeight(weight * w);
+	secondary->setTagOrigin(tagOrigin);
+	for (PropertyMap::const_iterator it = properties.begin(); it != properties.end(); ++it) {
+		secondary->setProperty(it->first, it->second);		
+	}
 	secondary->source = source;
 	secondary->previous = previous;
 	secondary->created = previous;
@@ -166,7 +173,6 @@ void Candidate::addSecondary(int id, double energy, Vector3d position, double w,
 	secondary->current.setPosition(position);
 	secondary->created.setPosition(position);
 	secondary->parent = this;
-	secondary->setTagOrigin(tagOrigin);
 	secondaries.push_back(secondary);
 }
 

--- a/src/Candidate.cpp
+++ b/src/Candidate.cpp
@@ -103,11 +103,11 @@ void Candidate::setProperty(const std::string &name, const Variant &value) {
 }
 
 void Candidate::setTagOrigin (std::string tagOrigin) {
-	this -> tagOrigin  = tagOrigin ;
+	this->tagOrigin = tagOrigin;
 }
 
 std::string Candidate::getTagOrigin () const {
-	return tagOrigin ;
+	return tagOrigin;
 }
 
 const Variant &Candidate::getProperty(const std::string &name) const {
@@ -148,14 +148,14 @@ void Candidate::addSecondary(int id, double energy, double w, std::string tagOri
 	secondary->current.setId(id);
 	secondary->current.setEnergy(energy);
 	secondary->parent = this;
-	secondary->setTagOrigin (tagOrigin);
+	secondary->setTagOrigin(tagOrigin);
 	secondaries.push_back(secondary);
 }
 
 void Candidate::addSecondary(int id, double energy, Vector3d position, double w, std::string tagOrigin) {
 	ref_ptr<Candidate> secondary = new Candidate;
 	secondary->setRedshift(redshift);
-	secondary->setTrajectoryLength(trajectoryLength - (current.getPosition() - position).getR() );
+	secondary->setTrajectoryLength(trajectoryLength - (current.getPosition() - position).getR());
 	secondary->setWeight(weight * w);
 	secondary->source = source;
 	secondary->previous = previous;
@@ -166,7 +166,7 @@ void Candidate::addSecondary(int id, double energy, Vector3d position, double w,
 	secondary->current.setPosition(position);
 	secondary->created.setPosition(position);
 	secondary->parent = this;
-	secondary->setTagOrigin (tagOrigin);
+	secondary->setTagOrigin(tagOrigin);
 	secondaries.push_back(secondary);
 }
 

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -3,960 +3,1122 @@
 // http://vispa.physik.rwth-aachen.de/                        -
 // Licensed under a LGPL-2 or later license                   -
 //-------------------------------------------------------------
+
 #include "crpropa/Variant.h"
 
-#include <algorithm>
 
-namespace crpropa
-{
+namespace crpropa {
 
-Variant::Variant() :
-		type(TYPE_NONE)
-{
+
+Variant::Variant() : type(TYPE_NONE) {
 }
 
-Variant::~Variant()
-{
-	clear();
+Variant::Variant(Type t) : type(TYPE_NONE) {
+	check(t);
 }
 
-Variant::Variant(const Variant& a) :
-		type(TYPE_NONE)
-{
-	copy(a);
+Variant::Variant(const Variant& v) : type(TYPE_NONE) {
+	copy(v);
 }
 
-Variant::Variant(const char *s)
-{
-	data._String = new std::string(s);
+Variant::Variant(const char* s) {
+	data._t_string = new std::string(s);
 	type = TYPE_STRING;
 }
 
-
-void Variant::clear()
-{
-	if (type == TYPE_STRING)
-	{
-		if(data._String)
-		{
-			delete data._String;
-			data._String = NULL;
-		}
-
-	}
-
-	type = TYPE_NONE;
+Variant::~Variant() {
+	clear();
 }
 
-void Variant::check(const Type t) const
-{
-	if (type != t)
-		throw bad_conversion(type, t);
+const char* Variant::getTypeName() const {
+	return getTypeName(type);
 }
 
-void Variant::check(const Type t)
-{
-	if (type == TYPE_NONE)
-	{
-		std::memset(&data, 0, sizeof(data));
-		switch (t)
-		{
-		case TYPE_STRING:
-			data._String = new std::string;
-			break;
-		default:
-			break;
-		}
-		type = t;
-	}
-	else if (type != t)
-	{
-		throw bad_conversion(type, t);
-	}
-}
-
-const std::type_info& Variant::getTypeInfo() const
-{
-	if (type == TYPE_BOOL)
-	{
-		const std::type_info &ti = typeid(data._Bool);
-		return ti;
-	}
-	else if (type == TYPE_CHAR)
-	{
-		const std::type_info &ti = typeid(data._Char);
-		return ti;
-	}
-	else if (type == TYPE_UCHAR)
-	{
-		const std::type_info &ti = typeid(data._UChar);
-		return ti;
-	}
-	else if (type == TYPE_INT16)
-	{
-		const std::type_info &ti = typeid(data._Int16);
-		return ti;
-	}
-	else if (type == TYPE_UINT16)
-	{
-		const std::type_info &ti = typeid(data._UInt16);
-		return ti;
-	}
-	else if (type == TYPE_INT32)
-	{
-		const std::type_info &ti = typeid(data._Int32);
-		return ti;
-	}
-	else if (type == TYPE_UINT32)
-	{
-		const std::type_info &ti = typeid(data._UInt32);
-		return ti;
-	}
-	else if (type == TYPE_INT64)
-	{
-		const std::type_info &ti = typeid(data._Int64);
-		return ti;
-	}
-	else if (type == TYPE_UINT64)
-	{
-		const std::type_info &ti = typeid(data._UInt64);
-		return ti;
-	}
-	else if (type == TYPE_FLOAT)
-	{
-		const std::type_info &ti = typeid(data._Float);
-		return ti;
-	}
-	else if (type == TYPE_DOUBLE)
-	{
-		const std::type_info &ti = typeid(data._Double);
-		return ti;
-	}
-	else if (type == TYPE_STRING)
-	{
-		const std::type_info &ti = typeid(*data._String);
-		return ti;
-	}
-	else
-	{
-		const std::type_info &ti = typeid(0);
-		return ti;
-	}
-
-}
-
-const char *Variant::getTypeName(Type type)
-{
-	if (type == TYPE_NONE)
-	{
+const char* Variant::getTypeName(Type t) {
+	if (t == TYPE_NONE)
 		return "none";
-	}
-	else if (type == TYPE_BOOL)
-	{
+	else if (t == TYPE_BOOL)
 		return "bool";
-	}
-	else if (type == TYPE_CHAR)
-	{
-		return "char";
-	}
-	else if (type == TYPE_UCHAR)
-	{
-		return "uchar";
-	}
-	else if (type == TYPE_INT16)
-	{
-		return "int16";
-	}
-	else if (type == TYPE_UINT16)
-	{
-		return "uint16";
-	}
-	else if (type == TYPE_INT32)
-	{
-		return "int32";
-	}
-	else if (type == TYPE_UINT32)
-	{
-		return "uint32";
-	}
-	else if (type == TYPE_INT64)
-	{
-		return "int64";
-	}
-	else if (type == TYPE_UINT64)
-	{
-		return "uint64";
-	}
-	else if (type == TYPE_FLOAT)
-	{
-		return "float";
-	}
-	else if (type == TYPE_DOUBLE)
-	{
-		return "double";
-	}
-	else if (type == TYPE_STRING)
-	{
-		return "string";
-	}
-	else
-	{
-		return "unknown";
-	}
-}
-
-Variant::Type Variant::toType(const std::string &name)
-{
-	if (name == "none")
-	{
-		return TYPE_NONE;
-	}
-	else if (name == "bool")
-	{
-		return TYPE_BOOL;
-	}
-	else if (name == "char")
-	{
-		return TYPE_CHAR;
-	}
-	else if (name == "uchar")
-	{
-		return TYPE_UCHAR;
-	}
-	else if (name == "int16")
-	{
-		return TYPE_INT16;
-	}
-	else if (name == "uint16")
-	{
-		return TYPE_UINT16;
-	}
-	else if (name == "int32")
-	{
-		return TYPE_INT32;
-	}
-	else if (name == "uint32")
-	{
-		return TYPE_UINT32;
-	}
-	else if (name == "int64")
-	{
-		return TYPE_INT64;
-	}
-	else if (name == "uint64")
-	{
-		return TYPE_UINT64;
-	}
-	else if (name == "float")
-	{
-		return TYPE_FLOAT;
-	}
-	else if (name == "double")
-	{
-		return TYPE_DOUBLE;
-	}
-	else if (name == "string")
-	{
-		return TYPE_STRING;
-	}
-	else
-	{
-		return TYPE_NONE;
-	}
-}
-
-bool Variant::operator ==(const Variant &a) const
-{
-	if (type != a.type)
-		return false;
-	if (type == TYPE_BOOL)
-	{
-		return (data._Bool == a.data._Bool);
-	}
-	else if (type == TYPE_CHAR)
-	{
-		return (data._Char == a.data._Char);
-	}
-	else if (type == TYPE_UCHAR)
-	{
-		return (data._UChar == a.data._UChar);
-	}
-	else if (type == TYPE_INT16)
-	{
-		return (data._Int16 == a.data._Int16);
-	}
-	else if (type == TYPE_UINT16)
-	{
-		return (data._UInt16 == a.data._UInt16);
-	}
-	else if (type == TYPE_INT32)
-	{
-		return (data._Int32 == a.data._Int32);
-	}
-	else if (type == TYPE_UINT32)
-	{
-		return (data._UInt32 == a.data._UInt32);
-	}
-	else if (type == TYPE_INT64)
-	{
-		return (data._Int64 == a.data._Int64);
-	}
-	else if (type == TYPE_UINT64)
-	{
-		return (data._UInt64 == a.data._UInt64);
-	}
-	else if (type == TYPE_FLOAT)
-	{
-		return (data._Float == a.data._Float);
-	}
-	else if (type == TYPE_DOUBLE)
-	{
-		return (data._Double == a.data._Double);
-	}
-	else if (type == TYPE_STRING)
-	{
-		return (*data._String == *a.data._String);
-	}
-	else
-	{
-		throw std::runtime_error("compare operator not implemented");
-	}
-}
-
-std::string Variant::toString() const
-{
-	if (type == TYPE_STRING)
-		return *data._String;
-
-	std::stringstream sstr;
-	if (type == TYPE_BOOL)
-	{
-		sstr << data._Bool;
-	}
-	else if (type == TYPE_CHAR)
-	{
-		sstr << data._Char;
-	}
-	else if (type == TYPE_UCHAR)
-	{
-		sstr << data._UChar;
-	}
-	else if (type == TYPE_INT16)
-	{
-		sstr << data._Int16;
-	}
-	else if (type == TYPE_UINT16)
-	{
-		sstr << data._UInt16;
-	}
-	else if (type == TYPE_INT32)
-	{
-		sstr << data._Int32;
-	}
-	else if (type == TYPE_UINT32)
-	{
-		sstr << data._UInt32;
-	}
-	else if (type == TYPE_INT64)
-	{
-		sstr << data._Int64;
-	}
-	else if (type == TYPE_UINT64)
-	{
-		sstr << data._UInt64;
-	}
-	else if (type == TYPE_FLOAT)
-	{
-		sstr << std::scientific << data._Float;
-	}
-	else if (type == TYPE_DOUBLE)
-	{
-		sstr << std::scientific << data._Double;
-	}
-
-	return sstr.str();
-}
-
-Variant Variant::fromString(const std::string &str, Type type)
-{
-	std::stringstream sstr(str);
-	switch (type)
-	{
-	case TYPE_BOOL:
-	{
-		std::string upperstr(str);
-		std::transform(upperstr.begin(), upperstr.end(), upperstr.begin(),
-				(int(*)(int))toupper);if
-(		upperstr == "YES")
-		return Variant(true);
-		else if (upperstr == "NO")
-		return Variant(false);
-		if (upperstr == "TRUE")
-			return Variant(true);
-		else if (upperstr == "FALSE")
-			return Variant(false);
-		if (upperstr == "1")
-			return Variant(true);
-		else if (upperstr == "0")
-			return Variant(false);
-		throw bad_conversion(type, TYPE_BOOL);
-	}
-	case TYPE_CHAR:
-	{
-		char c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_UCHAR:
-	{
-		unsigned char c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_INT16:
-	{
-		int16_t c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_UINT16:
-	{
-		uint16_t c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_INT32:
-	{
-		int32_t c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_UINT32:
-	{
-		uint32_t c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_INT64:
-	{
-		int64_t c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_UINT64:
-	{
-		uint64_t c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_FLOAT:
-	{
-		float c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_DOUBLE:
-	{
-		double c;
-		sstr >> c;
-		return Variant(c);
-	}
-	case TYPE_STRING:
-	{
-		return Variant(str);
-	}
-	default:
-		throw std::runtime_error("pxl::Variant::fromString: unknown type");
-	}
-
-}
-
-bool Variant::operator !=(const Variant &a) const
-{
-	if (type != a.type)
-		return true;
-
-	switch (type)
-	{
-	case TYPE_BOOL:
-		return (data._Bool != a.data._Bool);
-	case TYPE_CHAR:
-		return (data._Char != a.data._Char);
-	case TYPE_UCHAR:
-		return (data._UChar != a.data._UChar);
-	case TYPE_INT16:
-		return (data._Int16 != a.data._Int16);
-	case TYPE_UINT16:
-		return (data._UInt16 == a.data._UInt16);
-	case TYPE_INT32:
-		return (data._Int32 == a.data._Int32);
-	case TYPE_UINT32:
-		return (data._UInt32 == a.data._UInt32);
-	case TYPE_INT64:
-		return (data._Int64 == a.data._Int64);
-	case TYPE_UINT64:
-		return (data._UInt64 == a.data._UInt64);
-	case TYPE_FLOAT:
-		return (data._Float == a.data._Float);
-	case TYPE_DOUBLE:
-		return (data._Double == a.data._Double);
-	case TYPE_STRING:
-		return (*data._String == *a.data._String);
-	default:
-		throw std::runtime_error("compare operator not implemented");
-	}
-}
-
-
-void Variant::copy(const Variant &a)
-{
-	Type t = a.type;
-	if (t == TYPE_BOOL)
-	{
-		operator =(a.data._Bool);
-	}
 	else if (t == TYPE_CHAR)
-	{
-		operator =(a.data._Char);
-	}
+		return "char";
 	else if (t == TYPE_UCHAR)
-	{
-		operator =(a.data._UChar);
-	}
+		return "uchar";
 	else if (t == TYPE_INT16)
-	{
-		operator =(a.data._Int16);
-	}
+		return "int16";
 	else if (t == TYPE_UINT16)
-	{
-		operator =(a.data._UInt16);
-	}
+		return "uint16";
 	else if (t == TYPE_INT32)
-	{
-		operator =(a.data._Int32);
-	}
+		return "int32";
 	else if (t == TYPE_UINT32)
-	{
-		operator =(a.data._UInt32);
-	}
+		return "uint32";
 	else if (t == TYPE_INT64)
-	{
-		operator =(a.data._Int64);
-	}
+		return "int64";
 	else if (t == TYPE_UINT64)
-	{
-		operator =(a.data._UInt64);
-	}
+		return "uint64";
 	else if (t == TYPE_FLOAT)
-	{
-		operator =(a.data._Float);
-	}
+		return "float";
 	else if (t == TYPE_DOUBLE)
-	{
-		operator =(a.data._Double);
-	}
+		return "double";
+	else if (t == TYPE_LONGDOUBLE)
+		return "ldouble";
+	else if (t == TYPE_COMPLEXF)
+		return "complex_f";
+	else if (t == TYPE_COMPLEXD)
+		return "complex_d";
 	else if (t == TYPE_STRING)
-	{
-		operator =(*a.data._String);
-	}
+		return "string";
+	else if (t == TYPE_VECTOR3F)
+		return "Vector3f";
+	else if (t == TYPE_VECTOR3D)
+		return "Vector3d";
+	else if (t == TYPE_VECTOR3C)
+		return "Vector3c";
+	else if (t == TYPE_VECTOR)
+		return "vector";
 	else
-	{
-		type = TYPE_NONE;
+		return "unknown";
+}
+
+const std::type_info& Variant::getTypeInfo() const {
+	if (type == TYPE_BOOL) {
+		const std::type_info& ti = typeid(data._t_bool);
+		return ti;
+	} else if (type == TYPE_CHAR) {
+		const std::type_info& ti = typeid(data._t_char);
+		return ti;
+	} else if (type == TYPE_UCHAR) {
+		const std::type_info& ti = typeid(data._t_uchar);
+		return ti;
+	} else if (type == TYPE_INT16) {
+		const std::type_info& ti = typeid(data._t_int16);
+		return ti;
+	} else if (type == TYPE_UINT16) {
+		const std::type_info& ti = typeid(data._t_uint16);
+		return ti;
+	} else if (type == TYPE_INT32) {
+		const std::type_info& ti = typeid(data._t_int32);
+		return ti;
+	} else if (type == TYPE_UINT32) {
+		const std::type_info& ti = typeid(data._t_uint32);
+		return ti;
+	} else if (type == TYPE_INT64) {
+		const std::type_info& ti = typeid(data._t_int64);
+		return ti;
+	} else if (type == TYPE_UINT64) {
+		const std::type_info& ti = typeid(data._t_uint64);
+		return ti;
+	} else if (type == TYPE_FLOAT) {
+		const std::type_info& ti = typeid(data._t_float);
+		return ti;
+	} else if (type == TYPE_DOUBLE)	{
+		const std::type_info& ti = typeid(data._t_double);
+		return ti;
+	} else if (type == TYPE_LONGDOUBLE)	{
+		const std::type_info& ti = typeid(data._t_ldouble);
+		return ti;
+	} else if (type == TYPE_STRING) {
+		const std::type_info& ti = typeid(*data._t_string);
+		return ti;
+	} else if (type == TYPE_COMPLEXF) { // pointer needed?
+		const std::type_info& ti = typeid(*data._t_complex_f);
+		return ti;
+	} else if (type == TYPE_COMPLEXD) {
+		const std::type_info& ti = typeid(*data._t_complex_d);
+		return ti;
+	} else if (type == TYPE_VECTOR3D) {
+		const std::type_info& ti = typeid(data._t_vector3d);
+		return ti;
+	} else if (type == TYPE_VECTOR3F) {
+		const std::type_info& ti = typeid(data._t_vector3f);
+		return ti;
+	} else if (type == TYPE_VECTOR) {
+		const std::type_info& ti = typeid(*data._t_vector);
+		return ti;
+	} else {
+		const std::type_info& ti = typeid(0);
+		return ti;
 	}
 }
 
-bool Variant::toBool() const
-{
-	switch (type)
-	{
-	case TYPE_BOOL:
-		return data._Bool;
-		break;
-	case TYPE_CHAR:
-		return data._Char != 0;
-		break;
-	case TYPE_UCHAR:
-		return data._UChar != 0;
-		break;
-	case TYPE_INT16:
-		return data._Int16 != 0;
-		break;
-	case TYPE_UINT16:
-		return data._UInt16 != 0;
-		break;
-	case TYPE_INT32:
-		return data._Int32 != 0;
-		break;
-	case TYPE_UINT32:
-		return data._UInt32 != 0;
-		break;
-	case TYPE_INT64:
-		return data._Int64 != 0;
-		break;
-	case TYPE_UINT64:
-		return data._UInt64 != 0;
-		break;
-	case TYPE_STRING:
-	{
-		std::string upperstr(*data._String);
-		std::transform(upperstr.begin(), upperstr.end(), upperstr.begin(),
-				(int(*)(int))toupper);if
-(		upperstr == "YES")
-		return true;
-		else if (upperstr == "NO")
-		return false;
-		if (upperstr == "TRUE")
-			return true;
-		else if (upperstr == "FALSE")
-			return false;
-		if (upperstr == "1")
-			return true;
-		else if (upperstr == "0")
-			return false;
-		else
+Variant::Type Variant::toType(const std::string& name) {
+	if (name == "none")
+		return TYPE_NONE;
+	else if (name == "bool")
+		return TYPE_BOOL;
+	else if (name == "char") 
+		return TYPE_CHAR;
+	else if (name == "uchar")
+		return TYPE_UCHAR;
+	else if (name == "int16")
+		return TYPE_INT16;
+	else if (name == "uint16")
+		return TYPE_UINT16;
+	else if (name == "int32")
+		return TYPE_INT32;
+	else if (name == "uint32")
+		return TYPE_UINT32;
+	else if (name == "int64")
+		return TYPE_INT64;
+	else if (name == "uint64")
+		return TYPE_UINT64;
+	else if (name == "float")
+		return TYPE_FLOAT;
+	else if (name == "double")
+		return TYPE_DOUBLE;
+	else if (name == "long double")
+		return TYPE_LONGDOUBLE;
+	else if (name == "complex_f")
+		return TYPE_COMPLEXF;
+	else if (name == "complex_d")
+		return TYPE_COMPLEXD;
+	 else if (name == "string")
+		return TYPE_STRING;
+	else if (name == "Vector3f")
+		return TYPE_VECTOR3F;
+	else if (name == "Vector3d")
+		return TYPE_VECTOR3D;
+	else if (name == "Vector3c")
+		return TYPE_VECTOR3C;
+	else if (name == "vector")
+		return TYPE_VECTOR;
+	else
+		return TYPE_NONE;
+}
+
+bool Variant::toBool() const {
+	switch (type) {
+		case TYPE_BOOL:
+			return data._t_bool;
+			break;
+		case TYPE_CHAR:
+			return data._t_char != 0;
+			break;
+		case TYPE_UCHAR:
+			return data._t_uchar != 0;
+			break;
+		case TYPE_INT16:
+			return data._t_int16 != 0;
+			break;
+		case TYPE_UINT16:
+			return data._t_uint16 != 0;
+			break;
+		case TYPE_INT32:
+			return data._t_int32 != 0;
+			break;
+		case TYPE_UINT32:
+			return data._t_uint32 != 0;
+			break;
+		case TYPE_INT64:
+			return data._t_int64 != 0;
+			break;
+		case TYPE_UINT64:
+			return data._t_uint64 != 0;
+			break;
+		case TYPE_STRING: {
+				std::string upperstr(*data._t_string);
+				std::transform(upperstr.begin(), upperstr.end(), upperstr.begin(), (int(*) (int)) toupper);
+				if (upperstr == "YES" || upperstr == "TRUE" || upperstr == "1")
+					return true;
+				else if (upperstr == "NO" || upperstr == "FALSE" || upperstr == "0")
+					return false;
+				else
+					throw bad_conversion(type, TYPE_BOOL);
+			}
+			break;
+		case TYPE_COMPLEXF: {
+				if (data._t_complex_f->real() == 0 && data._t_complex_f->imag() == 0)
+					return true;
+				else
+					return false;
+			}
+			break;
+		case TYPE_COMPLEXD: {
+				if (data._t_complex_d->real() == 0 && data._t_complex_d->imag() == 0)
+					return true;
+				else
+					return false;
+			}
+			break;
+		case TYPE_VECTOR:
+			return data._t_vector->size() != 0;
+			break;
+		case TYPE_FLOAT:
+		case TYPE_DOUBLE:
+		case TYPE_LONGDOUBLE:
+		default:
 			throw bad_conversion(type, TYPE_BOOL);
+			break;
 	}
-		break;
-	case TYPE_FLOAT:
-	case TYPE_DOUBLE:
-	case TYPE_NONE:
-		throw bad_conversion(type, TYPE_BOOL);
-		break;
-	}
+
 	return false;
 }
 
-#define INT_CASE(from_var, from_type, to_type, to) \
-	case Variant::from_type:\
-		if (data._##from_var < std::numeric_limits<to>::min() || data._##from_var > std::numeric_limits<to>::max())\
-			throw bad_conversion(type, to_type);\
-		else\
-			return static_cast<to>(data._##from_var);\
-		break;\
+float Variant::toFloat() const {
+	switch (type) {
+		case TYPE_BOOL:
+			return data._t_bool ? (float) 1.0 : (float) 0.0; 
+			break;
+		case TYPE_CHAR:
+			return static_cast<float>(data._t_char);
+			break;
+		case TYPE_UCHAR:
+			return static_cast<float>(data._t_uchar);
+			break;
+		case TYPE_INT16:
+			return static_cast<float>(data._t_int16);
+			break;
+		case TYPE_INT32:
+			return static_cast<float>(data._t_int32);
+			break;
+		case TYPE_INT64:
+			return static_cast<float>(data._t_int64);
+			break;
+		case TYPE_UINT16:
+			return static_cast<float>(data._t_uint16);
+			break;
+		case TYPE_UINT32:
+			return static_cast<float>(data._t_uint32);
+			break;
+		case TYPE_UINT64:
+			return static_cast<float>(data._t_uint64);
+			break;
+		case TYPE_FLOAT:
+			return static_cast<float>(data._t_float);
+			break;
+		case TYPE_DOUBLE:
+			return static_cast<float>(data._t_double);
+			break;
+		case TYPE_LONGDOUBLE:
+			return static_cast<float>(data._t_ldouble);
+			break;
+		case TYPE_STRING:
+			return static_cast<float>(std::atof(data._t_string->c_str()));
+			break;
+		case TYPE_COMPLEXF: {
+				if (data._t_complex_f->imag() == 0)
+					return static_cast<float>(data._t_complex_f->real());
+				else
+					throw bad_conversion(type, TYPE_COMPLEXF);
+			}
+			break;
+		case TYPE_COMPLEXD: {
+				if (data._t_complex_d->imag() == 0)
+					return static_cast<float>(data._t_complex_d->real());
+				else
+					throw bad_conversion(type, TYPE_COMPLEXD);
+			}
+			break;
+		default:
+			throw bad_conversion(type, TYPE_FLOAT);
+			break;
+	}
 
-#define INT_FUNCTION(to_type, fun, to) \
-to Variant::fun() const { \
-	switch (type) { \
-	case Variant::TYPE_BOOL: \
-		return data._Bool ? 1 : 0; \
-		break; \
-	INT_CASE(Char, TYPE_CHAR, to_type, to) \
-	INT_CASE(UChar, TYPE_UCHAR, to_type, to) \
-	INT_CASE(Int16, TYPE_INT16, to_type, to) \
-	INT_CASE(UInt16, TYPE_UINT16, to_type, to) \
-	INT_CASE(Int32, TYPE_INT32, to_type, to) \
-	INT_CASE(UInt32, TYPE_UINT32, to_type, to) \
-	INT_CASE(Int64, TYPE_INT64, to_type, to) \
-	INT_CASE(UInt64, TYPE_UINT64, to_type, to) \
-	INT_CASE(Float, TYPE_FLOAT, to_type, to) \
-	INT_CASE(Double, TYPE_DOUBLE, to_type, to) \
-	case Variant::TYPE_STRING: \
-		{ \
-		long l = atol(data._String->c_str()); \
-		if (l < std::numeric_limits<to>::min() || l > std::numeric_limits<to>::max()) \
-			throw bad_conversion(type, to_type); \
-		else \
-			return l; \
-		} \
-		break; \
-	case Variant::TYPE_NONE: \
-		throw bad_conversion(type, TYPE_INT16); \
-		break;\
-	}\
-	return 0;\
+	return 0.;
 }
 
-INT_FUNCTION( TYPE_CHAR, toChar, char)
-INT_FUNCTION( TYPE_UCHAR, toUChar, unsigned char)
-INT_FUNCTION( TYPE_INT16, toInt16, int16_t)
-INT_FUNCTION( TYPE_UINT16, toUInt16, uint16_t)
-INT_FUNCTION( TYPE_INT32, toInt32, int32_t)
-INT_FUNCTION( TYPE_UINT32, toUInt32, uint32_t)
-INT_FUNCTION( TYPE_INT64, toInt64, int64_t)
-INT_FUNCTION( TYPE_UINT64, toUInt64, uint64_t)
-
-std::ostream& operator <<(std::ostream& os, const Variant &v)
-{
-	switch (v.getType())
-	{
-	case Variant::TYPE_BOOL:
-		os << v.asBool();
-		break;
-	case Variant::TYPE_CHAR:
-		os << v.asChar();
-		break;
-	case Variant::TYPE_UCHAR:
-		os << v.asUChar();
-		break;
-	case Variant::TYPE_INT16:
-		os << v.asInt16();
-		break;
-	case Variant::TYPE_UINT16:
-		os << v.asUInt16();
-		break;
-	case Variant::TYPE_INT32:
-		os << v.asInt32();
-		break;
-	case Variant::TYPE_UINT32:
-		os << v.asUInt32();
-		break;
-	case Variant::TYPE_INT64:
-		os << v.asInt64();
-		break;
-	case Variant::TYPE_UINT64:
-		os << v.asUInt64();
-		break;
-	case Variant::TYPE_FLOAT:
-		os << v.asFloat();
-		break;
-	case Variant::TYPE_DOUBLE:
-		os << v.asDouble();
-		break;
-	case Variant::TYPE_STRING:
-		os << v.asString();
-		break;
-	default:
-		break;
+double Variant::toDouble() const {
+	switch (type) {
+		case TYPE_BOOL:
+			return data._t_bool ? (double) 1.0 : (double) 0.0; 
+			break;
+		case TYPE_CHAR:
+			return static_cast<double>(data._t_char);
+			break;
+		case TYPE_UCHAR:
+			return static_cast<double>(data._t_uchar);
+			break;
+		case TYPE_INT16:
+			return static_cast<double>(data._t_int16);
+			break;
+		case TYPE_INT32:
+			return static_cast<double>(data._t_int32);
+			break;
+		case TYPE_INT64:
+			return static_cast<double>(data._t_int64);
+			break;
+		case TYPE_UINT16:
+			return static_cast<double>(data._t_uint16);
+			break;
+		case TYPE_UINT32:
+			return static_cast<double>(data._t_uint32);
+			break;
+		case TYPE_UINT64:
+			return static_cast<double>(data._t_uint64);
+			break;
+		case TYPE_FLOAT:
+			return static_cast<double>(data._t_float);
+			break;
+		case TYPE_DOUBLE:
+			return static_cast<double>(data._t_double);
+			break;
+		case TYPE_LONGDOUBLE:
+			return static_cast<double>(data._t_ldouble);
+			break;
+		case TYPE_COMPLEXF: {
+				if (data._t_complex_f->imag() == 0)
+					return static_cast<double>(data._t_complex_f->real());
+				else
+					throw bad_conversion(type, TYPE_COMPLEXF);
+			}
+			break;
+		case TYPE_COMPLEXD: {
+				if (data._t_complex_d->imag() == 0)
+					return static_cast<double>(data._t_complex_d->real());
+				else
+					throw bad_conversion(type, TYPE_COMPLEXD);
+			}
+			break;
+		case TYPE_STRING:
+			return static_cast<double>(std::atof(data._t_string->c_str()));
+			break;
+		default:
+			throw bad_conversion(type, TYPE_DOUBLE);
+			break;
 	}
+
+	return 0.;
+}
+
+long double Variant::toLongDouble() const {
+	switch (type) {
+		case TYPE_BOOL:
+			return data._t_bool ? (long double) 1.0 : (long double) 0.0; 
+			break;
+		case TYPE_CHAR:
+			return static_cast<long double>(data._t_char);
+			break;
+		case TYPE_UCHAR:
+			return static_cast<long double>(data._t_uchar);
+			break;
+		case TYPE_INT16:
+			return static_cast<long double>(data._t_int16);
+			break;
+		case TYPE_INT32:
+			return static_cast<long double>(data._t_int32);
+			break;
+		case TYPE_INT64:
+			return static_cast<long double>(data._t_int64);
+			break;
+		case TYPE_UINT16:
+			return static_cast<long double>(data._t_uint16);
+			break;
+		case TYPE_UINT32:
+			return static_cast<long double>(data._t_uint32);
+			break;
+		case TYPE_UINT64:
+			return static_cast<long double>(data._t_uint64);
+			break;
+		case TYPE_FLOAT:
+			return static_cast<long double>(data._t_float);
+			break;
+		case TYPE_DOUBLE:
+			return static_cast<long double>(data._t_double);
+			break;
+		case TYPE_LONGDOUBLE:
+			return static_cast<long double>(data._t_ldouble);
+			break;
+		case TYPE_COMPLEXF: {
+				if (data._t_complex_f->imag() == 0)
+					return static_cast<long double>(data._t_complex_f->real());
+				else
+					throw bad_conversion(type, TYPE_COMPLEXF);
+			}
+			break;
+		case TYPE_COMPLEXD: {
+				if (data._t_complex_d->imag() == 0)
+					return static_cast<long double>(data._t_complex_d->real());
+				else
+					throw bad_conversion(type, TYPE_COMPLEXD);
+			}
+			break;
+		case TYPE_STRING:
+			return static_cast<double>(std::atof(data._t_string->c_str()));
+			break;
+		default:
+			throw bad_conversion(type, TYPE_LONGDOUBLE);
+			break;
+	}
+
+	return 0.;
+}
+
+std::complex<float> Variant::toComplexFloat() const {
+	switch (type) {
+		case TYPE_COMPLEXF:
+			return static_cast<std::complex<float>>(*data._t_complex_f);
+			break;
+		case TYPE_COMPLEXD:
+			return static_cast<std::complex<float>>(*data._t_complex_d);
+			break;
+		default:
+			throw bad_conversion(type, TYPE_COMPLEXF);
+			break;
+	}
+}  
+
+std::complex<double> Variant::toComplexDouble() const {
+	switch (type) {
+		case TYPE_COMPLEXF:
+			return static_cast<std::complex<double>>(*data._t_complex_f);
+			break;
+		case TYPE_COMPLEXD:
+			return static_cast<std::complex<double>>(*data._t_complex_d);
+			break;
+		default:
+			throw bad_conversion(type, TYPE_COMPLEXD);
+			break;
+	}
+}  
+
+Vector3f Variant::toVector3f() const {
+	switch (type) {
+		case TYPE_VECTOR3F:
+			return static_cast<Vector3f>(*data._t_vector3f);
+			break;
+		case TYPE_VECTOR3D:
+			return static_cast<Vector3f>(*data._t_vector3d);
+			break;
+		default:
+			throw bad_conversion(type, TYPE_VECTOR3F);
+			break;
+	}
+}
+
+Vector3d Variant::toVector3d() const {
+	switch (type) {
+		case TYPE_VECTOR3F:
+			return static_cast<Vector3d>(*data._t_vector3f);
+			break;
+		case TYPE_VECTOR3D:
+			return static_cast<Vector3d>(*data._t_vector3d);
+			break;
+		default:
+			throw bad_conversion(type, TYPE_VECTOR3D);
+			break;
+	}
+}
+
+Vector3<std::complex<double>> Variant::toVector3c() const {
+	switch (type) {
+		case TYPE_VECTOR3C:
+			return static_cast<Vector3c>(*data._t_vector3c);
+			break;
+		default:
+			throw bad_conversion(type, TYPE_VECTOR3C);
+			break;
+	}
+}
+
+std::string Variant::toString(const std::string& delimiter) const {
+	if (type == TYPE_STRING)
+		return *data._t_string;
+
+	std::stringstream ss;
+
+	if (type == TYPE_BOOL) {
+		ss << data._t_bool;
+	} else if (type == TYPE_CHAR) {
+		ss << data._t_char;
+	} else if (type == TYPE_UCHAR) {
+		ss << data._t_uchar;
+	} else if (type == TYPE_INT16) {
+		ss << data._t_int16;
+	} else if (type == TYPE_UINT16) {
+		ss << data._t_uint16;
+	} else if (type == TYPE_INT32) {
+		ss << data._t_int32;
+	} else if (type == TYPE_UINT32) {
+		ss << data._t_uint32;
+	} else if (type == TYPE_INT64) {
+		ss << data._t_int64;
+	} else if (type == TYPE_UINT64) {
+		ss << data._t_uint64;
+	} else if (type == TYPE_FLOAT) {
+		ss << std::scientific << data._t_float;
+	} else if (type == TYPE_DOUBLE) {
+		ss << std::scientific << data._t_double;
+	} else if (type == TYPE_LONGDOUBLE) {
+		ss << std::scientific << data._t_ldouble;
+	} else if (type == TYPE_COMPLEXF) {
+		ss << std::scientific << data._t_complex_f->real() << delimiter; 
+		ss << std::scientific << data._t_complex_f->imag();
+	} else if (type == TYPE_COMPLEXD) {
+		ss << std::scientific << data._t_complex_d->real() << delimiter; 
+		ss << std::scientific << data._t_complex_d->imag();
+	} else if (type == TYPE_VECTOR3F) {
+		ss << *data._t_vector3f;
+	} else if (type == TYPE_VECTOR3D) {
+		ss << *data._t_vector3d;
+	} else if (type == TYPE_VECTOR) {
+		ss << *data._t_vector;
+	}
+
+	return ss.str();
+}
+
+Variant::vector_t Variant::toVector() const {
+	if (type == TYPE_VECTOR)
+		return *data._t_vector;
+	else
+		throw bad_conversion(type, TYPE_VECTOR);
+}
+
+Variant Variant::fromString(const std::string& s, Type t) {
+	std::stringstream ss(s);
+
+	if (t == TYPE_BOOL) {
+		std::string upperstr(s);
+		std::transform(upperstr.begin(), upperstr.end(), upperstr.begin(), (int (*)(int)) toupper);
+		if (upperstr == "YES" || upperstr == "TRUE" || upperstr == "1") 
+			return Variant(true);
+		else if (upperstr == "NO" || upperstr == "FALSE" || upperstr == "0")
+			return Variant(false);
+		throw bad_conversion(t, TYPE_BOOL);
+	} else if (t == TYPE_CHAR) {
+		char c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_UCHAR) {
+		unsigned char c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_INT16) {
+		int16_t c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_INT32) {
+		int32_t c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_INT64) {
+		int64_t c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_UINT16) {
+		uint16_t c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_UINT32) {
+		uint32_t c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_UINT64) {
+		uint64_t c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_FLOAT) {
+		float c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_DOUBLE) {
+		double c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_LONGDOUBLE) {
+		long double c;
+		ss >> c;
+		return Variant(c);
+	} else if (t == TYPE_STRING) {
+		return Variant(s);
+	} else if (t == TYPE_COMPLEXF) {
+		float _vr, _vi;
+		ss >> _vr >> _vi;
+		complex_f v(_vr, _vi);
+		return Variant(v);
+	} else if (t == TYPE_COMPLEXD) {
+		double _vr, _vi;
+		ss >> _vr >> _vi;
+		complex_d v(_vr, _vi);
+		return Variant(v);
+	} else if (t == TYPE_VECTOR3F) {
+		Vector3f v;
+		float _val;
+		ss >> _val;
+		v.setX(_val);
+		ss >> _val;
+		v.setY(_val);
+		ss >> _val;
+		v.setZ(_val);
+		return Variant(v);
+	} else if (t == TYPE_VECTOR3D) {
+		Vector3d v;
+		double _val;
+		ss >> _val;
+		v.setX(_val);
+		ss >> _val;
+		v.setY(_val);
+		ss >> _val;
+		v.setZ(_val);
+		return Variant(v);
+	} else if (t == TYPE_VECTOR3C) {
+		Vector3c v;
+		std::complex<double> _val;
+		ss >> _val;
+		v.setX(_val);
+		ss >> _val;
+		v.setY(_val);
+		ss >> _val;
+		v.setZ(_val);
+		return Variant(v);
+	} else if (t == TYPE_VECTOR) {
+		// std::regex useless("(|)|[|]| ");
+		vector_t v;
+		while (ss.good()) {
+			std::string s;
+			v.push_back(s);
+		}
+	} else {
+		std::string msg; 
+		msg += "fromString not implemented for type ";
+        msg += getTypeName(t);
+        throw std::runtime_error("Variant: " + msg);
+	}
+}
+
+void Variant::clear(Type t) {
+	if (t == TYPE_STRING)
+		safeDelete(data._t_string);
+	else if (t == TYPE_VECTOR3F)
+		safeDelete(data._t_vector3f);
+	else if (t == TYPE_VECTOR3D)
+		safeDelete(data._t_vector3d);
+	else if (t == TYPE_VECTOR3C)
+		safeDelete(data._t_vector3c);
+	else if (t == TYPE_COMPLEXF)
+		safeDelete(data._t_complex_f);
+	else if (t == TYPE_COMPLEXD)
+		safeDelete(data._t_complex_d);
+	else if (t == TYPE_VECTOR)
+		safeDelete(data._t_vector);
+
+	// set the type to TYPE_NONE which will be used for checks
+    type = TYPE_NONE;
+    check(t);
+}
+
+void Variant::copy(const Variant& v) {
+	Type t = v.type;
+
+	if (t == TYPE_BOOL) 
+		operator = (v.data._t_bool);
+	else if (t == TYPE_CHAR)
+		operator = (v.data._t_char);
+	else if (t == TYPE_UCHAR)
+		operator = (v.data._t_uchar);
+	else if (t == TYPE_INT16)
+		operator = (v.data._t_int16);
+	else if (t == TYPE_UINT16)
+		operator = (v.data._t_uint16);
+	else if (t == TYPE_INT32)
+		operator = (v.data._t_int32);
+	else if (t == TYPE_UINT32)
+		operator = (v.data._t_uint32);
+	else if (t == TYPE_INT64)
+		operator = (v.data._t_int64);
+	else if (t == TYPE_UINT64)
+		operator = (v.data._t_uint64);
+	else if (t == TYPE_FLOAT)
+		operator = (v.data._t_float);
+	else if (t == TYPE_DOUBLE)
+		operator = (v.data._t_double);
+	else if (t == TYPE_LONGDOUBLE)
+		operator = (v.data._t_ldouble);
+	else if (t == TYPE_STRING)
+		operator = (*v.data._t_string);
+	else if (t == TYPE_COMPLEXF)
+		operator = (*v.data._t_complex_f);
+	else if (t == TYPE_COMPLEXD)
+		operator = (*v.data._t_complex_d);
+	else if (t == TYPE_VECTOR3F)
+		operator = (*v.data._t_vector3f);
+	else if (t == TYPE_VECTOR3D)
+		operator = (*v.data._t_vector3d);
+	else if (t == TYPE_VECTOR3C)
+		operator = (*v.data._t_vector3c);
+	else if (t == TYPE_VECTOR)
+		operator = (*v.data._t_vector);
+	else
+		type = TYPE_NONE;
+}
+
+void Variant::check(const Type t) const {
+	if (type != t) {
+		throw bad_conversion(type, t);
+	}
+}
+
+void Variant::check(const Type t) {
+	if (type == TYPE_NONE) {
+		memset(&data, 0, sizeof(data));
+		if (t == TYPE_VECTOR3F)
+			data._t_vector3f = new Vector3f(); 
+		else if (t == TYPE_VECTOR3D)
+			data._t_vector3d = new Vector3d(); 
+		else if (t == TYPE_VECTOR3C)
+			data._t_vector3c = new Vector3c(); 
+		else if (t == TYPE_COMPLEXF)
+			data._t_complex_f = new complex_f(); 
+		else if (t == TYPE_COMPLEXD)
+			data._t_complex_d = new complex_d(); 
+		else if (t == TYPE_STRING)
+			data._t_string = new std::string();
+		else if (t == TYPE_VECTOR)
+			data._t_vector = new vector_t();
+		else
+			type = t;
+	} else if (type != t)  {
+	throw bad_conversion(type, t);
+	}
+}
+
+bool Variant::isValid() const {
+	return (type != TYPE_NONE);
+}
+
+size_t Variant::size() const {
+	if (type == TYPE_VECTOR) {
+		return data._t_vector->size();
+	} else {
+		std::string msg; 
+		msg += "size() not implemented for type ";
+		msg += getTypeName(type);
+		throw std::runtime_error("Variant: " + msg);
+	}
+}
+
+size_t Variant::getSizeOf() const {
+	switch (type) {
+		case TYPE_BOOL:
+			return sizeof(data._t_bool);
+			break;
+		case TYPE_CHAR:
+			return sizeof(data._t_char);
+			break;
+		case TYPE_UCHAR:
+			return sizeof(data._t_uchar);
+			break;
+		case TYPE_INT16:
+			return sizeof(data._t_int16);
+			break;
+		case TYPE_UINT16:
+			return sizeof(data._t_uint16);
+			break;
+		case TYPE_INT32:
+			return sizeof(data._t_int32);
+			break;
+		case TYPE_UINT32:
+			return sizeof(data._t_uint32);
+			break;
+		case TYPE_INT64:
+			return sizeof(data._t_int64);
+			break;
+		case TYPE_UINT64:
+			return sizeof(data._t_uint64);
+			break;
+		case TYPE_FLOAT:
+			return sizeof(data._t_float);
+			break;
+		case TYPE_DOUBLE:
+			return sizeof(data._t_double);
+			break;
+		case TYPE_LONGDOUBLE:
+			return sizeof(data._t_ldouble);
+			break;
+		case TYPE_COMPLEXF:
+			return sizeof(data._t_complex_f);
+			break;
+		case TYPE_COMPLEXD:
+			return sizeof(data._t_complex_d);
+			break;
+		case TYPE_VECTOR3F:
+			return sizeof(data._t_vector3f);
+			break;
+		case TYPE_VECTOR3D:
+			return sizeof(data._t_vector3d);
+			break;
+		case TYPE_VECTOR3C:
+			return sizeof(data._t_vector3c);
+			break;
+		case TYPE_STRING: {
+				size_t len = strlen(data._t_string->c_str() + 1);
+				return len;
+			}
+			break;
+		case TYPE_NONE:
+			return 0;
+			break;
+		default:
+			throw std::runtime_error("Function getSize() cannot handle this type.");
+	}
+}
+
+size_t Variant::getSize() const {
+	return getSizeOf();
+}
+
+void Variant::resize(size_t i) {
+	check(TYPE_VECTOR);
+	return data._t_vector->resize(i);
+}
+
+size_t Variant::copyToBuffer(void* buffer) {
+	if (type == TYPE_BOOL) {
+		memcpy(buffer, &data._t_bool, sizeof(bool));
+		return sizeof(data._t_bool);
+	} else if (type == TYPE_CHAR) {
+		memcpy(buffer, &data._t_char, sizeof(char));
+		return sizeof(data._t_char);
+	}  else if (type == TYPE_UCHAR) {
+		memcpy(buffer, &data._t_uchar, sizeof(unsigned char));
+		return sizeof(data._t_uchar);
+	} else if (type == TYPE_INT16) {
+		memcpy(buffer, &data._t_int16, sizeof(int16_t));
+		return sizeof(data._t_int16);
+	} else if (type == TYPE_UINT16) {
+		memcpy(buffer, &data._t_uint16, sizeof(uint16_t));
+		return sizeof(data._t_uint16);
+	} else if (type == TYPE_INT32) {
+		memcpy(buffer, &data._t_int32, sizeof(int32_t));
+		return sizeof(data._t_int32);
+	} else if (type == TYPE_UINT32) {
+		memcpy(buffer, &data._t_uint32, sizeof(uint32_t));
+		return sizeof(data._t_uint32);
+	} else if (type == TYPE_INT64) {
+		memcpy(buffer, &data._t_int64, sizeof(int64_t));
+		return sizeof(data._t_int64);
+	} else if (type == TYPE_UINT64) {
+		memcpy(buffer, &data._t_uint64, sizeof(uint64_t));
+		return sizeof(data._t_uint64);
+	} else if (type == TYPE_FLOAT) {
+		memcpy(buffer, &data._t_float, sizeof(float));
+		return sizeof(data._t_float);
+	} else if (type == TYPE_DOUBLE) {
+		memcpy(buffer, &data._t_double, sizeof(double));
+		return sizeof(data._t_double);
+	} else if (type == TYPE_LONGDOUBLE) {
+		memcpy(buffer, &data._t_ldouble, sizeof(long double));
+		return sizeof(data._t_ldouble);
+	}  else if (type == TYPE_STRING) {
+		size_t len = data._t_string->size();
+		memcpy(buffer, data._t_string->c_str(), len);
+		return len;
+	} else if (type == TYPE_NONE) {
+		return 0;
+	} else {
+		throw std::runtime_error("This type cannot be handled by copyToBuffer().");
+	}
+}
+
+Variant& Variant::operator=(const Variant &v) {
+	copy(v);
+	return *this;
+}
+
+bool Variant::operator==(const Variant& v) const {
+	if (type != v.type)
+		return false;
+
+	if (type == TYPE_BOOL) {
+		return (data._t_bool == v.data._t_bool);
+	} else if (type == TYPE_CHAR) {
+		return (data._t_char == v.data._t_char);
+	} else if (type == TYPE_UCHAR) {
+		return (data._t_uchar == v.data._t_uchar);
+	} else if (type == TYPE_INT16) {
+		return (data._t_int16 == v.data._t_int16);
+	} else if (type == TYPE_UINT16) {
+		return (data._t_uint16 == v.data._t_uint16);
+	} else if (type == TYPE_INT32) {
+		return (data._t_int32 == v.data._t_int32);
+	} else if (type == TYPE_UINT32) {
+		return (data._t_uint32 == v.data._t_uint32);
+	} else if (type == TYPE_INT64) {
+		return (data._t_int64 == v.data._t_int64);
+	} else if (type == TYPE_UINT64) {
+		return (data._t_uint64 == v.data._t_uint64);
+	} else if (type == TYPE_FLOAT) {
+		return (data._t_float == v.data._t_float);
+	} else if (type == TYPE_DOUBLE) {
+		return (data._t_double == v.data._t_double);
+	} else if (type == TYPE_LONGDOUBLE) {
+		return (data._t_ldouble == v.data._t_ldouble);
+	} else if (type == TYPE_STRING) {
+		return (*data._t_string == *v.data._t_string);
+	} else if (type == TYPE_COMPLEXF) {
+		return (*data._t_complex_f == *v.data._t_complex_f);
+	} else if (type == TYPE_COMPLEXD) {
+		return (*data._t_complex_d == *v.data._t_complex_d);
+	} else if (type == TYPE_VECTOR3F) {
+		return (*data._t_vector3f == *v.data._t_vector3f);
+	} else if (type == TYPE_VECTOR3D) {
+		return (*data._t_vector3d == *v.data._t_vector3d);
+	} else if (type == TYPE_VECTOR3C) {
+		return (*data._t_vector3c == *v.data._t_vector3c);
+	} else if (type == TYPE_VECTOR) {
+		return (*data._t_vector == *v.data._t_vector);
+	} else {
+		throw std::runtime_error("compare operator not implemented");
+	}
+}
+
+bool Variant::operator!=(const Variant& v) const {
+	if (type != v.type)
+		return true;
+	
+	if (*this == v)
+		return false;
+	else
+		return true;
+}
+
+bool Variant::operator!=(const char* v) const {
+	check(TYPE_STRING);
+	return data._t_string->compare(v) != 0;
+}
+
+Variant& Variant::operator[](size_t i) {
+	check(TYPE_VECTOR);
+	return (*data._t_vector)[i];
+}
+
+const Variant& Variant::operator[](size_t i) const {
+	check(TYPE_VECTOR);
+	return (*data._t_vector)[i];
+}
+
+Variant::operator std::vector<Variant>&() {
+	check(TYPE_VECTOR);
+	return *data._t_vector;
+}
+
+Variant::operator const std::vector<Variant>&() const {
+	check(TYPE_VECTOR);
+	return *data._t_vector;
+}
+
+
+
+#define INT_CASE(from_var, from_type, to_type, to) 													                   \
+    case Variant::from_type: {                                                                                         \
+		if (data._t_##from_var <std::numeric_limits<to>::min() || data._t_##from_var> std::numeric_limits<to>::max())  \
+			throw bad_conversion(type, to_type);                                                                       \
+		else                                                                                                           \
+			return static_cast<to>(data._t_##from_var);                                                                \
+		}                                                                                                              \
+    	break;                                                                                                         \
+
+#define INT_FUNCTION(to_type, fun, to)                                                                                 \
+	to Variant::fun() const {                                                                                          \
+		switch (type) {                                                                                                \
+			case Variant::TYPE_BOOL:                                                                                   \
+				return data._t_bool ? 1 : 0;                                                                           \
+				break;                                                                                                 \
+				INT_CASE(char, TYPE_CHAR, to_type, to)                                                                 \
+				INT_CASE(uchar, TYPE_UCHAR, to_type, to)                                                               \
+				INT_CASE(int16, TYPE_INT16, to_type, to)                                                               \
+				INT_CASE(uint16, TYPE_UINT16, to_type, to)                                                             \
+				INT_CASE(int32, TYPE_INT32, to_type, to)                                                               \
+				INT_CASE(uint32, TYPE_UINT32, to_type, to)                                                             \
+				INT_CASE(int64, TYPE_INT64, to_type, to)                                                               \
+				INT_CASE(uint64, TYPE_UINT64, to_type, to)                                                             \
+				INT_CASE(float, TYPE_FLOAT, to_type, to)                                                               \
+				INT_CASE(double, TYPE_DOUBLE, to_type, to)                                                             \
+				INT_CASE(ldouble, TYPE_LONGDOUBLE, to_type, to)                                                        \
+			case Variant::TYPE_STRING: {                                                                               \
+				long l = atol(data._t_string->c_str());                                                                \
+				if (l <std::numeric_limits<to>::min() || l > std::numeric_limits<to>::max())                           \
+					throw bad_conversion(type, to_type);                                                               \
+				else                                                                                                   \
+					return l;                                                                                          \
+				}                                                                                                      \
+				break;                                                                                                 \
+			case Variant::TYPE_COMPLEXF:                                                                               \
+			case Variant::TYPE_COMPLEXD:                                                                               \
+			case Variant::TYPE_VECTOR3F:                                                                               \
+			case Variant::TYPE_VECTOR3D:                                                                               \
+			case Variant::TYPE_VECTOR3C:                                                                               \
+			case Variant::TYPE_VECTOR:                                                                                 \
+			case Variant::TYPE_NONE:                                                                                   \
+				throw bad_conversion(type, to_type);                                                                   \
+				break;                                                                                                 \
+		}                                                                                                              \
+		return 0;                                                                                                      \
+	} 
+
+INT_FUNCTION(TYPE_CHAR, toChar, char)
+INT_FUNCTION(TYPE_UCHAR, toUChar, unsigned char)
+INT_FUNCTION(TYPE_INT16, toInt16, int16_t)
+INT_FUNCTION(TYPE_UINT16, toUInt16, uint16_t)
+INT_FUNCTION(TYPE_INT32, toInt32, int32_t)
+INT_FUNCTION(TYPE_UINT32, toUInt32, uint32_t)
+INT_FUNCTION(TYPE_INT64, toInt64, int64_t)
+INT_FUNCTION(TYPE_UINT64, toUInt64, uint64_t)
+
+
+
+std::ostream& operator <<(std::ostream& os, const Variant& v) {
+	switch (v.getType()) {
+		case Variant::TYPE_BOOL:
+			os << v.asBool();
+			break;
+		case Variant::TYPE_CHAR:
+			os << v.asChar();
+			break;
+		case Variant::TYPE_UCHAR:
+			os << v.asUChar();
+			break;
+		case Variant::TYPE_INT16:
+			os << v.asInt16();
+			break;
+		case Variant::TYPE_UINT16:
+			os << v.asUInt16();
+			break;
+		case Variant::TYPE_INT32:
+			os << v.asInt32();
+			break;
+		case Variant::TYPE_UINT32:
+			os << v.asUInt32();
+			break;
+		case Variant::TYPE_INT64:
+			os << v.asInt64();
+			break;
+		case Variant::TYPE_UINT64:
+			os << v.asUInt64();
+			break;
+		case Variant::TYPE_FLOAT:
+			os << v.asFloat();
+			break;
+		case Variant::TYPE_DOUBLE:
+			os << v.asDouble();
+			break;
+		case Variant::TYPE_LONGDOUBLE:
+			os << v.asLongDouble();
+			break;
+		case Variant::TYPE_COMPLEXF:
+			os << v.asComplexFloat();
+			break;
+		case Variant::TYPE_COMPLEXD:
+			os << v.asComplexDouble();
+			break;
+		case Variant::TYPE_STRING:
+			os << v.asString();
+			break;
+		case Variant::TYPE_VECTOR3F:
+			os << v.asVector3f();
+			break;
+		case Variant::TYPE_VECTOR3D:
+			os << v.asVector3d();
+			break;
+		case Variant::TYPE_VECTOR3C:
+			os << v.asVector3c();
+			break;
+		default:
+			break;
+	}
+
 	return os;
 }
 
 
 
-float Variant::toFloat() const
-{
-	if (type == TYPE_CHAR)
-	{
-		return static_cast<float>(data._Char);
-	}
-	else if (type == TYPE_UCHAR)
-	{
-		return static_cast<float>(data._UChar);
-	}
-	else if (type == TYPE_INT16)
-	{
-		return static_cast<float>(data._Int16);
-	}
-	else if (type == TYPE_UINT16)
-	{
-		return static_cast<float>(data._UInt16);
-	}
-	else if (type == TYPE_INT32)
-	{
-		return static_cast<float>(data._Int32);
-	}
-	else if (type == TYPE_UINT32)
-	{
-		return static_cast<float>(data._UInt32);
-	}
-	else if (type == TYPE_INT64)
-	{
-		return static_cast<float>(data._Int64);
-	}
-	else if (type == TYPE_UINT64)
-	{
-		return static_cast<float>(data._UInt64);
-	}
-	else if (type == TYPE_FLOAT)
-	{
-		return static_cast<float>(data._Float);
-	}
-	else if (type == TYPE_DOUBLE)
-	{
-		return static_cast<float>(data._Double);
-	}
-	else if (type == TYPE_STRING)
-	{
-		return static_cast<float>(std::atof(data._String->c_str()));
-	}
-	else if (type == TYPE_BOOL)
-	{
-		return data._Bool ? 1.0f : 0.0f;
-	}
-	else
-	{
-		return 0.0;
-	}
-}
-
-double Variant::toDouble() const
-{
-	if (type == TYPE_CHAR)
-	{
-		return static_cast<double>(data._Char);
-	}
-	else if (type == TYPE_UCHAR)
-	{
-		return static_cast<double>(data._UChar);
-	}
-	else if (type == TYPE_INT16)
-	{
-		return static_cast<double>(data._Int16);
-	}
-	else if (type == TYPE_UINT16)
-	{
-		return static_cast<double>(data._UInt16);
-	}
-	else if (type == TYPE_INT32)
-	{
-		return static_cast<double>(data._Int32);
-	}
-	else if (type == TYPE_UINT32)
-	{
-		return static_cast<double>(data._UInt32);
-	}
-	else if (type == TYPE_INT64)
-	{
-		return static_cast<double>(data._Int64);
-	}
-	else if (type == TYPE_UINT64)
-	{
-		return static_cast<double>(data._UInt64);
-	}
-	else if (type == TYPE_FLOAT)
-	{
-		return static_cast<double>(data._Float);
-	}
-	else if (type == TYPE_DOUBLE)
-	{
-		return static_cast<double>(data._Double);
-	}
-	else if (type == TYPE_STRING)
-	{
-		return std::atof(data._String->c_str());
-	}
-	else if (type == TYPE_BOOL)
-	{
-		return data._Bool ? 1.0 : 0.0;
-	}
-	else
-	{
-		return 0.0;
-	}
-}
-
-
-#define MEMCPYRET(VAR) \
-	memcpy(buffer, &VAR, sizeof( VAR) );\
-  return sizeof( VAR );
-
-size_t Variant::copyToBuffer(void* buffer)
-{
-  if (type == TYPE_CHAR)
-	{
-		MEMCPYRET( data._Char )
-	}
-	else if (type == TYPE_UCHAR)
-	{
-		MEMCPYRET( data._UChar )
-	}
-	else if (type == TYPE_INT16)
-	{
-		MEMCPYRET(data._Int16);
-	}
-	else if (type == TYPE_UINT16)
-	{
-		MEMCPYRET(data._UInt16);
-	}
-	else if (type == TYPE_INT32)
-	{
-		MEMCPYRET(data._Int32);
-	}
-	else if (type == TYPE_UINT32)
-	{
-		MEMCPYRET(data._UInt32);
-	}
-	else if (type == TYPE_INT64)
-	{
-		MEMCPYRET(data._Int64);
-	}
-	else if (type == TYPE_UINT64)
-	{
-		MEMCPYRET(data._UInt64);
-	}
-	else if (type == TYPE_FLOAT)
-	{
-		MEMCPYRET(data._Float);
-	}
-	else if (type == TYPE_DOUBLE)
-	{
-		MEMCPYRET(data._Double);
-	}
-	else if (type == TYPE_STRING)
-	{
-		size_t len = data._String->size();
-		memcpy(buffer, data._String->c_str(), len);
-		return len;
-	}
-	else if (type == TYPE_BOOL)
-	{
-		MEMCPYRET(data._Bool);
-	}
-	else if (type == TYPE_NONE)
-	{
-		return 0;
-	}
-	throw std::runtime_error("This is serious: Type not handled in copyToBuffer()!");
-};
-
-size_t Variant::getSize() const
-{
-  if (type == TYPE_CHAR)
-	{
-		return sizeof(data._Char);
-	}
-	else if (type == TYPE_UCHAR)
-	{
-		return sizeof(data._UChar);
-	}
-	else if (type == TYPE_INT16)
-	{
-		return sizeof(data._Int16);
-	}
-	else if (type == TYPE_UINT16)
-	{
-		return sizeof(data._UInt16);
-	}
-	else if (type == TYPE_INT32)
-	{
-		return sizeof(data._Int32);
-	}
-	else if (type == TYPE_UINT32)
-	{
-		return sizeof(data._UInt32);
-	}
-	else if (type == TYPE_INT64)
-	{
-		return sizeof(data._Int64);
-	}
-	else if (type == TYPE_UINT64)
-	{
-		return sizeof(data._UInt64);
-	}
-	else if (type == TYPE_FLOAT)
-	{
-		return sizeof(data._Float);
-	}
-	else if (type == TYPE_DOUBLE)
-	{
-		return sizeof(data._Double);
-	}
-	else if (type == TYPE_STRING)
-	{
-		size_t len = strlen(data._String->c_str()+1);
-		return len;
-	}
-	else if (type == TYPE_BOOL)
-	{
-		return sizeof(data._Bool);
-	}
-	else if (type == TYPE_NONE)
-	{
-		return 0;
-	}
-	throw std::runtime_error("This is serious: Type not handled in getSize()!");
-};
-
-
-
-} // namespace pxl
+} // namespace crpropa

--- a/src/module/TextOutput.cpp
+++ b/src/module/TextOutput.cpp
@@ -257,18 +257,14 @@ void TextOutput::process(Candidate *c) const {
 	}
 
 	for(std::vector<Output::Property>::const_iterator iter = properties.begin();
-			iter != properties.end(); ++iter)
-	{
+			iter != properties.end(); ++iter) {
 		  Variant v;
-			if (c->hasProperty((*iter).name))
-			{
+			if (c->hasProperty((*iter).name)) {
 				v = c->getProperty((*iter).name);
-			}
-			else
-			{
+			} else {
 				v = (*iter).defaultValue;
 			}
-			p += std::sprintf(buffer + p, "%s", v.toString().c_str());
+			p += std::sprintf(buffer + p, "%s", v.toString("\t").c_str());
 			p += std::sprintf(buffer + p, "\t");
 	}
 	buffer[p - 1] = '\n';

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -5,6 +5,8 @@
 	Common functions
  */
 
+#include <complex>
+
 #include "crpropa/Candidate.h"
 #include "crpropa/base64.h"
 #include "crpropa/Common.h"
@@ -16,6 +18,7 @@
 #include "crpropa/GridTools.h"
 #include "crpropa/Geometry.h"
 #include "crpropa/EmissionMap.h"
+#include "crpropa/Vector3.h"
 
 #include <HepPID/ParticleIDMethods.hh>
 #include "gtest/gtest.h"

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -932,8 +932,7 @@ TEST(EmissionMap, merge) {
 }
 
 
-TEST(Variant, copyToBuffer)
-{
+TEST(Variant, copyToBuffer) {
 	double a = 23.42;
 	Variant v(a);
 	double b;
@@ -941,8 +940,7 @@ TEST(Variant, copyToBuffer)
 	EXPECT_EQ(a, b);
 }
 
-TEST(Variant, stringConversion)
-{
+TEST(Variant, stringConversion) {
 	Variant v, w;
 	{
 		int32_t a = 12;
@@ -961,25 +959,66 @@ TEST(Variant, stringConversion)
 		w = Variant::fromString(v.toString(), v.getType());
 		EXPECT_EQ(a, w.asInt64());
 	}
+
+	{
+		Vector3d a(1, 2, 3);
+		Variant v = Variant::fromVector3d(a);
+		Vector3d u = v.asVector3d();
+		EXPECT_EQ(a.getX(), u.getX());
+		EXPECT_EQ(a.getY(), u.getY());
+		EXPECT_EQ(a.getZ(), u.getZ());
+	}
+
+	{
+		std::complex<double> a1(1, 1);
+		std::complex<double> a2(2, 0);
+		Vector3<std::complex<double>> a(a1, a1, a2);
+		Variant v = Variant::fromVector3c(a);
+		Vector3<std::complex<double>> u = v.asVector3c();
+		EXPECT_EQ(a1, u.getX());
+		EXPECT_EQ(a1, u.getY());
+		EXPECT_EQ(a2, u.getZ());
+	}
+
+	{
+		std::complex<double> a(1, 2);
+		Variant v = Variant::fromComplexDouble(a);
+		std::complex<double> u = v.asComplexDouble();
+		EXPECT_EQ(u.real(), 1);
+		EXPECT_EQ(u.imag(), 2);
+	}
+
+	{
+		std::vector<Variant> a;
+		a.push_back(Variant::fromDouble(1));
+		a.push_back(Variant::fromDouble(2));
+		a.push_back(Variant::fromDouble(3));
+		a.push_back(Variant::fromDouble(4));
+		Variant v = Variant::fromVector(a);
+		std::vector<Variant> u = v.asVector();
+		EXPECT_EQ(a[0], Variant::fromDouble(u[0]));
+		EXPECT_EQ(a[1], Variant::fromDouble(u[1]));
+		EXPECT_EQ(a[2], Variant::fromDouble(u[2]));
+		EXPECT_EQ(a[3], Variant::fromDouble(u[3]));
+	}
+
+
 }
 
 
-TEST(Geometry, Plane)
-{
+TEST(Geometry, Plane) {
 	Plane p(Vector3d(0,0,1), Vector3d(0,0,1));
 	EXPECT_DOUBLE_EQ(-1., p.distance(Vector3d(0, 0, 0)));
 	EXPECT_DOUBLE_EQ(9., p.distance(Vector3d(1, 1, 10)));
 }
 
-TEST(Geometry, Sphere)
-{
+TEST(Geometry, Sphere) {
 	Sphere s(Vector3d(0,0,0), 1.);
 	EXPECT_DOUBLE_EQ(-1., s.distance(Vector3d(0, 0, 0)));
 	EXPECT_DOUBLE_EQ(9., s.distance(Vector3d(10, 0, 0)));
 }
 
-TEST(Geometry, ParaxialBox)
-{
+TEST(Geometry, ParaxialBox) {
 	ParaxialBox b(Vector3d(0,0,0), Vector3d(3,4,5));
 	EXPECT_NEAR(-.1, b.distance(Vector3d(0.1, 0.1, 0.1)), 1E-10);
 	EXPECT_NEAR(-.1, b.distance(Vector3d(0.1, 3.8, 0.1)), 1E-10);


### PR DESCRIPTION
This PR improves the handling of variants in CRPropa. It updates the previous implementation making the code more efficient. Its main goal is to facilitate the lives of users aiming to write their own plugins. 
This PR also adds some more tests in `testCore.cpp` to check if variants are being treated correctly.

Currently some types like `Vector3d` cannot be treated as a variant. Instead, the user would require three `double` and consequently three operations to handle it.
New types added are: `complex<double>`, `complex<float>`, `Vector3d`, `Vector3f`, `Vector3c` (alias for `Vector3<complex<double>>`, `long double`. A new type for a vector of variants (`vector<Variant>`) was also added.

For some yet-unknown reason these new types have to be called with `variant.toVector3d()`, for instance, whereas operations assigning a variant directly to some types are permitted for the more conventional types like `double`. 

