### PR TITLE
GridProperties: Default Value for Volume Clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ### Bug fixes:
 * Re-added ToroidalHaloField and LogarithmicSpiralField models. Note, that the class name was also corrected in spelling: TorroidalHaloField --> ToroidalHaloField
 * Synchronized signature of ParticleSplitting constructor
-* Added default parameter for clipVolume in GridProperties. Could have lead to random clipping of grid values outside of the original grid volume.
 
 ### New features:
-* new candidate property tagOrigin to trace back which source or which interaction created the candidate
-* new interace for massdistributions given on a Grid1f
-* grids can be restricted to the volume without repetition
-* sourceFeature to sample the source position from a given massdistribution
+* New candidate property tagOrigin to trace back which source or which interaction created the candidate
+* New interace for massdistributions given on a Grid1f
+* Grids can be restricted to the volume without repetition
+* SourceFeature to sample the source position from a given massdistribution
+* Added default parameter for clipVolume in GridProperties.
 
 ### Interface changes:
 * Weight column in hdf-Output is now called "W", which is the same as for TextOutput.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@
 
 ### New features:
 * New candidate property tagOrigin to trace back which source or which interaction created the candidate
-* New interace for massdistributions given on a Grid1f
-* Grids can be restricted to the volume without repetition
+* New interface for massdistributions given on a Grid1f
+* Grids can be restricted to the volume without repetition (clipVolume parameter)
 * SourceFeature to sample the source position from a given massdistribution
-* Added default parameter for clipVolume in GridProperties.
 
 ### Interface changes:
 * Weight column in hdf-Output is now called "W", which is the same as for TextOutput.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# CRPropa vNext
+## CRPropa vNext
 
 ### Bug fixes:
 * Re-added ToroidalHaloField and LogarithmicSpiralField models. Note, that the class name was also corrected in spelling: TorroidalHaloField --> ToroidalHaloField
 * Synchronized signature of ParticleSplitting constructor
+* Added default parameter for clipVolume in GridProperties. Could have lead to random clipping of grid values outside of the original grid volume.
 
 ### New features:
 * new candidate property tagOrigin to trace back which source or which interaction created the candidate

--- a/include/crpropa/Grid.h
+++ b/include/crpropa/Grid.h
@@ -77,6 +77,7 @@ public:
 	Vector3d spacing; 	// Spacing vector between gridpoints
 	bool reflective;	// using reflective repetition of the grid instead of periodic
 	interpolationType ipol;	// Interpolation type used between grid points
+	bool clipVolume;	// Set grid values to 0 outside the volume if true
 
 	/** Constructor for cubic grid
 	 @param	origin	Position of the lower left front corner of the volume
@@ -84,7 +85,7 @@ public:
 	 @param spacing	Spacing between grid points
 	 */
 	GridProperties(Vector3d origin, size_t N, double spacing) :
-		origin(origin), Nx(N), Ny(N), Nz(N), spacing(Vector3d(spacing)), reflective(false), ipol(TRILINEAR) {
+		origin(origin), Nx(N), Ny(N), Nz(N), spacing(Vector3d(spacing)), reflective(false), ipol(TRILINEAR), clipVolume(false) {
 	}
 
 	/** Constructor for non-cubic grid
@@ -95,7 +96,7 @@ public:
 	 @param spacing	Spacing between grid points
 	 */
 	GridProperties(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, double spacing) :
-		origin(origin), Nx(Nx), Ny(Ny), Nz(Nz), spacing(Vector3d(spacing)), reflective(false), ipol(TRILINEAR) {
+		origin(origin), Nx(Nx), Ny(Ny), Nz(Nz), spacing(Vector3d(spacing)), reflective(false), ipol(TRILINEAR), clipVolume(false) {
 	}
 
 	/** Constructor for non-cubic grid with spacing vector
@@ -106,7 +107,7 @@ public:
 	 @param spacing	Spacing vector between grid points
 	*/
 	GridProperties(Vector3d origin, size_t Nx, size_t Ny, size_t Nz, Vector3d spacing) :
-		origin(origin), Nx(Nx), Ny(Ny), Nz(Nz), spacing(spacing), reflective(false), ipol(TRILINEAR) {
+		origin(origin), Nx(Nx), Ny(Ny), Nz(Nz), spacing(spacing), reflective(false), ipol(TRILINEAR), clipVolume(false) {
 	}
 	
 	virtual ~GridProperties() {
@@ -121,6 +122,11 @@ public:
 	 * @param i: interpolationType (TRILINEAR, TRICUBIC, NEAREST_NEIGHBOUR) */
 	void setInterpolationType(interpolationType i) {
 		ipol = i;
+	}
+
+	/** If True, the grid is set to zero outside of the volume. */
+	void setClipVolume(bool b) {
+		clipVolume = b;
 	}
 };
 
@@ -194,6 +200,7 @@ public:
 	Grid(const GridProperties &p) :
 		origin(p.origin), spacing(p.spacing), reflective(p.reflective), ipolType(p.ipol) {
 		setGridSize(p.Nx, p.Ny, p.Nz);
+		setClipVolume(p.clipVolume);
 	}
 
 	void setOrigin(Vector3d origin) {
@@ -240,6 +247,10 @@ public:
 	/** returns the position of the lower left front corner of the volume */
 	Vector3d getOrigin() const {
 		return origin;
+	}
+
+	bool getClipVolume() const {
+		return clipVolume;
 	}
 
 	size_t getNx() const {

--- a/include/crpropa/Grid.h
+++ b/include/crpropa/Grid.h
@@ -162,6 +162,7 @@ public:
 		setSpacing(Vector3d(spacing));
 		setReflective(false);
 		setClipVolume(false);
+		setInterpolationType(TRILINEAR);
 	}
 
 	/** Constructor for non-cubic grid
@@ -177,6 +178,7 @@ public:
 		setSpacing(Vector3d(spacing));
 		setReflective(false);
 		setClipVolume(false);
+		setInterpolationType(TRILINEAR);
 	}
 
 	/** Constructor for non-cubic grid with spacing vector
@@ -192,6 +194,7 @@ public:
 		setSpacing(spacing);
 		setReflective(false);
 		setClipVolume(false);
+		setInterpolationType(TRILINEAR);
 	}
 
 	/** Constructor for GridProperties

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -522,6 +522,12 @@ TEST(Grid1f, SimpleTest) {
 	//nearest neighbour interpolated
 	grid.setInterpolationType(NEAREST_NEIGHBOUR);
 	EXPECT_FLOAT_EQ(7., grid.interpolate(some_grid_point));
+
+	//Test if grid is set to zero outside of volume for clipVolume=true
+	grid.setClipVolume(true);
+	EXPECT_EQ(0, grid.get(0, 0, 12));
+	EXPECT_EQ(0, grid.get(0, 0, 12));
+	EXPECT_EQ(0, grid.get(0, 0, 12));
 }
 
 TEST(Grid1f, GridPropertiesConstructor) {
@@ -599,6 +605,35 @@ TEST(Grid1f, ClosestValue) {
 	EXPECT_FLOAT_EQ(2, grid.closestValue(Vector3d(0.2, 0.1, 1.3)));
 	EXPECT_FLOAT_EQ(3, grid.closestValue(Vector3d(0.3, 1.2, 0.2)));
 	EXPECT_FLOAT_EQ(7, grid.closestValue(Vector3d(1.7, 1.8, 0.4)));
+
+	//Test if grid is set to zero outside of volume for clipVolume=true
+	EXPECT_NE(0, grid.get(0, 0, 12));
+	grid.setClipVolume(true);
+	double b = grid.interpolate(Vector3d(0, 0, 10));
+	EXPECT_EQ(0, b);
+}
+
+TEST(Grid1f, clipVolume) {
+	// Check volume clipping for gridproperties constructor
+	size_t N = 2;
+	Vector3d origin = Vector3d(0.);
+	double spacing = 2;
+	GridProperties properties(origin, N, spacing);
+	Grid1f grid(properties);
+	grid.get(0, 0, 0) = 1;
+	grid.get(0, 0, 1) = 2;
+	grid.get(0, 1, 0) = 3;
+	grid.get(0, 1, 1) = 4;
+	grid.get(1, 0, 0) = 5;
+	grid.get(1, 0, 1) = 6;
+	grid.get(1, 1, 0) = 7;
+	grid.get(1, 1, 1) = 8;
+
+	//Test if grid is set to zero outside of volume for clipVolume=true
+	EXPECT_NE(0, grid.get(0, 0, 12));
+	grid.setClipVolume(true);
+	double b = grid.interpolate(Vector3d(0, 0, 10));
+	EXPECT_EQ(0, b);
 }
 
 TEST(Grid3f, Interpolation) {
@@ -731,6 +766,13 @@ TEST(Grid3f, Periodicity) {
 	EXPECT_FLOAT_EQ(b.x, b2.x);
 	EXPECT_FLOAT_EQ(b.y, b2.y);
 	EXPECT_FLOAT_EQ(b.z, b2.z);
+
+	//Test if grid is set to zero outside of volume for clipVolume=true
+	grid.setClipVolume(true);
+	Vector3f b3 = grid.interpolate(pos + Vector3d(0, 0, -2) * size);
+	EXPECT_FLOAT_EQ(0., b3.x);
+	EXPECT_FLOAT_EQ(0., b3.y);
+	EXPECT_FLOAT_EQ(0., b3.z);
 }
 
 TEST(Grid3f, Reflectivity) {
@@ -807,6 +849,13 @@ TEST(Grid3f, Reflectivity) {
 	EXPECT_FLOAT_EQ(b.x, b2.x);
 	EXPECT_FLOAT_EQ(b.y, b2.y);
 	EXPECT_FLOAT_EQ(b.z, b2.z);
+
+	//Test if grid is set to zero outside of volume for clipVolume=true
+	grid.setClipVolume(true);
+	Vector3f b3 = grid.interpolate(pos + Vector3d(0, 0, -2) * size);
+	EXPECT_FLOAT_EQ(0., b3.x);
+	EXPECT_FLOAT_EQ(0., b3.y);
+	EXPECT_FLOAT_EQ(0., b3.z);
 }
 
 TEST(Grid3f, DumpLoad) {

--- a/test/testCore.cpp
+++ b/test/testCore.cpp
@@ -526,8 +526,6 @@ TEST(Grid1f, SimpleTest) {
 	//Test if grid is set to zero outside of volume for clipVolume=true
 	grid.setClipVolume(true);
 	EXPECT_EQ(0, grid.get(0, 0, 12));
-	EXPECT_EQ(0, grid.get(0, 0, 12));
-	EXPECT_EQ(0, grid.get(0, 0, 12));
 }
 
 TEST(Grid1f, GridPropertiesConstructor) {


### PR DESCRIPTION
This PR adds a default value for the volume clipping switch to the `GridProperties` module.

Context:
Creating a grid (e.g. `Grid3f`) is possible in different ways. Either grid properties can be defined as separate arguments or a GridProperties instance is used as a single argument for the Grid constructor. 
However, the handling to define the clipVolume value was different depending on the chosen constructor. This behavior is unified by this PR and defaults now to `clipVolume=false` for all Grid constructors. 

Issue:
Using the Grid constructor with the GridProperties argument led to a random initialization of the clipVolume variable.

Problem:
This might have led to an unnoticed effect, e.g. in turbulent magnetic field creation, where the field strength outside the original grid volume would have been set to zero. To see this problem, you can run the following code:
`from crpropa import *`
`randomSeed = 42`
`Brms=8*nG`
`lMin = 60*kpc`
`lMax=800*kpc`
`sIndex=5./3.`
`turbSpectrum = SimpleTurbulenceSpectrum(Brms, lMin, lMax, sIndex)`
`gridprops = GridProperties(Vector3d(0), 256, 30*kpc)`
`BField = SimpleGridTurbulence(turbSpectrum, gridprops, randomSeed)`
`R = Vector3d(10, 1, 5)*Mpc`
`BField.getField(R)`