### PR TITLE
Saldana-Lopez 2021 EBL model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * New interface for massdistributions given on a Grid1f
 * Grids can be restricted to the volume without repetition (clipVolume parameter)
 * SourceFeature to sample the source position from a given massdistribution
+* EBL model from Saldana-Lopez et al. 2021
 
 ### Interface changes:
 * Weight column in hdf-Output is now called "W", which is the same as for TextOutput.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,16 +336,18 @@ endif(APPLE)
 # Download data files (interaction data, masses, decay data ...)
 # ----------------------------------------------------------------------------
 OPTION(DOWNLOAD_DATA "Download CRPropa data files" ON)
-set(CRPROPA_DATAFILE_VER "2022-07-06")
+set(CRPROPA_DATAFILE_VER "2023-10-20")
 if(DOWNLOAD_DATA)
-  message("-- Downloading data file from crpropa.desy.de ~ 65 MB")
+  message("-- Downloading data file from crpropa.desy.de ~ 73 MB")
   file(DOWNLOAD
-    https://www.desy.de/~crpropa/data/interaction_data/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM
-    ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM)
+  https://ruhr-uni-bochum.sciebo.de/public.php/webdav/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM
+    ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM 
+    USERPWD "3juW9sntQX2IWBS")
   file(STRINGS ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM DATA_CHECKSUM LIMIT_COUNT 1 LENGTH_MINIMUM 32 LENGTH_MAXIMUM 32)
   file(DOWNLOAD
-    https://www.desy.de/~crpropa/data/interaction_data/data-${CRPROPA_DATAFILE_VER}.tar.gz
+  https://ruhr-uni-bochum.sciebo.de/public.php/webdav/data-${CRPROPA_DATAFILE_VER}.tar.gz
     ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz
+    USERPWD "3juW9sntQX2IWBS"
     EXPECTED_MD5 "${DATA_CHECKSUM}")
   message("-- Extracting data file")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,7 +338,7 @@ endif(APPLE)
 OPTION(DOWNLOAD_DATA "Download CRPropa data files" ON)
 set(CRPROPA_DATAFILE_VER "2023-10-20")
 if(DOWNLOAD_DATA)
-  message("-- Downloading data file from crpropa.desy.de ~ 73 MB")
+  message("-- Downloading data files from sciebo ~ 73 MB")
   file(DOWNLOAD
   https://ruhr-uni-bochum.sciebo.de/public.php/webdav/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM
     ${CMAKE_BINARY_DIR}/data-${CRPROPA_DATAFILE_VER}.tar.gz-CHECKSUM 

--- a/include/crpropa/PhotonBackground.h
+++ b/include/crpropa/PhotonBackground.h
@@ -71,7 +71,7 @@ protected:
 class TabularPhotonField: public PhotonField {
 public:
 	TabularPhotonField(const std::string fieldName, const bool isRedshiftDependent = true);
-	
+
 	double getPhotonDensity(double ePhoton, double z = 0.) const;
 	double getRedshiftScaling(double z) const;
 	double getMinimumPhotonEnergy(double z) const;
@@ -195,6 +195,45 @@ public:
 };
 
 /**
+ @class IRB_Saldana21
+ @brief Extragalactic background light model from Saldana-Lopez et al. 2021
+
+ Source info:
+ DOI:10.1093/mnras/stab2393
+ https://ui.adsabs.harvard.edu/abs/2021MNRAS.507.5144S/abstract
+ */
+class IRB_Saldana21: public TabularPhotonField {
+public:
+	IRB_Saldana21() : TabularPhotonField("IRB_Saldana21", true) {}
+};
+
+/**
+ @class IRB_Saldana21_upper
+ @brief Extragalactic background light model from Saldana-Lopez et al. 2021 (upper-bound model)
+
+ Source info:
+ DOI:10.1093/mnras/stab2393
+ https://ui.adsabs.harvard.edu/abs/2021MNRAS.507.5144S/abstract
+ */
+class IRB_Saldana21_upper: public TabularPhotonField {
+public:
+	IRB_Saldana21_upper() : TabularPhotonField("IRB_Saldana21_upper", true) {}
+};
+
+/**
+ @class IRB_Saldana21_lower
+ @brief Extragalactic background light model from Saldana-Lopez et al. 2021 (lower-bound model)
+
+ Source info:
+ DOI:10.1093/mnras/stab2393
+ https://ui.adsabs.harvard.edu/abs/2021MNRAS.507.5144S/abstract
+ */
+class IRB_Saldana21_lower: public TabularPhotonField {
+public:
+	IRB_Saldana21_lower() : TabularPhotonField("IRB_Saldana21_lower", true) {}
+};
+
+/**
  @class URB
  @brief Extragalactic background light model from Protheroe & Biermann 1996
 
@@ -210,11 +249,11 @@ public:
 /**
  @class URB
  @brief Extragalactic background light model based on ARCADE2 observations, by Fixsen et al.
- Note that this model does not cover the same energy range as other URB models. Here, only ~10 MHz - 10 GHz is considered. 
+ Note that this model does not cover the same energy range as other URB models. Here, only ~10 MHz - 10 GHz is considered.
  Therefore, it only makes sense to use this model in very specific studies.
-  
+
  Source info:
- DOI:10.1088/0004-637X/734/1/5 
+ DOI:10.1088/0004-637X/734/1/5
  https://iopscience.iop.org/article/10.1088/0004-637X/734/1/5
  */
 class URB_Fixsen11: public TabularPhotonField {
@@ -224,8 +263,8 @@ public:
 
 /**
  @class URB
- @brief Extragalactic background light model by Nitu et al. 
-  
+ @brief Extragalactic background light model by Nitu et al.
+
  Source info:
  DOI:10.1016/j.astropartphys.2020.102532
  https://www.sciencedirect.com/science/article/pii/S0927650520301043?


### PR DESCRIPTION
This PR adds the recent [Saldana-Lopez 2021](https://ui.adsabs.harvard.edu/abs/2021MNRAS.507.5144S/abstract) EBL model - along with its lower and upper limits - to CRPropa. The model data files are part of the [related PR](https://github.com/CRPropa/CRPropa3-data/pull/18) to the CRPropa-data repository.