### PR TITLE
remove candidate tag column from EventND output type

### DIFF
--- a/src/module/Output.cpp
+++ b/src/module/Output.cpp
@@ -43,13 +43,12 @@ void Output::setOutputType(OutputType outputtype) {
 		set(CurrentEnergyColumn, true);
 		set1D(true);
 	} else if (outputtype == Event1D) {
-		// D, ID, E, ID0, E0, tag
+		// D, ID, E, ID0, E0
 		set(TrajectoryLengthColumn, true);
 		set(CurrentIdColumn, true);
 		set(CurrentEnergyColumn, true);
 		set(SourceIdColumn, true);
 		set(SourceEnergyColumn, true);
-		set(CandidateTagColumn, true);
 		set1D(true);
 	} else if (outputtype == Trajectory3D) {
 		// D, ID, E, X, Y, Z, Px, Py, Pz
@@ -60,7 +59,7 @@ void Output::setOutputType(OutputType outputtype) {
 		set(CurrentDirectionColumn, true);
 		set1D(false);
 	} else if (outputtype == Event3D) {
-		// D, ID, E, X, Y, Z, Px, Py, Pz, ID0, E0, X0, Y0, Z0, P0x, P0y, P0z, tag
+		// D, ID, E, X, Y, Z, Px, Py, Pz, ID0, E0, X0, Y0, Z0, P0x, P0y, P0z
 		set(TrajectoryLengthColumn, true);
 		set(CurrentIdColumn, true);
 		set(CurrentEnergyColumn, true);
@@ -70,7 +69,6 @@ void Output::setOutputType(OutputType outputtype) {
 		set(SourceEnergyColumn, true);
 		set(SourcePositionColumn, true);
 		set(SourceDirectionColumn, true);
-		set(CandidateTagColumn, true);
 		set1D(false);
 	} else if (outputtype == Everything) {
 		enableAll();

--- a/test/testOutput.cpp
+++ b/test/testOutput.cpp
@@ -64,7 +64,7 @@ TEST(TextOutput, printHeader_Event1D) {
 	output.process(&c);
 	std::string captured = testing::internal::GetCapturedStdout();
 
-	EXPECT_EQ(captured.substr(0, captured.find("\n")), "#\tD\tID\tE\tID0\tE0\ttag");
+	EXPECT_EQ(captured.substr(0, captured.find("\n")), "#\tD\tID\tE\tID0\tE0");
 }
 
 TEST(TextOutput, printHeader_Trajectory3D) {
@@ -89,7 +89,7 @@ TEST(TextOutput, printHeader_Event3D) {
 
 	EXPECT_EQ(
 	    captured.substr(0, captured.find("\n")),
-	    "#\tD\tID\tE\tX\tY\tZ\tPx\tPy\tPz\tID0\tE0\tX0\tY0\tZ0\tP0x\tP0y\tP0z\ttag");
+	    "#\tD\tID\tE\tX\tY\tZ\tPx\tPy\tPz\tID0\tE0\tX0\tY0\tZ0\tP0x\tP0y\tP0z");
 }
 
 TEST(TextOutput, printHeader_Custom) {
@@ -99,6 +99,7 @@ TEST(TextOutput, printHeader_Custom) {
 	output.enable(Output::SerialNumberColumn);
 	output.disable(Output::TrajectoryLengthColumn);
 	output.set(Output::RedshiftColumn, false);
+	output.enable(Output::CandidateTagColumn);
 
 	::testing::internal::CaptureStdout();
 	output.process(&c);


### PR DESCRIPTION
as discussed in #428 the `CandidateTagColumn` should not be part of the `EventND` Output fortmat. 

I added the tag for the `printHeader_custom` test of the textoutput, to have at least one test including the column. 

