### PR TITLE
Candidate Splitting module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,7 @@ add_library(crpropa SHARED
   src/module/Acceleration.cpp
   src/module/Boundary.cpp
   src/module/BreakCondition.cpp
+  src/module/CandidateSplitting.cpp
   src/module/DiffusionSDE.cpp
   src/module/EMCascade.cpp
   src/module/EMDoublePairProduction.cpp
@@ -655,6 +656,10 @@ if(ENABLE_TESTING)
   add_executable(testAdiabaticCooling test/testAdiabaticCooling.cpp)
   target_link_libraries(testAdiabaticCooling crpropa gtest gtest_main pthread ${COVERAGE_LIBS})
   add_test(testAdiabaticCooling testAdiabaticCooling)
+
+  add_executable(testCandidateSplitting test/testCandidateSplitting.cpp)
+  target_link_libraries(testCandidateSplitting crpropa gtest gtest_main pthread ${COVERAGE_LIBS})
+  add_test(testCandidateSplitting testCandidateSplitting)
 
 
   if(WITH_GALACTIC_LENSES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,7 +661,6 @@ if(ENABLE_TESTING)
   target_link_libraries(testCandidateSplitting crpropa gtest gtest_main pthread ${COVERAGE_LIBS})
   add_test(testCandidateSplitting testCandidateSplitting)
 
-
   if(WITH_GALACTIC_LENSES)
     add_executable(testGalacticMagneticLens test/testMagneticLens.cpp)
     target_link_libraries(testGalacticMagneticLens crpropa gtest gtest_main pthread ${COVERAGE_LIBS})

--- a/include/CRPropa.h
+++ b/include/CRPropa.h
@@ -29,6 +29,7 @@
 #include "crpropa/module/Acceleration.h"
 #include "crpropa/module/Boundary.h"
 #include "crpropa/module/BreakCondition.h"
+#include "crpropa/module/CandidateSplitting.h"
 #include "crpropa/module/DiffusionSDE.h"
 #include "crpropa/module/EMCascade.h"
 #include "crpropa/module/EMDoublePairProduction.h"

--- a/include/crpropa/module/CandidateSplitting.h
+++ b/include/crpropa/module/CandidateSplitting.h
@@ -35,20 +35,11 @@ public:
 	 @param nSplit 	Number of copies candidates are split 
 	 @param Emin 		Minimal energy for splitting
 	 @param Emax		Maximal energy for splitting
-	 @param minWeight   Mimimal Weight
-	 @param nBins		Number of energy bins 
-	 */
-	CandidateSplitting(int nSplit, double Emin, double Emax, double nBins, double minWeight);
-	
-	/** Constructor
-	 @param nSplit 	Number of copies candidates are split 
-	 @param Emin 		Minimal energy for splitting
-	 @param Emax		Maximal energy for splitting
 	 @param nBins		Number of energy bins 
 	 @param minWeight   Mimimal Weight
 	 @param log 		Energy bins in log
 	 */
-	CandidateSplitting(int nSplit, double Emin, double Emax, double nBins, double minWeight, bool log);
+	CandidateSplitting(int nSplit, double Emin, double Emax, double nBins, double minWeight, bool log = false);
 	
 	/** Constructor
 	 @param spectralIndex    Absolute value of expected spectral index determines splitting number 

--- a/include/crpropa/module/CandidateSplitting.h
+++ b/include/crpropa/module/CandidateSplitting.h
@@ -17,14 +17,13 @@ namespace crpropa {
 
 /**
 @class CandidateSplitting
-@brief Candidates are split into n copies when they cross specified energy bins. Weights are set accordingly.
+@brief Candidates are split into n copies when they gain energy and cross specified energy bins. Weights are set accordingly.
 		In case of Diffusice Shock Acceleration, splitting number can be adapted to expected spectral index to 
 		compensate for the loss of particles per magnitude in energy
 */
-
 class CandidateSplitting: public Module {
 private:
-	double n_split;
+	double nSplit;
 	double minWeight;
 	std::vector<double> Ebins;
 
@@ -32,34 +31,35 @@ public:
 
 	CandidateSplitting();
 	
-	CandidateSplitting(int n_split, double Emin, double Emax, double n_bins, double minWeight);
 	/** Constructor
-	 @param n_split 	Number of copies candidates are split 
+	 @param nSplit 	Number of copies candidates are split 
 	 @param Emin 		Minimal energy for splitting
 	 @param Emax		Maximal energy for splitting
 	 @param minWeight   Mimimal Weight
-	 @param n_bins		Number of energy bins 
+	 @param nBins		Number of energy bins 
 	 */
-	CandidateSplitting(int n_split, double Emin, double Emax, double n_bins, double minWeight, bool log);
+	CandidateSplitting(int nSplit, double Emin, double Emax, double nBins, double minWeight);
+	
 	/** Constructor
-	 @param n_split 	Number of copies candidates are split 
+	 @param nSplit 	Number of copies candidates are split 
 	 @param Emin 		Minimal energy for splitting
 	 @param Emax		Maximal energy for splitting
-	 @param n_bins		Number of energy bins 
+	 @param nBins		Number of energy bins 
 	 @param minWeight   Mimimal Weight
 	 @param log 		Energy bins in log
 	 */
-
-	CandidateSplitting(double SpectralIndex, double Emin, int nBins);
+	CandidateSplitting(int nSplit, double Emin, double Emax, double nBins, double minWeight, bool log);
+	
 	/** Constructor
-	 @param SpectralIndex    Absolute value of expected spectral index determines splitting number 
+	 @param spectralIndex    Absolute value of expected spectral index determines splitting number 
 	 @param Emin 			 Minimal energy for splitting
 	 @param nBins            Number of bins in energy, with dE(spectralIndex) it determines Emax 
 	 */
+	CandidateSplitting(double spectralIndex, double Emin, int nBins);
 
 	void process(Candidate *c) const;
 
-	void setEnergyBins(double Emin, double Emax, double n_bins, bool log);
+	void setEnergyBins(double Emin, double Emax, double nBins, bool log);
 
 	void setEnergyBinsDSA(double Emin, double dE, int n);
 
@@ -77,4 +77,4 @@ public:
 /** @}*/
 
 } // namespace crpropa
-#endif // CRPROPA_PARTICLESPLITTING_H
+#endif // CRPROPA_CANDIDATESPLITTING_H

--- a/include/crpropa/module/CandidateSplitting.h
+++ b/include/crpropa/module/CandidateSplitting.h
@@ -1,0 +1,80 @@
+#ifndef CRPROPA_CANDIDATEPLITTING_H
+#define CRPROPA_CANDIDATEPLITTING_H
+
+#include <string>
+#include <iostream>
+#include <cmath>
+#include <cstdlib>
+#include <sstream>
+
+#include "crpropa/Vector3.h"
+#include "crpropa/Module.h"
+#include "crpropa/Units.h"
+#include "kiss/logger.h"
+
+
+namespace crpropa {
+
+/**
+@class CandidateSplitting
+@brief Candidates are split into n copies when they cross specified energy bins. Weights are set accordingly.
+		In case of Diffusice Shock Acceleration, splitting number can be adapted to expected spectral index to 
+		compensate for the loss of particles per magnitude in energy
+*/
+
+class CandidateSplitting: public Module {
+private:
+	double n_split;
+	double minWeight;
+	std::vector<double> Ebins;
+
+public:
+
+	CandidateSplitting();
+	
+	CandidateSplitting(int n_split, double Emin, double Emax, double n_bins, double minWeight);
+	/** Constructor
+	 @param n_split 	Number of copies candidates are split 
+	 @param Emin 		Minimal energy for splitting
+	 @param Emax		Maximal energy for splitting
+	 @param minWeight   Mimimal Weight
+	 @param n_bins		Number of energy bins 
+	 */
+	CandidateSplitting(int n_split, double Emin, double Emax, double n_bins, double minWeight, bool log);
+	/** Constructor
+	 @param n_split 	Number of copies candidates are split 
+	 @param Emin 		Minimal energy for splitting
+	 @param Emax		Maximal energy for splitting
+	 @param n_bins		Number of energy bins 
+	 @param minWeight   Mimimal Weight
+	 @param log 		Energy bins in log
+	 */
+
+	CandidateSplitting(double SpectralIndex, double Emin, int nBins);
+	/** Constructor
+	 @param SpectralIndex    Absolute value of expected spectral index determines splitting number 
+	 @param Emin 			 Minimal energy for splitting
+	 @param nBins            Number of bins in energy, with dE(spectralIndex) it determines Emax 
+	 */
+
+	void process(Candidate *c) const;
+
+	void setEnergyBins(double Emin, double Emax, double n_bins, bool log);
+
+	void setEnergyBinsDSA(double Emin, double dE, int n);
+
+	void setNsplit(int n);
+
+	void setMinimalWeight(double w);
+
+	int getNsplit() const;
+
+	double getMinimalWeight() const;
+
+	const std::vector<double>& getEnergyBins() const;
+
+};
+/** @}*/
+
+} // namespace crpropa
+#endif // CRPROPA_PARTICLESPLITTING_H

--- a/include/crpropa/module/CandidateSplitting.h
+++ b/include/crpropa/module/CandidateSplitting.h
@@ -14,6 +14,9 @@
 
 
 namespace crpropa {
+/** @addtogroup Acceleration
+*  @{
+ */
 
 /**
 @class CandidateSplitting
@@ -42,7 +45,7 @@ public:
 	CandidateSplitting(int nSplit, double Emin, double Emax, double nBins, double minWeight, bool log = false);
 	
 	/** Constructor
-	 @param spectralIndex    Absolute value of expected spectral index determines splitting number 
+	 @param spectralIndex    Expected spectral index determines splitting numbe
 	 @param Emin 			 Minimal energy for splitting
 	 @param nBins            Number of bins in energy, with dE(spectralIndex) it determines Emax 
 	 */

--- a/python/2_headers.i
+++ b/python/2_headers.i
@@ -564,6 +564,7 @@ using namespace crpropa;   // for usage of namespace in header files, necessary
 %include "crpropa/module/EMInverseComptonScattering.h"
 %include "crpropa/module/SynchrotronRadiation.h"
 %include "crpropa/module/AdiabaticCooling.h"
+%include "crpropa/module/CandidateSplitting.h"
 
 %template(IntSet) std::set<int>;
 %include "crpropa/module/Tools.h"

--- a/src/module/CandidateSplitting.cpp
+++ b/src/module/CandidateSplitting.cpp
@@ -1,0 +1,154 @@
+#include "crpropa/module/CandidateSplitting.h"
+
+namespace crpropa {
+
+CandidateSplitting::CandidateSplitting() {
+	// no particle splitting if EnergyBins and NSplit are not specified
+	setNsplit(0);
+	setMinimalWeight(1.);
+}
+
+CandidateSplitting::CandidateSplitting(int n_split, double Emin, double Emax, double n_bins, double minWeight) {
+	// linear energy bins:
+	setNsplit(n_split);
+	setEnergyBins(Emin, Emax, n_bins, false);
+	setMinimalWeight(minWeight);
+}
+
+CandidateSplitting::CandidateSplitting(int n_split, double Emin, double Emax,  double n_bins, double minWeight, bool log) {
+	setNsplit(n_split);
+	setEnergyBins(Emin, Emax, n_bins, log);
+	setMinimalWeight(minWeight);
+}
+
+CandidateSplitting::CandidateSplitting(double SpectralIndex, double Emin, int nBins)  {
+	// to use with Diffusive Shock Acceleration
+
+	if (SpectralIndex <= 0){
+		throw std::runtime_error(
+				"CandidateSplitting: spectralIndex <= 0 !");
+	}
+
+	setNsplit(2); // always split in 2, calculate bins in energy for given spectrum:
+	double dE = pow(1./2, 1./(-SpectralIndex + 1)); 
+	setEnergyBinsDSA(Emin, dE, nBins);
+	setMinimalWeight(1./pow(2, nBins));
+
+}
+
+
+void CandidateSplitting::process(Candidate *c) const {
+
+	double currE = c->current.getEnergy(); 
+	double prevE = c->previous.getEnergy();
+
+	if (c->getWeight() <= minWeight){
+		// minimal weight reached, no splitting
+		return;
+	}
+	if (currE < Ebins[0] || n_split == 0 ){
+		// current energy is smaller than first bin -> no splitting
+		// or, number of splits = 0
+		return;
+	}
+	for (size_t i = 0; i < Ebins.size(); ++i){
+		
+		if( prevE < Ebins[i] ){
+			// previous energy is in energy bin [i-1, i]
+			if(currE < Ebins[i]){
+				//assuming that dE greater than 0, prevE and E in same energy bin -> no splitting
+				return;
+			}
+			// current energy is in energy bin [i,i+1] or higher -> particle splitting for each crossing
+			for (size_t j = i; j < Ebins.size(); ++j ){
+
+				// adapted from Acceleration Module:
+				c->updateWeight(1. / n_split); // * 1/n_split
+
+				for (int i = 1; i < n_split; i++) {
+				
+					ref_ptr<Candidate> new_candidate = c->clone(false);
+					new_candidate->parent = c;
+					uint64_t snr = Candidate::getNextSerialNumber();
+					new_candidate->setSerialNumber(snr);
+					new_candidate->previous.setEnergy(currE); // so that new candidate is not split again in next step!
+					//InteractionTag is PRIM, physically no new particles are created
+					c->addSecondary(new_candidate);
+					Candidate::setNextSerialNumber(snr + 1);
+				}
+
+
+				if (j < Ebins.size()-1 && currE < Ebins[j+1]){
+					// candidate is in energy bin [j, j+1] -> no further splitting
+					return;
+				}
+			}
+
+			return;
+
+		}
+	}
+}
+	
+
+void CandidateSplitting::setEnergyBins(double Emin, double Emax, double n_bins, bool log) {
+
+	Ebins.resize(0);
+
+	if (Emin > Emax){
+		throw std::runtime_error(
+				"CandidateSplitting: Emin > Emax!");
+	}
+
+	double dE = (Emax-Emin)/n_bins;
+	
+	for (size_t i = 0; i < n_bins; ++i) {
+		if (log == true) {
+			Ebins.push_back(Emin * pow(Emax / Emin, i / (n_bins - 1.0)));
+		} else {
+			Ebins.push_back(Emin + i * dE);
+		}
+	}
+
+}
+
+
+void CandidateSplitting::setEnergyBinsDSA(double Emin, double dE, int n) {
+
+	Ebins.resize(0);
+	
+	for (size_t i = 1; i < n + 1; ++i) {
+	
+		Ebins.push_back(Emin * pow(dE, i));
+	}
+
+}
+
+
+const std::vector<double>& CandidateSplitting::getEnergyBins() const {
+	return Ebins;
+}
+
+void CandidateSplitting::setNsplit(int n) {
+
+	n_split = n;
+}
+
+void CandidateSplitting::setMinimalWeight(double w) {
+
+	minWeight = w;
+}
+
+int CandidateSplitting::getNsplit() const {
+
+	return n_split;
+}
+
+double CandidateSplitting::getMinimalWeight() const {
+
+	return minWeight;
+}
+
+
+} // end namespace crpropa
+

--- a/src/module/CandidateSplitting.cpp
+++ b/src/module/CandidateSplitting.cpp
@@ -8,13 +8,6 @@ CandidateSplitting::CandidateSplitting() {
 	setMinimalWeight(1.);
 }
 
-CandidateSplitting::CandidateSplitting(int nSplit, double Emin, double Emax, double nBins, double minWeight) {
-	// linear energy bins:
-	setNsplit(nSplit);
-	setEnergyBins(Emin, Emax, nBins, false);
-	setMinimalWeight(minWeight);
-}
-
 CandidateSplitting::CandidateSplitting(int nSplit, double Emin, double Emax,  double nBins, double minWeight, bool log) {
 	setNsplit(nSplit);
 	setEnergyBins(Emin, Emax, nBins, log);
@@ -23,13 +16,13 @@ CandidateSplitting::CandidateSplitting(int nSplit, double Emin, double Emax,  do
 
 CandidateSplitting::CandidateSplitting(double spectralIndex, double Emin, int nBins)  {
 	// to use with Diffusive Shock Acceleration
-	if (spectralIndex <= 0){
+	if (spectralIndex > 0){
 		throw std::runtime_error(
-				"CandidateSplitting: spectralIndex <= 0 !");
+				"CandidateSplitting: spectralIndex > 0 !"); 
 	}
 
 	setNsplit(2); // always split in 2, calculate bins in energy for given spectrum:
-	double dE = pow(1. / 2, 1. / (-spectralIndex + 1)); 
+	double dE = pow(1. / 2, 1. / (spectralIndex + 1)); 
 	setEnergyBinsDSA(Emin, dE, nBins);
 	setMinimalWeight(1. / pow(2, nBins));
 }

--- a/src/module/CandidateSplitting.cpp
+++ b/src/module/CandidateSplitting.cpp
@@ -8,37 +8,33 @@ CandidateSplitting::CandidateSplitting() {
 	setMinimalWeight(1.);
 }
 
-CandidateSplitting::CandidateSplitting(int n_split, double Emin, double Emax, double n_bins, double minWeight) {
+CandidateSplitting::CandidateSplitting(int nSplit, double Emin, double Emax, double nBins, double minWeight) {
 	// linear energy bins:
-	setNsplit(n_split);
-	setEnergyBins(Emin, Emax, n_bins, false);
+	setNsplit(nSplit);
+	setEnergyBins(Emin, Emax, nBins, false);
 	setMinimalWeight(minWeight);
 }
 
-CandidateSplitting::CandidateSplitting(int n_split, double Emin, double Emax,  double n_bins, double minWeight, bool log) {
-	setNsplit(n_split);
-	setEnergyBins(Emin, Emax, n_bins, log);
+CandidateSplitting::CandidateSplitting(int nSplit, double Emin, double Emax,  double nBins, double minWeight, bool log) {
+	setNsplit(nSplit);
+	setEnergyBins(Emin, Emax, nBins, log);
 	setMinimalWeight(minWeight);
 }
 
-CandidateSplitting::CandidateSplitting(double SpectralIndex, double Emin, int nBins)  {
+CandidateSplitting::CandidateSplitting(double spectralIndex, double Emin, int nBins)  {
 	// to use with Diffusive Shock Acceleration
-
-	if (SpectralIndex <= 0){
+	if (spectralIndex <= 0){
 		throw std::runtime_error(
 				"CandidateSplitting: spectralIndex <= 0 !");
 	}
 
 	setNsplit(2); // always split in 2, calculate bins in energy for given spectrum:
-	double dE = pow(1./2, 1./(-SpectralIndex + 1)); 
+	double dE = pow(1. / 2, 1. / (-spectralIndex + 1)); 
 	setEnergyBinsDSA(Emin, dE, nBins);
-	setMinimalWeight(1./pow(2, nBins));
-
+	setMinimalWeight(1. / pow(2, nBins));
 }
 
-
 void CandidateSplitting::process(Candidate *c) const {
-
 	double currE = c->current.getEnergy(); 
 	double prevE = c->previous.getEnergy();
 
@@ -46,7 +42,7 @@ void CandidateSplitting::process(Candidate *c) const {
 		// minimal weight reached, no splitting
 		return;
 	}
-	if (currE < Ebins[0] || n_split == 0 ){
+	if (currE < Ebins[0] || nSplit == 0 ){
 		// current energy is smaller than first bin -> no splitting
 		// or, number of splits = 0
 		return;
@@ -63,9 +59,9 @@ void CandidateSplitting::process(Candidate *c) const {
 			for (size_t j = i; j < Ebins.size(); ++j ){
 
 				// adapted from Acceleration Module:
-				c->updateWeight(1. / n_split); // * 1/n_split
+				c->updateWeight(1. / nSplit); // * 1/n_split
 
-				for (int i = 1; i < n_split; i++) {
+				for (int i = 1; i < nSplit; i++) {
 				
 					ref_ptr<Candidate> new_candidate = c->clone(false);
 					new_candidate->parent = c;
@@ -76,79 +72,58 @@ void CandidateSplitting::process(Candidate *c) const {
 					c->addSecondary(new_candidate);
 					Candidate::setNextSerialNumber(snr + 1);
 				}
-
-
 				if (j < Ebins.size()-1 && currE < Ebins[j+1]){
 					// candidate is in energy bin [j, j+1] -> no further splitting
 					return;
 				}
 			}
-
 			return;
-
 		}
 	}
 }
-	
 
-void CandidateSplitting::setEnergyBins(double Emin, double Emax, double n_bins, bool log) {
-
+void CandidateSplitting::setEnergyBins(double Emin, double Emax, double nBins, bool log) {
 	Ebins.resize(0);
-
 	if (Emin > Emax){
 		throw std::runtime_error(
 				"CandidateSplitting: Emin > Emax!");
 	}
-
-	double dE = (Emax-Emin)/n_bins;
-	
-	for (size_t i = 0; i < n_bins; ++i) {
+	double dE = (Emax-Emin)/nBins;
+	for (size_t i = 0; i < nBins; ++i) {
 		if (log == true) {
-			Ebins.push_back(Emin * pow(Emax / Emin, i / (n_bins - 1.0)));
+			Ebins.push_back(Emin * pow(Emax / Emin, i / (nBins - 1.0)));
 		} else {
 			Ebins.push_back(Emin + i * dE);
 		}
 	}
-
 }
-
 
 void CandidateSplitting::setEnergyBinsDSA(double Emin, double dE, int n) {
-
 	Ebins.resize(0);
-	
 	for (size_t i = 1; i < n + 1; ++i) {
-	
 		Ebins.push_back(Emin * pow(dE, i));
 	}
-
 }
-
 
 const std::vector<double>& CandidateSplitting::getEnergyBins() const {
 	return Ebins;
 }
 
 void CandidateSplitting::setNsplit(int n) {
-
-	n_split = n;
+	nSplit = n;
 }
 
 void CandidateSplitting::setMinimalWeight(double w) {
-
 	minWeight = w;
 }
 
 int CandidateSplitting::getNsplit() const {
-
-	return n_split;
+	return nSplit;
 }
 
 double CandidateSplitting::getMinimalWeight() const {
-
 	return minWeight;
 }
-
 
 } // end namespace crpropa
 

--- a/src/module/CandidateSplitting.cpp
+++ b/src/module/CandidateSplitting.cpp
@@ -64,13 +64,9 @@ void CandidateSplitting::process(Candidate *c) const {
 				for (int i = 1; i < nSplit; i++) {
 				
 					ref_ptr<Candidate> new_candidate = c->clone(false);
-					new_candidate->parent = c;
-					uint64_t snr = Candidate::getNextSerialNumber();
-					new_candidate->setSerialNumber(snr);
-					new_candidate->previous.setEnergy(currE); // so that new candidate is not split again in next step!
 					//InteractionTag is PRIM, physically no new particles are created
-					c->addSecondary(new_candidate);
-					Candidate::setNextSerialNumber(snr + 1);
+					new_candidate->parent = c;
+					new_candidate->previous.setEnergy(currE); // so that new candidate is not split again in next step!
 				}
 				if (j < Ebins.size()-1 && currE < Ebins[j+1]){
 					// candidate is in energy bin [j, j+1] -> no further splitting

--- a/test/testCandidateSplitting.cpp
+++ b/test/testCandidateSplitting.cpp
@@ -10,46 +10,41 @@
 namespace crpropa {
 
 TEST(testCandidateSplitting, SimpleTest) {
-
-
-	int n_split = 2;
-	int n_bins = 4;
-	double minWeight = pow(1./n_split, 2);
+	int nSplit = 2;
+	int nBins = 4;
+	double minWeight = pow(1. / nSplit, 2);
 	double Emin = 1*GeV;
 	double Emax = 10*GeV; 	
 
-	CandidateSplitting split_lin(n_split, Emin, Emax, n_bins, minWeight);
-	double dE = (Emax-Emin)/n_bins;
+	CandidateSplitting split_lin(nSplit, Emin, Emax, nBins, minWeight);
+	double dE = (Emax-Emin)/nBins;
 	EXPECT_DOUBLE_EQ(split_lin.getEnergyBins()[0], Emin);
 	EXPECT_DOUBLE_EQ(split_lin.getEnergyBins()[1], Emin+dE);
 
-	EXPECT_EQ(split_lin.getNsplit(), n_split);
+	EXPECT_EQ(split_lin.getNsplit(), nSplit);
 	EXPECT_DOUBLE_EQ(split_lin.getMinimalWeight(), minWeight);
 
-	CandidateSplitting split_log(n_split, Emin, Emax, n_bins, minWeight, true);
-	double dE_log = pow(Emax / Emin, 1./(n_bins - 1.0));
+	CandidateSplitting split_log(nSplit, Emin, Emax, nBins, minWeight, true);
+	double dE_log = pow(Emax / Emin, 1. / (nBins - 1.0));
 	EXPECT_DOUBLE_EQ(split_log.getEnergyBins()[0], Emin);
 	EXPECT_DOUBLE_EQ(split_log.getEnergyBins()[1], Emin*dE_log);
 
 	double spectralIndex = 2.;
-	CandidateSplitting split_dsa(spectralIndex, Emin, n_bins);
-	double dE_dsa = pow(1./2, 1./(-spectralIndex + 1));
+	CandidateSplitting split_dsa(spectralIndex, Emin, nBins);
+	double dE_dsa = pow(1. / 2, 1. / (-spectralIndex + 1));
 	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[0], Emin*dE_dsa);
-	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[n_bins-1], Emin * pow(dE_dsa, n_bins));
-
-
+	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[nBins-1], Emin * pow(dE_dsa, nBins));
 }
 
 
 TEST(testCandidateSplitting, CheckSplits) {
-
-	int n_split = 2;
-	int n_bins = 3;
+	int nSplit = 2;
+	int nBins = 3;
 	double Emin = 1*GeV;
 	double Emax = 10*GeV;
-	double minWeight = pow(1./n_split, 4);
+	double minWeight = pow(1. / nSplit, 4);
 
-	CandidateSplitting splitting(n_split, Emin, Emax, n_bins, minWeight);
+	CandidateSplitting splitting(nSplit, Emin, Emax, nBins, minWeight);
 	Candidate c(nucleusId(1,1),0.5*GeV);
 	double weight = 1.0;
 	
@@ -58,13 +53,13 @@ TEST(testCandidateSplitting, CheckSplits) {
 
 	c.current.setEnergy(2*GeV); 
 	splitting.process(&c); // 1. split
-	weight = weight/n_split;
+	weight = weight/nSplit;
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
 	c.previous.setEnergy(2*GeV);
 
 	c.current.setEnergy(6*GeV); 
 	splitting.process(&c); // 2. split
-	weight = weight/n_split;
+	weight = weight/nSplit;
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
 	c.previous.setEnergy(6*GeV);
 
@@ -75,7 +70,7 @@ TEST(testCandidateSplitting, CheckSplits) {
 
 	c.current.setEnergy(6*GeV); 
 	splitting.process(&c); // 3. & 4. split, crosses two boundaries
-	weight = weight/n_split/n_split;
+	weight = weight/nSplit/nSplit;
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
 	c.previous.setEnergy(6*GeV);
 
@@ -83,8 +78,6 @@ TEST(testCandidateSplitting, CheckSplits) {
 	splitting.process(&c); // no split, minimal weight reached
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
 	c.previous.setEnergy(8*GeV);
-
 }
-
 
 } //namespace crpropa

--- a/test/testCandidateSplitting.cpp
+++ b/test/testCandidateSplitting.cpp
@@ -40,44 +40,51 @@ TEST(testCandidateSplitting, SimpleTest) {
 TEST(testCandidateSplitting, CheckSplits) {
 	int nSplit = 2;
 	int nBins = 3;
-	double Emin = 1*GeV;
-	double Emax = 10*GeV;
+	double Emin = 1; // dimensionless for testing
+	double Emax = 10;
 	double minWeight = pow(1. / nSplit, 4);
 
 	CandidateSplitting splitting(nSplit, Emin, Emax, nBins, minWeight);
-	Candidate c(nucleusId(1,1),0.5*GeV);
+	Candidate c(nucleusId(1,1),0.5);
 	double weight = 1.0;
+	double serial = c.getSerialNumber();
 	
 	splitting.process(&c); // no split
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
+	EXPECT_DOUBLE_EQ(c.getNextSerialNumber(), serial);
 
-	c.current.setEnergy(2*GeV); 
+	c.current.setEnergy(2); 
 	splitting.process(&c); // 1. split
 	weight = weight/nSplit;
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
-	c.previous.setEnergy(2*GeV);
+	EXPECT_DOUBLE_EQ(c.getNextSerialNumber(), serial + 1);
+	c.previous.setEnergy(2);
 
-	c.current.setEnergy(6*GeV); 
+	c.current.setEnergy(6); 
 	splitting.process(&c); // 2. split
 	weight = weight/nSplit;
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
-	c.previous.setEnergy(6*GeV);
+	EXPECT_DOUBLE_EQ(c.getNextSerialNumber(), serial + 2);
+	c.previous.setEnergy(6);
 
-	c.current.setEnergy(0.5*GeV); 
+	c.current.setEnergy(0.5); 
 	splitting.process(&c); // no split, cooling
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
-	c.previous.setEnergy(0.5*GeV);
+	EXPECT_DOUBLE_EQ(c.getNextSerialNumber(), serial + 2);
+	c.previous.setEnergy(0.5);
 
-	c.current.setEnergy(6*GeV); 
+	c.current.setEnergy(6); 
 	splitting.process(&c); // 3. & 4. split, crosses two boundaries
 	weight = weight/nSplit/nSplit;
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
-	c.previous.setEnergy(6*GeV);
+	EXPECT_DOUBLE_EQ(c.getNextSerialNumber(), serial + 4);
+	c.previous.setEnergy(6);
 
-	c.current.setEnergy(8*GeV); 
+	c.current.setEnergy(8); 
 	splitting.process(&c); // no split, minimal weight reached
 	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
-	c.previous.setEnergy(8*GeV);
+	EXPECT_DOUBLE_EQ(c.getNextSerialNumber(), serial + 4);
+	c.previous.setEnergy(8);
 }
 
 } //namespace crpropa

--- a/test/testCandidateSplitting.cpp
+++ b/test/testCandidateSplitting.cpp
@@ -1,0 +1,90 @@
+#include "crpropa/Units.h"
+#include "crpropa/Common.h"
+#include "crpropa/ParticleID.h"
+#include "crpropa/module/CandidateSplitting.h"
+
+#include "gtest/gtest.h"
+#include <stdexcept>
+#include <cmath>
+
+namespace crpropa {
+
+TEST(testCandidateSplitting, SimpleTest) {
+
+
+	int n_split = 2;
+	int n_bins = 4;
+	double minWeight = pow(1./n_split, 2);
+	double Emin = 1*GeV;
+	double Emax = 10*GeV; 	
+
+	CandidateSplitting split_lin(n_split, Emin, Emax, n_bins, minWeight);
+	double dE = (Emax-Emin)/n_bins;
+	EXPECT_DOUBLE_EQ(split_lin.getEnergyBins()[0], Emin);
+	EXPECT_DOUBLE_EQ(split_lin.getEnergyBins()[1], Emin+dE);
+
+	EXPECT_EQ(split_lin.getNsplit(), n_split);
+	EXPECT_DOUBLE_EQ(split_lin.getMinimalWeight(), minWeight);
+
+	CandidateSplitting split_log(n_split, Emin, Emax, n_bins, minWeight, true);
+	double dE_log = pow(Emax / Emin, 1./(n_bins - 1.0));
+	EXPECT_DOUBLE_EQ(split_log.getEnergyBins()[0], Emin);
+	EXPECT_DOUBLE_EQ(split_log.getEnergyBins()[1], Emin*dE_log);
+
+	double spectralIndex = 2.;
+	CandidateSplitting split_dsa(spectralIndex, Emin, n_bins);
+	double dE_dsa = pow(1./2, 1./(-spectralIndex + 1));
+	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[0], Emin*dE_dsa);
+	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[n_bins-1], Emin * pow(dE_dsa, n_bins));
+
+
+}
+
+
+TEST(testCandidateSplitting, CheckSplits) {
+
+	int n_split = 2;
+	int n_bins = 3;
+	double Emin = 1*GeV;
+	double Emax = 10*GeV;
+	double minWeight = pow(1./n_split, 4);
+
+	CandidateSplitting splitting(n_split, Emin, Emax, n_bins, minWeight);
+	Candidate c(nucleusId(1,1),0.5*GeV);
+	double weight = 1.0;
+	
+	splitting.process(&c); // no split
+	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
+
+	c.current.setEnergy(2*GeV); 
+	splitting.process(&c); // 1. split
+	weight = weight/n_split;
+	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
+	c.previous.setEnergy(2*GeV);
+
+	c.current.setEnergy(6*GeV); 
+	splitting.process(&c); // 2. split
+	weight = weight/n_split;
+	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
+	c.previous.setEnergy(6*GeV);
+
+	c.current.setEnergy(0.5*GeV); 
+	splitting.process(&c); // no split, cooling
+	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
+	c.previous.setEnergy(0.5*GeV);
+
+	c.current.setEnergy(6*GeV); 
+	splitting.process(&c); // 3. & 4. split, crosses two boundaries
+	weight = weight/n_split/n_split;
+	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
+	c.previous.setEnergy(6*GeV);
+
+	c.current.setEnergy(8*GeV); 
+	splitting.process(&c); // no split, minimal weight reached
+	EXPECT_DOUBLE_EQ(c.getWeight(), weight);
+	c.previous.setEnergy(8*GeV);
+
+}
+
+
+} //namespace crpropa

--- a/test/testCandidateSplitting.cpp
+++ b/test/testCandidateSplitting.cpp
@@ -13,13 +13,13 @@ TEST(testCandidateSplitting, SimpleTest) {
 	int nSplit = 2;
 	int nBins = 4;
 	double minWeight = pow(1. / nSplit, 2);
-	double Emin = 1*GeV;
-	double Emax = 10*GeV; 	
+	double Emin = 1; // dimensionless for testing
+	double Emax = 10; 	
 
 	CandidateSplitting split_lin(nSplit, Emin, Emax, nBins, minWeight);
-	double dE = (Emax-Emin)/nBins;
+	double dE = (Emax - Emin) / nBins;
 	EXPECT_DOUBLE_EQ(split_lin.getEnergyBins()[0], Emin);
-	EXPECT_DOUBLE_EQ(split_lin.getEnergyBins()[1], Emin+dE);
+	EXPECT_DOUBLE_EQ(split_lin.getEnergyBins()[1], Emin + dE);
 
 	EXPECT_EQ(split_lin.getNsplit(), nSplit);
 	EXPECT_DOUBLE_EQ(split_lin.getMinimalWeight(), minWeight);
@@ -27,13 +27,13 @@ TEST(testCandidateSplitting, SimpleTest) {
 	CandidateSplitting split_log(nSplit, Emin, Emax, nBins, minWeight, true);
 	double dE_log = pow(Emax / Emin, 1. / (nBins - 1.0));
 	EXPECT_DOUBLE_EQ(split_log.getEnergyBins()[0], Emin);
-	EXPECT_DOUBLE_EQ(split_log.getEnergyBins()[1], Emin*dE_log);
+	EXPECT_DOUBLE_EQ(split_log.getEnergyBins()[1], Emin * dE_log);
 
-	double spectralIndex = 2.;
+	double spectralIndex = -2.;
 	CandidateSplitting split_dsa(spectralIndex, Emin, nBins);
-	double dE_dsa = pow(1. / 2, 1. / (-spectralIndex + 1));
-	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[0], Emin*dE_dsa);
-	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[nBins-1], Emin * pow(dE_dsa, nBins));
+	double dE_dsa = pow(1. / 2, 1. / (spectralIndex + 1));
+	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[0], Emin * dE_dsa);
+	EXPECT_DOUBLE_EQ(split_dsa.getEnergyBins()[nBins - 1], Emin * pow(dE_dsa, nBins));
 }
 
 


### PR DESCRIPTION
This pull request adds a new module that splits candidates in a user-defined number of copies when energy boundaries are crossed. The candidates weights are lowered depending on the splitting number. Candidates can be split until a minimal weight is reached. To use, the `CandidateSplitting` module must be added to the `ModuleList`.

Originally, the module was developed to enhance statistics at high energies for diffusive shock acceleration. For that, only the expected spectral index, minimal energy and number of energy bins needs to be specified. The energy bins are then calculated so that the decrease of candidates over the specified energy range is compensated by always splitting into two copies. This way of splitting was used in the 2023 ICRC proceedings to model time-dependent diffusive shock acceleration. Simulations are significantly faster when the `CandidateSplitting` module is used instead of just increasing the number of candidates to reach sufficiently high statistics. It is also possible to define splitting number, energy bins, and minimal weights.

The `Acceleration` module already provides candidate splitting for acceleration at shocks, the new independent `CandidateSplitting` module is more flexible. It does not depend on the shock surface and can be used in other scenarios as well. The code that performs splitting is adapted from the `Acceleration` module.

The `testCandidateSplitting` test checks the correct calculation of energy bins and if weights are set accordingly depending on the number of energy bins that are crossed.

