### PR TITLE
remove Quimby from default installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ if(FFTW3F_FOUND)
 endif(FFTW3F_FOUND)
 
 # Quimby (optional for SPH magnetic fields)
-option(ENABLE_QUIMBY "Quimby Support" ON)
+option(ENABLE_QUIMBY "Quimby Support" OFF)
 if(ENABLE_QUIMBY)
   find_package(Quimby)
   if(QUIMBY_FOUND)


### PR DESCRIPTION
With this PR the `ENABLE_QUIMBY` flag in the installation is set to `OFF` as default. 
In many cases Quimby is not used for simulations and therefore users needing Quimby should activate it in the installation 