### PR TITLE
Update download links

### DIFF
--- a/doc/pages/AdditionalResources.rst
+++ b/doc/pages/AdditionalResources.rst
@@ -2,26 +2,26 @@ Additional Resources
 --------------------
 
 -  The Galactic magnetic field lenses can be downloaded
-   `here <https://syncandshare.desy.de/index.php/s/ReEXpW7Lngbn2j3>`__ .
+   `here <https://ruhr-uni-bochum.sciebo.de/s/VEaAL2HYbkaHL06>`__ .
 -  The multi-resolution 'Dolag' extragalactic magnetic field, using
    `Quimby <https://github.com/CRPropa/Quimby>`__, can be
    downloaded
-   `here <https://syncandshare.desy.de/index.php/s/StYK4jqcXMtgbZG>`__
+   `here <https://ruhr-uni-bochum.sciebo.de/s/qXJ4sGxA2qW8OQh>`__
 -  The 'Miniati', 'Dolag' and 'Benchmark' extragalactic magnetic field
    models on regular grids are available in the same directory
-   `here <https://syncandshare.desy.de/index.php/s/StYK4jqcXMtgbZG>`__ and the
+   `here <https://ruhr-uni-bochum.sciebo.de/s/qXJ4sGxA2qW8OQh>`__ and the
    corresponding large-scale structure density fields can be downloaded
-   `here <https://syncandshare.desy.de/index.php/s/7a948NZT98fP77Q>`__.
+   `here <https://ruhr-uni-bochum.sciebo.de/s/hQYDJfGwh9HCpQ8>`__.
 -  Data for the constrained `'Hackstein'
    models <https://arxiv.org/abs/1710.01353>`__ of the local Universe
    using initial conditions from the `CLUES
    project <https://arxiv.org/abs/1510.04900>`__ can be downloaded
-   `here <https://syncandshare.desy.de/index.php/s/6HbWrBZeQtQ5t4c>`__.
+   `here <https://ruhr-uni-bochum.sciebo.de/s/kcsulGIhrnU9ks0>`__.
 -  Data for the strong extragalactic magnetic fields by `Alves Batista  et al. 
    <https://arxiv.org/abs/1704.05869>`__ can be downloaded
-   `here <https://syncandshare.desy.de/index.php/s/Fo5xceXtwtk5Exo>`__.
+   `here <https://ruhr-uni-bochum.sciebo.de/s/oerRpvSzFKbkQNj>`__.
 -  Data for the Galactic mass distribution by `Mertsch et al. (2020) <https://arxiv.org/abs/2012.15770>`__ can be found 
-   `here <https://syncandshare.desy.de/index.php/s/aR8wkqYYkDyfWgs>`__. 
+   `here <https://ruhr-uni-bochum.sciebo.de/s/YD4wiiAdn3AK1SU>`__. 
 
 
 Note that these resources are completely external to CRPropa. We cannot supply any kind of additional information nor can we offer support on how to use them.

--- a/doc/pages/Data-files.md
+++ b/doc/pages/Data-files.md
@@ -1,7 +1,7 @@
 CRPropa needs a number of data files to run. These include databases for nuclear mass and decay rates, interaction rates for photodisintegration, photo-pion production and electron-pair production.
 The scripts and files that are used to prepare the data files are tracked by the [CRPropa3-data repository](https://github.com/CRPropa/CRPropa3-data).
 
-Since a git repository is not well suited to store these large files (and git-lfs is not free on GitHub), the data files are downloaded automatically during cmake configuration. In case you want to use a different photodisintegration model or want to download the default data file manually use the following [link](https://www.desy.de/~crpropa/data/interaction_data/) to the tarballs files and extract them to your install folder.
+Since a git repository is not well suited to store these large files (and git-lfs is not free on GitHub), the data files are downloaded automatically during cmake configuration. In case you want to use a different photodisintegration model or want to download the default data file manually use the following [link](https://ruhr-uni-bochum.sciebo.de/s/3juW9sntQX2IWBS) to the tarballs files and extract them to your install folder.
 
 **Default data files:** (data-YYYY-MM-DD.tar.gz where YYYY-MM-DD depends on the data files version)
 Contains interaction rates nuclei, electrons and photons and spectra of secondary particles from these interactions, as well as data on nuclear masses and decay rates.

--- a/doc/pages/example_notebooks/density/density_grid_sampling.ipynb
+++ b/doc/pages/example_notebooks/density/density_grid_sampling.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "source": [
     "In this example a mass distribution is loaded from a given grid and used for the sampling of the source position of the candidates. \n",
-    "Here, we use the H2 distribution from [Mertsch & Vittino A&A 655, A64 (2021)](https://doi.org/10.1051/0004-6361/202141000). The original data can be found [here](https://zenodo.org/record/5501196) and have been converted to an CRPropa compatible format. The final data can be downloaded from the [additional rescources](https://desycloud.desy.de/index.php/f/451988900). We use the the Model SBM15. "
+    "Here, we use the H2 distribution from [Mertsch & Vittino A&A 655, A64 (2021)](https://doi.org/10.1051/0004-6361/202141000). The original data can be found [here](https://zenodo.org/record/5501196) and have been converted to an CRPropa compatible format. The final data can be downloaded from the [additional rescources](https://ruhr-uni-bochum.sciebo.de/s/YD4wiiAdn3AK1SU). We use the the Model SBM15. "
    ]
   },
   {


### PR DESCRIPTION
This PR updates the links for additional resources to download data from RUB's sciebo instead of the hard to maintain DESY cloud. Closes #454.