### PR TITLE
add python_install_package as ccmake option, adapt example test

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/
       - name: Build CRPropa
         run: |
           cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,9 +466,7 @@ if(ENABLE_PYTHON AND Python_FOUND)
 
 
   #  use Python_INSTALL_PACKAGE_DIR if provided; otherwise, install in Python_SITELIB 
-  if(NOT DEFINED Python_INSTALL_PACKAGE_DIR)
-    set(Python_INSTALL_PACKAGE_DIR "${Python_SITELIB}")
-  endif(NOT DEFINED Python_INSTALL_PACKAGE_DIR)
+  set(Python_INSTALL_PACKAGE_DIR "${Python_SITELIB}" CACHE PATH "folder in which the python package is installed")
   message(STATUS "  package install directory: ${Python_INSTALL_PACKAGE_DIR}")
 
 


### PR DESCRIPTION
I noticed a problem with the new installation in the example-test. In the previous test we had no write access to the package installation directory. I addepted it to the `.local` folder. 
Also I added the `Python_INSTALL_PACKAGE_DIR` as an option when using `ccmake`

