### PR TITLE
Update action to create the documentation

### DIFF
--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -20,7 +20,7 @@ jobs:
     # define steps to take
     steps: 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Prerequirements
         run: |
           sudo apt-get update
@@ -57,7 +57,7 @@ jobs:
           make doc
           tar -zcvf documentation.tar.gz doc
       - name: archive documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "documentation"
           path: | 

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} 
-            -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native 
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} \ 
+            -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native \
             -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -9,22 +9,18 @@ jobs:
       fail-fast: false
       matrix:
         config:
-         - name: "ubuntu-20"
-           os: ubuntu-20.04
-           cxx: "g++-9"
-           cc: "gcc-9"
-           fc: "gfortran-9"
-           swig_builtin: "Off" #uses swig 4.0.1
+          - name: "ubuntu-22"
+            os: ubuntu-22.04
+            cxx: "g++-11"
+            cc: "gcc-11"
+            fc: "gfortran-11"
+            swig_builtin: "On" #uses swig 4.0.2
+            py: "/usr/bin/python3" #python 3.10
     
     # define steps to take
     steps: 
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Python install
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-          cache: 'pip' # caching pip dependencies
       - name: Prerequirements
         run: |
           sudo apt-get update
@@ -40,9 +36,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local \
-            -DENABLE_PYTHON=True -DENABLE_TESTING=ON -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} \
-            -DSIMD_EXTENSIONS=native -DBUILD_DOC=True -DENABLE_COVERAGE=True
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/
       - name: Build CRPropa
         run: |
           cd build

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -36,7 +36,9 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} 
+            -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native 
+            -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -36,9 +36,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} \ 
-            -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native \
-            -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build


### PR DESCRIPTION
Due to the change of installation the change in building the documentation is needed. 

With this PR we also move from Node 16 to Node 20 (see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) by updateing the versions of the used actions (checkout and upload-artifact). 

