### PR TITLE
Implement optional logarithmic sampling of the photon energies

### DIFF
--- a/src/module/PhotoPionProduction.cpp
+++ b/src/module/PhotoPionProduction.cpp
@@ -422,7 +422,11 @@ double PhotoPionProduction::sampleEps(bool onProton, double E, double z) const {
 
 	Random &random = Random::instance();
 	for (int i = 0; i < 1000000; i++) {
-		double eps = epsMin + random.rand() * (epsMax - epsMin);
+		double eps;
+		if (sampleLog){
+			eps = epsMin * pow(epsMax / epsMin, random.rand());
+		} else
+			eps = epsMin + random.rand() * (epsMax - epsMin);
 		double pEps = probEps(eps, onProton, Ein, z);
 		if (random.rand() * pEpsMax < pEps)
 			return eps * eV;


### PR DESCRIPTION
Hey,
this is the follow-up to #474 . With this change it is possible to sample photons from tabulated photon fields where the maximum tabulated energy is much larger than the highest energies where the field density is non-zero.
I have attached a minimal CRPropa 1D simulation script that illustrates a scenario where the current version of CRPropa fails to find photons and stops with `error: no photon found in sampleEps, please make sure that photon field provides photons for the interaction by adapting the energy range of the tabulated photon field.`
The files for such a tabulated (CMB-like) photon field are also included and must be placed in the share folder of the local CRPropa installation.
Let me know what you think!
[supplementary_files.tar.gz](https://github.com/CRPropa/CRPropa3/files/14522020/supplementary_files.tar.gz)

