### PR TITLE
Add names to omp critical statements

### DIFF
--- a/include/crpropa/Referenced.h
+++ b/include/crpropa/Referenced.h
@@ -47,7 +47,7 @@ public:
 #elif defined(__GNUC__)
 		newRef = __sync_add_and_fetch(&_referenceCount, 1);
 #else
-		#pragma omp critical
+		#pragma omp critical(newRef)
 		{newRef = _referenceCount++;}
 #endif
 		return newRef;
@@ -67,7 +67,7 @@ public:
 #elif defined(__GNUC__)
 		newRef = __sync_sub_and_fetch(&_referenceCount, 1);
 #else
-		#pragma omp critical
+		#pragma omp critical(newRef)
 		{newRef = _referenceCount--;}
 #endif
 

--- a/src/Candidate.cpp
+++ b/src/Candidate.cpp
@@ -20,7 +20,7 @@ Candidate::Candidate(int id, double E, Vector3d pos, Vector3d dir, double z, dou
 #elif defined(__GNUC__)
 		{serialNumber = __sync_add_and_fetch(&nextSerialNumber, 1);}
 #else
-		#pragma omp critical
+		#pragma omp critical(serialNumber)
 		{serialNumber = nextSerialNumber++;}
 #endif
 
@@ -35,7 +35,7 @@ Candidate::Candidate(const ParticleState &state) :
 #elif defined(__GNUC__)
 		{serialNumber = __sync_add_and_fetch(&nextSerialNumber, 1);}
 #else
-		#pragma omp critical
+		#pragma omp critical(serialNumber)
 		{serialNumber = nextSerialNumber++;}
 #endif
 

--- a/src/module/HDF5Output.cpp
+++ b/src/module/HDF5Output.cpp
@@ -248,7 +248,7 @@ void HDF5Output::close() {
 }
 
 void HDF5Output::process(Candidate* candidate) const {
-	#pragma omp critical
+	#pragma omp critical(HDF5Output_access_file)
 	{
 	if (file == -1)
 		// This is ugly, but necesary as otherwise the user has to manually open the
@@ -316,7 +316,7 @@ void HDF5Output::process(Candidate* candidate) const {
 			pos += v.copyToBuffer(&r.propertyBuffer[pos]);
 	}
 
-	#pragma omp critical
+	#pragma omp critical(HDF5Output_access_file)
 	{
 		const_cast<HDF5Output*>(this)->candidatesSinceFlush++;
 		Output::process(candidate);

--- a/src/module/HDF5Output.cpp
+++ b/src/module/HDF5Output.cpp
@@ -248,7 +248,7 @@ void HDF5Output::close() {
 }
 
 void HDF5Output::process(Candidate* candidate) const {
-	#pragma omp critical(HDF5Output_access_file)
+	#pragma omp critical(HDFOutput)
 	{
 	if (file == -1)
 		// This is ugly, but necesary as otherwise the user has to manually open the
@@ -316,7 +316,7 @@ void HDF5Output::process(Candidate* candidate) const {
 			pos += v.copyToBuffer(&r.propertyBuffer[pos]);
 	}
 
-	#pragma omp critical(HDF5Output_access_file)
+	#pragma omp critical(HDFOutput)
 	{
 		const_cast<HDF5Output*>(this)->candidatesSinceFlush++;
 		Output::process(candidate);

--- a/src/module/OutputShell.cpp
+++ b/src/module/OutputShell.cpp
@@ -6,7 +6,7 @@
 namespace crpropa {
 
 void ShellOutput::process(Candidate* c) const {
-#pragma omp critical
+#pragma omp critical(ShellOutput)
 	{
 		std::cout << std::fixed << std::showpoint << std::setprecision(3)
 				<< std::setw(6);
@@ -25,7 +25,7 @@ std::string ShellOutput::getDescription() const {
 }
 
 void ShellOutput1D::process(Candidate* c) const {
-#pragma omp critical
+#pragma omp critical(ShellOutput)
 	{
 		std::cout << std::fixed << std::showpoint << std::setprecision(3)
 				<< std::setw(6);
@@ -43,7 +43,7 @@ std::string ShellOutput1D::getDescription() const {
 
 void ShellPropertyOutput::process(Candidate* c) const {
 	Candidate::PropertyMap::const_iterator i = c->properties.begin();
-#pragma omp critical
+#pragma omp critical(ShellOutput)
 	{
 		for ( ; i != c->properties.end(); i++) {
 			std::cout << "  " << i->first << ", " << i->second << std::endl;

--- a/src/module/ParticleCollector.cpp
+++ b/src/module/ParticleCollector.cpp
@@ -21,7 +21,7 @@ ParticleCollector::ParticleCollector(const std::size_t nBuffer, const bool clone
 }
 
 void ParticleCollector::process(Candidate *c) const {
-#pragma omp critical
+#pragma omp critical(ModifiyContainer)
         {
 		if(clone)
 		       	container.push_back(c->clone(recursive));

--- a/src/module/ParticleCollector.cpp
+++ b/src/module/ParticleCollector.cpp
@@ -21,7 +21,7 @@ ParticleCollector::ParticleCollector(const std::size_t nBuffer, const bool clone
 }
 
 void ParticleCollector::process(Candidate *c) const {
-#pragma omp critical(ModifiyContainer)
+#pragma omp critical(ModifyContainer)
         {
 		if(clone)
 		       	container.push_back(c->clone(recursive));

--- a/src/module/PhotoPionProduction.cpp
+++ b/src/module/PhotoPionProduction.cpp
@@ -231,7 +231,7 @@ void PhotoPionProduction::performInteraction(Candidate *candidate, bool onProton
 	int outPartID[2000];
 	int nParticles;
 
-#pragma omp critical
+#pragma omp critical(SophiaEvent)
 	{
 		sophiaevent_(nature, Ein, eps, outputEnergy, outPartID, nParticles);
 	}

--- a/src/module/PhotonOutput1D.cpp
+++ b/src/module/PhotonOutput1D.cpp
@@ -63,7 +63,7 @@ void PhotonOutput1D::process(Candidate *candidate) const {
 	p += std::sprintf(buffer + p, "%8.4f\t", candidate->source.getEnergy() / EeV);
 	p += std::sprintf(buffer + p, "%8.4f\n", candidate->source.getPosition().getR() / Mpc);
 
-#pragma omp critical
+#pragma omp critical(FileOutput)
 	{
 		out->write(buffer, p);
 	}

--- a/src/module/TextOutput.cpp
+++ b/src/module/TextOutput.cpp
@@ -271,7 +271,7 @@ void TextOutput::process(Candidate *c) const {
 
 	std::locale::global(old_locale);
 
-#pragma omp critical
+#pragma omp critical(FileOutput)
 	{
 		if (count == 0)
 			printHeader();

--- a/src/module/Tools.cpp
+++ b/src/module/Tools.cpp
@@ -40,7 +40,7 @@ void PerformanceModule::process(Candidate *candidate) const {
 		times[i] = end - start;
 	}
 
-#pragma omp critical
+#pragma omp critical(PerformanceModule)
 	{
 		for (size_t i = 0; i < modules.size(); i++) {
 			_module_info &m = modules[i];
@@ -109,7 +109,7 @@ void EmissionMapFiller::setEmissionMap(EmissionMap *emissionMap) {
 
 void EmissionMapFiller::process(Candidate* candidate) const {
 	if (emissionMap) {
-		#pragma omp critical
+		#pragma omp critical(EmissionMap)
 		{
 			emissionMap->fillMap(candidate->source);
 		}


### PR DESCRIPTION
Dear All,

with this pull request I want to add names to various `#pragma omp critical` statements.
If such a statement has no name, it blocks every other critical statement with no name, which may cause an increase in runtime.
For example, a shell output should only block other shell outputs and not file outputs.
Furthermore, if not accessed through a python script but directly through c++, critical statements from the users files may also block critical statements in CRPropa.