### PR TITLE
Small fix for EMPairProduction when haveElectrons=False and small Optimizations

### DIFF
--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -78,7 +78,6 @@ void EMDoublePairProduction::performInteraction(Candidate *candidate) const {
 
 	double f = Ee / E;
 
-	if (haveElectrons) {
 		if (random.rand() < pow(1 - f, thinning)) {
 			double w = 1. / pow(1 - f, thinning);
 			candidate->addSecondary( 11, Ee / (1 + z), pos, w, interactionTag);
@@ -87,7 +86,6 @@ void EMDoublePairProduction::performInteraction(Candidate *candidate) const {
 			double w = 1. / pow(f, thinning);
 			candidate->addSecondary(-11, Ee / (1 + z), pos, w, interactionTag);
 		}
-	}
 }
 
 void EMDoublePairProduction::process(Candidate *candidate) const {

--- a/src/module/EMInverseComptonScattering.cpp
+++ b/src/module/EMInverseComptonScattering.cpp
@@ -189,9 +189,9 @@ void EMInverseComptonScattering::performInteraction(Candidate *candidate) const 
 	double Enew = distribution.sample(E, s);
 
 	// add up-scattered photon
-	double Esecondary = E - Enew;
-	double f = Enew / E;
 	if (havePhotons) {
+		double Esecondary = E - Enew;
+		double f = Enew / E;
 		if (random.rand() < pow(1 - f, thinning)) {
 			double w = 1. / pow(1 - f, thinning);
 			Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());

--- a/src/module/EMPairProduction.cpp
+++ b/src/module/EMPairProduction.cpp
@@ -173,13 +173,17 @@ class PPSecondariesEnergyDistribution {
 };
 
 void EMPairProduction::performInteraction(Candidate *candidate) const {
-	// scale particle energy instead of background photon energy
-	double z = candidate->getRedshift();
-	double E = candidate->current.getEnergy() * (1 + z);
+	
+	// photon is lost after interacting
+	candidate->setActive(false);
 
 	// check if secondary electron pair needs to be produced
 	if (not haveElectrons)
 		return;
+		
+	// scale particle energy instead of background photon energy
+	double z = candidate->getRedshift();
+	double E = candidate->current.getEnergy() * (1 + z);
 
 	// check if in tabulated energy range
 	if (E < tabE.front() or (E > tabE.back()))
@@ -202,9 +206,6 @@ void EMPairProduction::performInteraction(Candidate *candidate) const {
 	// for some backgrounds Ee=nan due to precision limitations.
 	if (not std::isfinite(Ee) || not std::isfinite(Ep))
 		return;
-
-	// photon is lost after interacting
-	candidate->setActive(false);
 
 	// sample random position along current step
 	Vector3d pos = random.randomInterpolatedPosition(candidate->previous.getPosition(), candidate->current.getPosition());


### PR DESCRIPTION
Dear all,

@lukasmerten , @JulienDoerner and me discussed a possible fix of #488 and thought of opening this very small PR. 
We switched the order of the lines in EMPairProduction.cpp that in the current master-version would prevent the catastrophic energy loss of the pairproduction in the case of haveElectrons=False.
We also noticed two very small optimizations that could be done in EMDoublePairProduction.cpp and EMInverseComptonScattering.cpp that we included in this PR, that do not affect the physics and could lead to a little speedup in the runtime of the modules.

Thank you in advance!