### PR TITLE
Memory management in Variants

### DIFF
--- a/include/crpropa/Module.h
+++ b/include/crpropa/Module.h
@@ -59,7 +59,17 @@ public:
 	void setMakeAcceptedInactive(bool makeInactive);
 	void setRejectFlag(std::string key, std::string value);
 	void setAcceptFlag(std::string key, std::string value);
+
+	void printRejectFlag();
+	void printAcceptFlag();
 };
+
+class DeactivateModule: public AbstractCondition {
+	public: 
+		void process(Candidate *cand) const { reject(cand); }
+};
+
+
 } // namespace crpropa
 
 #endif /* CRPROPA_MODULE_H */

--- a/include/crpropa/Module.h
+++ b/include/crpropa/Module.h
@@ -64,7 +64,11 @@ public:
 	void printAcceptFlag();
 };
 
-class DeactivateModule: public AbstractCondition {
+/**
+ @class Deactivation
+ @brief Direct deactivation of the candidate. Can be used for debuging.
+*/
+class Deactivation: public AbstractCondition {
 	public: 
 		void process(Candidate *cand) const { reject(cand); }
 };

--- a/include/crpropa/Module.h
+++ b/include/crpropa/Module.h
@@ -60,8 +60,11 @@ public:
 	void setRejectFlag(std::string key, std::string value);
 	void setAcceptFlag(std::string key, std::string value);
 
-	void printRejectFlag();
-	void printAcceptFlag();
+	// return the reject flag (key & value), delimiter is the "&".
+	std::string getRejectFlag();
+
+	// return the accept flag (key & value), delimiter is the "&"
+	std::string getAcceptFlag();
 };
 
 /**

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -281,6 +281,17 @@ public:
 	DetectionState checkDetection(Candidate *candidate) const;
 	std::string getDescription() const;
 };
+
+class ObserverTrajectoryLength: public ObserverFeature {
+private: 
+	double maxLength; 
+public: 
+	ObserverTrajectoryLength(double l);
+
+	DetectionState checkDetection(Candidate *candidate) const;
+};
+
+
 /** @} */
 
 }

--- a/include/crpropa/module/Observer.h
+++ b/include/crpropa/module/Observer.h
@@ -282,16 +282,6 @@ public:
 	std::string getDescription() const;
 };
 
-class ObserverTrajectoryLength: public ObserverFeature {
-private: 
-	double maxLength; 
-public: 
-	ObserverTrajectoryLength(double l);
-
-	DetectionState checkDetection(Candidate *candidate) const;
-};
-
-
 /** @} */
 
 }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -76,12 +76,14 @@ void AbstractCondition::setAcceptFlag(std::string key, std::string value) {
 	acceptFlagValue = value;
 }
 
-void AbstractCondition::printRejectFlag() {
-	std::cout << "rejectKey: " << rejectFlagKey << " with flag: " << rejectFlagValue << "\n";
+std::string AbstractCondition::getRejectFlag() {
+	std::string out = rejectFlagKey + "&" + rejectFlagValue; 
+	return out;
 }
 
-void AbstractCondition::printAcceptFlag() {
-	std::cout << "acceptKey: " << acceptFlagKey << " with flag: " << acceptFlagValue << "\n";
+std::string AbstractCondition::getAcceptFlag() {
+	std::string out = acceptFlagKey + "&" + acceptFlagValue;
+	return out;
 }
 
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -19,8 +19,7 @@ void Module::setDescription(const std::string &d) {
 
 AbstractCondition::AbstractCondition() :
 		makeRejectedInactive(true), makeAcceptedInactive(false), rejectFlagKey(
-				"Rejected") {
-
+				"Rejected"), rejectFlagValue( typeid(*this).name() ) {
 }
 
 void AbstractCondition::reject(Candidate *candidate) const {
@@ -76,5 +75,14 @@ void AbstractCondition::setAcceptFlag(std::string key, std::string value) {
 	acceptFlagKey = key;
 	acceptFlagValue = value;
 }
+
+void AbstractCondition::printRejectFlag() {
+	std::cout << "rejectKey: " << rejectFlagKey << " with flag: " << rejectFlagValue << "\n";
+}
+
+void AbstractCondition::printAcceptFlag() {
+	std::cout << "acceptKey: " << acceptFlagKey << " with flag: " << acceptFlagValue << "\n";
+}
+
 
 } // namespace crpropa

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -27,7 +27,7 @@ Variant::Variant(const char* s) {
 }
 
 Variant::~Variant() {
-	clear();
+	clear(type);
 }
 
 const char* Variant::getTypeName() const {

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -28,6 +28,7 @@ Variant::Variant(const char* s) {
 
 Variant::~Variant() {
 	clear(type);
+	delete data._t_string;
 }
 
 const char* Variant::getTypeName() const {
@@ -676,7 +677,7 @@ Variant Variant::fromString(const std::string& s, Type t) {
 }
 
 void Variant::clear(Type t) {
-	if (t == TYPE_STRING)
+	if (t == TYPE_STRING) 
 		safeDelete(data._t_string);
 	else if (t == TYPE_VECTOR3F)
 		safeDelete(data._t_vector3f);

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -365,17 +365,5 @@ std::string ObserverSurface::getDescription() const {
 	return ss.str();
 }
 
-// ObserverTrajectoryLength ---------------------------------------------------
 
-ObserverTrajectoryLength::ObserverTrajectoryLength(double l) : maxLength(l) { }
-
-DetectionState ObserverTrajectoryLength::checkDetection(Candidate *cand) const {
-	double currentLength = cand -> getTrajectoryLength(); 
-
-	if (currentLength > maxLength) 
-		return DETECTED;
-	
-	cand -> limitNextStep(maxLength - currentLength); 
-	return NOTHING;
-}
 } // namespace crpropa

--- a/src/module/Observer.cpp
+++ b/src/module/Observer.cpp
@@ -365,4 +365,17 @@ std::string ObserverSurface::getDescription() const {
 	return ss.str();
 }
 
+// ObserverTrajectoryLength ---------------------------------------------------
+
+ObserverTrajectoryLength::ObserverTrajectoryLength(double l) : maxLength(l) { }
+
+DetectionState ObserverTrajectoryLength::checkDetection(Candidate *cand) const {
+	double currentLength = cand -> getTrajectoryLength(); 
+
+	if (currentLength > maxLength) 
+		return DETECTED;
+	
+	cand -> limitNextStep(maxLength - currentLength); 
+	return NOTHING;
+}
 } // namespace crpropa


### PR DESCRIPTION
fixes #493: 

The `abstractConditions` added a property to the candidate on the rejection. Up to now it only adds the key `Rejected`. I added the module name as the default Value for the flag. 

Also the variant (in which this key is stored), does not have the right destructor. If it is deleted, the type of the variant was not passed to the `clear` function. Therefore no deletion of the variant was possible. This leaded to the bug in the memory consumption. 

