### PR TITLE
MacOS install issue

### DIFF
--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -20,7 +20,7 @@ jobs:
      - name: Preinstall 
        run: | 
          brew install hdf5 fftw cfitsio muparser libomp swig
-         pip install numpy==1.26
+         pip install numpy==1.26.4
      - name: Set up the build
        env:
          CXX: ${{ matrix.config.cxx }}

--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -20,7 +20,7 @@ jobs:
      - name: Preinstall 
        run: | 
          brew install hdf5 fftw cfitsio muparser libomp swig python3
-         pip install numpy==1.26.4
+         pip install numpy==1.26.4 cmake
      - name: Set up the build
        env:
          CXX: ${{ matrix.config.cxx }}

--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -19,7 +19,7 @@ jobs:
        uses: actions/checkout@v4 
      - name: Preinstall 
        run: | 
-         brew install hdf5 fftw cfitsio muparser libomp swig
+         brew install hdf5 fftw cfitsio muparser libomp swig python3
          pip install numpy==1.26.4
      - name: Set up the build
        env:

--- a/include/crpropa/ModuleList.h
+++ b/include/crpropa/ModuleList.h
@@ -1,13 +1,19 @@
 #ifndef CRPROPA_MODULE_LIST_H
 #define CRPROPA_MODULE_LIST_H
 
+#include <algorithm>
+#include <csignal>
+#include <iostream>
+#include <vector>
+#include <exception>
+#include <sstream>
+#include <list>
+
 #include "crpropa/Candidate.h"
 #include "crpropa/Module.h"
 #include "crpropa/Source.h"
 #include "crpropa/module/Output.h"
 
-#include <list>
-#include <sstream>
 
 namespace crpropa {
 

--- a/src/ModuleList.cpp.in
+++ b/src/ModuleList.cpp.in
@@ -1,16 +1,12 @@
 #include "crpropa/ModuleList.h"
 #include "crpropa/ProgressBar.h"
 
-#if _OPENMP
-#include <omp.h>
-#define OMP_SCHEDULE @OMP_SCHEDULE@
-#endif
-
-#include <algorithm>
-#include <csignal>
-#include <bits/stdc++.h> 
 #ifndef sighandler_t
 typedef void (*sighandler_t)(int);
+#endif
+#ifdef _OPENMP
+#include <omp.h>
+#define OMP_SCHEDULE @OMP_SCHEDULE@
 #endif
 
 using namespace std;


### PR DESCRIPTION
I recently had a problem installing the lastest master version of CRPropa on my M1Max, this seemed to be coming from a bad include statement in ModuleList.cpp.in

`#include <bits/stdc++.h>`

This seems to be bad practice according to [this](https://stackoverflow.com/questions/31816095/why-should-i-not-include-bits-stdc-h) stack overflow post. 
I replace the general import with explicits imports of the necessary libraries, which fixed the issue for me.

In addition I tried to fix issue #515 but was not yet successful with it.

So any input on the issue with the not working MacOS runner is appreciated. 