### PR TITLE
Many bug and warning fixes

### DIFF
--- a/.github/workflows/create_coverage_report.yml
+++ b/.github/workflows/create_coverage_report.yml
@@ -23,7 +23,7 @@ jobs:
         - name: Prerequirements
           run: |
             sudo apt-get update
-            sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz
+            sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz ninja-build
             sudo apt-get install pandoc # do not only use pip to install pandoc, see https://stackoverflow.com/questions/62398231/building-docs-fails-due-to-missing-pandoc
             pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
             pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
@@ -35,20 +35,20 @@ jobs:
           run: |
             mkdir build
             cd build
-            cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=OFF -DENABLE_COVERAGE=On
+            cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=OFF -DENABLE_COVERAGE=On
         - name: Build CRPropa
           run: |
             cd build
-            make -j
+            cmake --build .
         - name: run test
           run: | 
             cd build
-            make test
+            ctest --output-on-failure
           continue-on-error: true
         - name: coverage report
           run: |
             cd build
-            make coverage
+            cmake --build . --target coverage
             tar -zcvf coverage.tar.gz coverageReport
         - name: archive documentation
           uses: actions/upload-artifact@v4

--- a/.github/workflows/create_coverage_report.yml
+++ b/.github/workflows/create_coverage_report.yml
@@ -39,7 +39,7 @@ jobs:
         - name: Build CRPropa
           run: |
             cd build
-            cmake --build .
+            make -j
         - name: run test
           run: | 
             cd build
@@ -48,7 +48,7 @@ jobs:
         - name: coverage report
           run: |
             cd build
-            cmake --build . --target coverage
+            make coverage
             tar -zcvf coverage.tar.gz coverageReport
         - name: archive documentation
           uses: actions/upload-artifact@v4

--- a/.github/workflows/create_coverage_report.yml
+++ b/.github/workflows/create_coverage_report.yml
@@ -23,7 +23,7 @@ jobs:
         - name: Prerequirements
           run: |
             sudo apt-get update
-            sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz ninja-build
+            sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz
             sudo apt-get install pandoc # do not only use pip to install pandoc, see https://stackoverflow.com/questions/62398231/building-docs-fails-due-to-missing-pandoc
             pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
             pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
@@ -35,7 +35,7 @@ jobs:
           run: |
             mkdir build
             cd build
-            cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=OFF -DENABLE_COVERAGE=On
+            cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=OFF -DENABLE_COVERAGE=On
         - name: Build CRPropa
           run: |
             cd build

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Prerequirements
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz ninja-build
+          sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz
           sudo apt-get install pandoc # do not only use pip to install pandoc, see https://stackoverflow.com/questions/62398231/building-docs-fails-due-to-missing-pandoc
           pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
           pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Prerequirements
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz
+          sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz ninja-build
           sudo apt-get install pandoc # do not only use pip to install pandoc, see https://stackoverflow.com/questions/62398231/building-docs-fails-due-to-missing-pandoc
           pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
           pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
@@ -36,24 +36,24 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build
-          make -j
+          cmake --build .
       - name: run test
         run: | 
           cd build
-          make test
+          ctest --output-on-failure
         continue-on-error: true
       - name: coverage report
         run: |
           cd build
-          make coverage
+          cmake --build . --target coverage
       - name: build documentation
         run: |
           cd build
-          make doc
+          cmake --build . --target doc
           cp -r coverageReport doc/pages/coverageReport
           tar -zcvf documentation.tar.gz doc  
       - name: archive documentation

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build CRPropa
         run: |
           cd build
-          cmake --build .
+          make -j
       - name: run test
         run: | 
           cd build
@@ -49,11 +49,11 @@ jobs:
       - name: coverage report
         run: |
           cd build
-          cmake --build . --target coverage
+          make coverage
       - name: build documentation
         run: |
           cd build
-          cmake --build . --target doc
+          make doc
           cp -r coverageReport doc/pages/coverageReport
           tar -zcvf documentation.tar.gz doc  
       - name: archive documentation

--- a/.github/workflows/deploy_new_documentation.yml
+++ b/.github/workflows/deploy_new_documentation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Prerequirements
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz
+          sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz ninja-build
           sudo apt-get install pandoc # do not only use pip to install pandoc, see https://stackoverflow.com/questions/62398231/building-docs-fails-due-to-missing-pandoc
           pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
           pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
@@ -40,24 +40,24 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build
-          make -j
+          cmake --build .
       - name: run test
         run: | 
           cd build
-          make test
+          ctest --output-on-failure
         continue-on-error: true
       - name: coverage report
         run: |
           cd build
-          make coverage
+          cmake --build . --target coverage
       - name: build documentation
         run: |
           cd build
-          make doc
+          cmake --build . --target doc
       - name: move final documentation # to avoid conflict with .gitignore
         run: | 
           mv build/doc ~/final_doc 

--- a/.github/workflows/deploy_new_documentation.yml
+++ b/.github/workflows/deploy_new_documentation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Prerequirements
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz ninja-build
+          sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz
           sudo apt-get install pandoc # do not only use pip to install pandoc, see https://stackoverflow.com/questions/62398231/building-docs-fails-due-to-missing-pandoc
           pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
           pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
@@ -40,7 +40,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build

--- a/.github/workflows/deploy_new_documentation.yml
+++ b/.github/workflows/deploy_new_documentation.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build CRPropa
         run: |
           cd build
-          cmake --build .
+          make -j
       - name: run test
         run: | 
           cd build
@@ -53,11 +53,11 @@ jobs:
       - name: coverage report
         run: |
           cd build
-          cmake --build . --target coverage
+          make coverage
       - name: build documentation
         run: |
           cd build
-          cmake --build . --target doc
+          make doc
       - name: move final documentation # to avoid conflict with .gitignore
         run: | 
           mv build/doc ~/final_doc 

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -36,8 +36,7 @@ jobs:
       - name: Build CRPropa
         run: |
           cd build
-          cmake --build .
-          cmake --install .
+          make install -j
       - name: convert notebooks to python 
         env: 
           PYTHONPATH: "/home/runner/.local"

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python3 python3-dev python3-setuptools python-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov ninja-build
+          sudo apt-get install libmuparser-dev python3 python3-dev python3-setuptools python-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
           pip3 install -r doc/pages/example_notebooks/requirements.txt # load requrements for notebooks
           pip3 install --upgrade Pygments
       - name: Set up the build
@@ -32,7 +32,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/
+          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/
       - name: Build CRPropa
         run: |
           cd build

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python3 python3-dev python3-setuptools python-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
+          sudo apt-get install libmuparser-dev python3 python3-dev python3-setuptools python-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov ninja-build
           pip3 install -r doc/pages/example_notebooks/requirements.txt # load requrements for notebooks
           pip3 install --upgrade Pygments
       - name: Set up the build
@@ -32,11 +32,12 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=Off -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/
       - name: Build CRPropa
         run: |
           cd build
-          make install -j
+          cmake --build .
+          cmake --install .
       - name: convert notebooks to python 
         env: 
           PYTHONPATH: "/home/runner/.local"

--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -19,7 +19,7 @@ jobs:
        uses: actions/checkout@v4 
      - name: Preinstall 
        run: | 
-         brew install hdf5 fftw cfitsio muparser libomp swig
+         brew install hdf5 fftw cfitsio muparser libomp swig 
          python3 -m venv venv
          source venv/bin/activate
          python -m pip install --upgrade pip
@@ -48,7 +48,7 @@ jobs:
      - name: Build CRPropa
        run: |
          cd build
-         cmake --build .
+         make
      - name: Run tests
        env:
          CRPROPA_DATA_PATH: "/Users/runner/work/CRPropa3/CRPropa3/build/data"

--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -19,7 +19,7 @@ jobs:
        uses: actions/checkout@v4 
      - name: Preinstall 
        run: | 
-         brew install hdf5 fftw cfitsio muparser libomp swig ninja
+         brew install hdf5 fftw cfitsio muparser libomp swig
          python3 -m venv venv
          source venv/bin/activate
          python -m pip install --upgrade pip
@@ -36,7 +36,6 @@ jobs:
         cd build
       
         cmake .. \
-          -G Ninja \
           -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/venv \
           -DENABLE_PYTHON=True \
           -DPython_EXECUTABLE=$GITHUB_WORKSPACE/venv/bin/python \

--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -19,7 +19,7 @@ jobs:
        uses: actions/checkout@v4 
      - name: Preinstall 
        run: | 
-         brew install hdf5 fftw cfitsio muparser libomp swig 
+         brew install hdf5 fftw cfitsio muparser libomp swig ninja
          python3 -m venv venv
          source venv/bin/activate
          python -m pip install --upgrade pip
@@ -36,6 +36,7 @@ jobs:
         cd build
       
         cmake .. \
+          -G Ninja \
           -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/venv \
           -DENABLE_PYTHON=True \
           -DPython_EXECUTABLE=$GITHUB_WORKSPACE/venv/bin/python \
@@ -46,13 +47,13 @@ jobs:
      - name: Build CRPropa
        run: |
          cd build
-         make
+         cmake --build .
      - name: Run tests
        env:
          CRPROPA_DATA_PATH: "/Users/runner/work/CRPropa3/CRPropa3/build/data"
        run: |
          cd build
-         make test
+         ctest --output-on-failure
      - name: Archive test results
        if: always()
        uses: actions/upload-artifact@v4

--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -39,8 +39,6 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/venv \
           -DENABLE_PYTHON=True \
           -DPython_EXECUTABLE=$GITHUB_WORKSPACE/venv/bin/python \
-          -DCMAKE_CXX_STANDARD=17 \
-          -DCMAKE_CXX_FLAGS="-std=c++17 -stdlib=libc++" \
           -DENABLE_TESTING=On \
           -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} \
           -DPython_INSTALL_PACKAGE_DIR=$GITHUB_WORKSPACE/venv/lib/python3.14/site-packages

--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -39,6 +39,8 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/venv \
           -DENABLE_PYTHON=True \
           -DPython_EXECUTABLE=$GITHUB_WORKSPACE/venv/bin/python \
+          -DCMAKE_CXX_STANDARD=17 \
+          -DCMAKE_CXX_FLAGS="-std=c++17 -stdlib=libc++" \
           -DENABLE_TESTING=On \
           -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} \
           -DPython_INSTALL_PACKAGE_DIR=$GITHUB_WORKSPACE/venv/lib/python3.14/site-packages

--- a/.github/workflows/testing_ubuntu22.yml
+++ b/.github/workflows/testing_ubuntu22.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python3 python3-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov ninja-build
+          sudo apt-get install libmuparser-dev python3 python3-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
           pip install --upgrade pip
           pip install numpy 
           pip show numpy
@@ -33,7 +33,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -G Ninja -DENABLE_PYTHON=True -DENABLE_TESTING=On -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native
+          cmake .. -DENABLE_PYTHON=True -DENABLE_TESTING=On -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native
       - name: Build CRPropa
         run: |
           cd build

--- a/.github/workflows/testing_ubuntu22.yml
+++ b/.github/workflows/testing_ubuntu22.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python3 python3-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
+          sudo apt-get install libmuparser-dev python3 python3-setuptools libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov ninja-build
           pip install --upgrade pip
           pip install numpy 
           pip show numpy
@@ -33,15 +33,15 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DENABLE_PYTHON=True -DENABLE_TESTING=On -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native
+          cmake .. -G Ninja -DENABLE_PYTHON=True -DENABLE_TESTING=On -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native
       - name: Build CRPropa
         run: |
           cd build
-          make
+          cmake --build .
       - name: Run tests
         run: |
           cd build
-          make test
+          ctest --output-on-failure
       - name: Archive test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/testing_ubuntu22.yml
+++ b/.github/workflows/testing_ubuntu22.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build CRPropa
         run: |
           cd build
-          cmake --build .
+          make
       - name: Run tests
         run: |
           cd build

--- a/.github/workflows/testing_ubuntu24.yml
+++ b/.github/workflows/testing_ubuntu24.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python-dev-is-python3 libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov ninja-build
+          sudo apt-get install libmuparser-dev python-dev-is-python3 libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
           pip install numpy
           pip show numpy
       - name: Set up the build
@@ -76,7 +76,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -G Ninja -DENABLE_PYTHON=True -DENABLE_TESTING=On  -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS="none" 
+          cmake .. -DENABLE_PYTHON=True -DENABLE_TESTING=On  -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS="none" 
       - name: Build CRPropa
         run: |
           cd build

--- a/.github/workflows/testing_ubuntu24.yml
+++ b/.github/workflows/testing_ubuntu24.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python-dev-is-python3 libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov ninja-build
+          sudo apt-get install libmuparser-dev python-dev-is-python3 libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
           pip install numpy
       - name: Set up the build
         env:
@@ -31,11 +31,11 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -G Ninja -DENABLE_PYTHON=True -DENABLE_TESTING=On  -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS="none" 
+          cmake .. -DENABLE_PYTHON=True -DENABLE_TESTING=On  -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS="none" 
       - name: Build CRPropa
         run: |
           cd build
-          cmake --build .
+          make
       - name: Run tests
         run: |
           cd build
@@ -80,7 +80,7 @@ jobs:
       - name: Build CRPropa
         run: |
           cd build
-          cmake --build .
+          make
       - name: Run tests
         run: |
           cd build

--- a/.github/workflows/testing_ubuntu24.yml
+++ b/.github/workflows/testing_ubuntu24.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python-dev-is-python3 libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
+          sudo apt-get install libmuparser-dev python-dev-is-python3 libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov ninja-build
           pip install numpy
       - name: Set up the build
         env:
@@ -31,15 +31,15 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DENABLE_PYTHON=True -DENABLE_TESTING=On  -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS="none" 
+          cmake .. -G Ninja -DENABLE_PYTHON=True -DENABLE_TESTING=On  -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS="none" 
       - name: Build CRPropa
         run: |
           cd build
-          make
+          cmake --build .
       - name: Run tests
         run: |
           cd build
-          make test
+          ctest --output-on-failure
       - name: Archive test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -65,7 +65,7 @@ jobs:
       - name: Preinstall
         run: |
           sudo apt-get update
-          sudo apt-get install libmuparser-dev python-dev-is-python3 libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov
+          sudo apt-get install libmuparser-dev python-dev-is-python3 libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov ninja-build
           pip install numpy
           pip show numpy
       - name: Set up the build
@@ -76,15 +76,15 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DENABLE_PYTHON=True -DENABLE_TESTING=On  -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS="none" 
+          cmake .. -G Ninja -DENABLE_PYTHON=True -DENABLE_TESTING=On  -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS="none" 
       - name: Build CRPropa
         run: |
           cd build
-          make
+          cmake --build .
       - name: Run tests
         run: |
           cd build
-          make test 
+          ctest --output-on-failure
       - name: Archive test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 3.14)
 project(CRPropa Fortran C CXX)
 set(CRPROPA_RELEASE_VERSION 3.2.1+)  # Update for new release
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 set(CRPROPA_EXTRA_SOURCES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 project(CRPropa Fortran C CXX)
 set(CRPROPA_RELEASE_VERSION 3.2.1+)  # Update for new release
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 set(CRPROPA_EXTRA_SOURCES)

--- a/cmake/FindGooglePerfTools.cmake
+++ b/cmake/FindGooglePerfTools.cmake
@@ -7,7 +7,7 @@
 #  STACKTRACE_LIBRARIES, where to find the stacktrace library.
 #  PROFILER_LIBRARIES, where to find the profiler library.
 
-FIND_PATH(GOOGLE_PERFTOOLS_INCLUDE_DIR google/heap-profiler.h)
+FIND_PATH(GOOGLE_PERFTOOLS_INCLUDE_DIR NAMES google/heap-profiler.h gperftools/heap-profiler.h)
 
 SET(TCMALLOC_NAMES ${TCMALLOC_NAMES} tcmalloc)
 FIND_LIBRARY(TCMALLOC_LIBRARY  NAMES ${TCMALLOC_NAMES})

--- a/include/crpropa/AssocVector.h
+++ b/include/crpropa/AssocVector.h
@@ -122,8 +122,7 @@ namespace Loki
         typedef typename Base::const_reverse_iterator const_reverse_iterator;
 
         class value_compare
-            : public std::binary_function<value_type, value_type, bool>
-            , private key_compare
+            : private key_compare
         {
             friend class AssocVector;
 

--- a/include/crpropa/AssocVector.h
+++ b/include/crpropa/AssocVector.h
@@ -46,12 +46,12 @@ namespace Loki
 
     namespace Private
     {
-        template <class Value, class C>
+        template <class Value, class C, class K>
         class AssocVectorCompare : public C
         {
-            typedef std::pair<typename C::first_argument_type, Value>
+            typedef K first_argument_type;
+            typedef std::pair<first_argument_type, Value>
                 Data;
-            typedef typename C::first_argument_type first_argument_type;
 
         public:
             AssocVectorCompare()
@@ -98,10 +98,10 @@ namespace Loki
     >
     class AssocVector
         : private std::vector< std::pair<K, V>, A >
-        , private Private::AssocVectorCompare<V, C>
+        , private Private::AssocVectorCompare<V, C, K>
     {
         typedef std::vector<std::pair<K, V>, A> Base;
-        typedef Private::AssocVectorCompare<V, C> MyCompare;
+        typedef Private::AssocVectorCompare<V, C, K> MyCompare;
 
     public:
         typedef K key_type;

--- a/include/crpropa/AssocVector.h
+++ b/include/crpropa/AssocVector.h
@@ -110,14 +110,14 @@ namespace Loki
 
         typedef C key_compare;
         typedef A allocator_type;
-        typedef typename A::reference reference;
-        typedef typename A::const_reference const_reference;
+        typedef typename A::value_type& reference;
+        typedef const typename A::value_type* const_reference;
         typedef typename Base::iterator iterator;
         typedef typename Base::const_iterator const_iterator;
         typedef typename Base::size_type size_type;
         typedef typename Base::difference_type difference_type;
-        typedef typename A::pointer pointer;
-        typedef typename A::const_pointer const_pointer;
+        typedef typename A::value_type* pointer;
+        typedef const typename A::value_type* const_pointer;
         typedef typename Base::reverse_iterator reverse_iterator;
         typedef typename Base::const_reverse_iterator const_reverse_iterator;
 

--- a/include/crpropa/Random.h
+++ b/include/crpropa/Random.h
@@ -92,7 +92,7 @@ namespace crpropa {
 
  Mersenne Twister random number generator -- a C++ class Random
  Based on code by Makoto Matsumoto, Takuji Nishimura, and Shawn Cokus
- Richard J. Wagner  v1.0  15 May 2003  rjwagner@writeme.com
+ Richard J. Wagner  v1.0  15 May 2003  rjwagner\@writeme.com
  */
 class Random {
 public:

--- a/include/crpropa/Vector3.h
+++ b/include/crpropa/Vector3.h
@@ -420,7 +420,7 @@ public:
 	
 	const std::string getDescription() {
 		char buffer[256];
-		sprintf(buffer, "Vector(%.6G, %.6G, %.6G)", data[0], data[1], data[2]);
+		snprintf(buffer, 256, "Vector(%.6G, %.6G, %.6G)", data[0], data[1], data[2]);
 		return buffer;
 	}
 

--- a/include/crpropa/magneticField/turbulentField/SimpleGridTurbulence.h
+++ b/include/crpropa/magneticField/turbulentField/SimpleGridTurbulence.h
@@ -30,7 +30,7 @@ class SimpleTurbulenceSpectrum : public TurbulenceSpectrum {
 	*/
 	SimpleTurbulenceSpectrum(double Brms, double lMin, double lMax,
 	                         double sIndex = 5. / 3)
-	    : TurbulenceSpectrum(Brms, lMin, lMax, constScaleBendover * lMax, sIndex, 0) {}
+	    : TurbulenceSpectrum(Brms, lMin, lMax, 1000 * lMax, sIndex, 0) {}
 	~SimpleTurbulenceSpectrum() {}
 
 	/**

--- a/include/crpropa/magneticField/turbulentField/TurbulentField.h
+++ b/include/crpropa/magneticField/turbulentField/TurbulentField.h
@@ -81,7 +81,7 @@ class TurbulenceSpectrum : public Referenced {
 
 	/**
   Computes the magnetic field coherence length
-	Obtained from the definition of \f$l_c = 1/B_{\rm rms}^2 \int_0^\infty dr\langleB(0)B^*(r)\rangle \f$
+	Obtained from the definition of \\f$l_c = 1/B_{\\rm rms}^2 \\int_0^\\infty dr\\langleB(0)B^*(r)\\rangle \\f$
 	Approximates the true value correctly as long as lBendover <= lMax/8 (~5%
   error) (for the true value the above integral should go from lMin to lMax)
 	*/

--- a/include/crpropa/module/Acceleration.h
+++ b/include/crpropa/module/Acceleration.h
@@ -122,13 +122,13 @@ class DirectedFlowOfScatterCenters : public StepLengthModifier {
 /// @class QuasiLinearTheory
 /// @brief Scales the steplength according to quasi linear theory.
 /// @details Following quasi-linear theory [Schlickeiser1989], the mean free
-/// path \f$\lambda\f$ of a
-///  particle with energy \f$E\f$ and charge \f$Z\f$ in a field with turbulence
-///  spectrum \f$\frac{k}{k_{\min}}^{-q}\f$ is
-///   \f$ \lambda = {\left(\frac{B}{\delta B}\right)}^2 {\left(R_G\;
-///   k_{\min}\right)}^{1-q} R_G \equiv \lambda_0 {\left( \frac{E}{1
-///   EeV}\frac{1}{Z} \right)}^{2-q} \f$
-///  where \f$R_G = \frac{E}{B Z}\f$ is the gyro-radius of the
+/// path \\f$\\lambda\\f$ of a
+///  particle with energy \\f$E\\f$ and charge \\f$Z\\f$ in a field with turbulence
+///  spectrum \\f$\\frac{k}{k_{\\min}}^{-q}\\f$ is
+///   \\f$ \\lambda = {\\left(\\frac{B}{\\delta B}\\right)}^2 {\\left(R_G\\;
+///   k_{\\min}\\right)}^{1-q} R_G \\equiv \\lambda_0 {\\left( \\frac{E}{1
+///   EeV}\\frac{1}{Z} \\right)}^{2-q} \\f$
+///  where \\f$R_G = \\frac{E}{B Z}\\f$ is the gyro-radius of the
 ///  particles.
 /// This class implements the rigidity dependent scaling factor used to modify
 /// the base step length.

--- a/libs/sophia/sophia_interface.f
+++ b/libs/sophia/sophia_interface.f
@@ -2568,45 +2568,55 @@ C...Calculate maximum weight for ND-particle decay
 
 C...generation of the masses, compute weight, if rejected try again
 240   RORD(1) = 1.D0
-      DO 260 IL1=2,ND-1
-      RSAV = RNDM(0)
-      DO 250 IL2=IL1-1,1,-1
-      IF(RSAV.LE.RORD(IL2))   GOTO 260
-250     RORD(IL2+1)=RORD(IL2)
+      DO IL1=2,ND-1
+        RSAV = RNDM(0)
+        DO IL2=IL1-1,1,-1
+          IF(RSAV.LE.RORD(IL2))   GOTO 260
+          RORD(IL2+1)=RORD(IL2)
+        ENDDO
 260     RORD(IL2+1)=RSAV
+      ENDDO
       RORD(ND) = 0.D0
       WT = 1.D0
-      DO 270 IL=ND-1,1,-1
-      PV(IL,5)=PV(IL+1,5)+P(IL,5)+(RORD(IL)-RORD(IL+1))*(PV(1,5)-PS)
-270   WT=WT*PAWT(PV(IL,5),PV(IL+1,5),P(IL,5))
+      DO IL=ND-1,1,-1
+        PV(IL,5)=PV(IL+1,5)+P(IL,5)+(RORD(IL)-RORD(IL+1))*(PV(1,5)-PS)
+        WT=WT*PAWT(PV(IL,5),PV(IL+1,5),P(IL,5))
+      ENDDO
       IF (WT.LT.RNDM(0)*WWTMAX)   GOTO 240
 
 C...Perform two particle decays in respective cm frame
-280   DO 300 IL=1,ND-1
-      PA=PAWT(PV(IL,5),PV(IL+1,5),P(IL,5))
-      UE(3)=2.D0*RNDM(0)-1.D0
-      PHI=2.D0*PI*RNDM(0)
-      UT = SQRT(1.D0-UE(3)**2)
-      UE(1) = UT*COS(PHI)
-      UE(2) = UT*SIN(PHI)
-      DO 290 J=1,3
-      P(IL,J)=PA*UE(J)
-290   PV(IL+1,J)=-PA*UE(J)
-      P(IL,4)=SQRT(PA**2+P(IL,5)**2)
-300   PV(IL+1,4)=SQRT(PA**2+PV(IL+1,5)**2)
+280   DO IL=1,ND-1
+        PA=PAWT(PV(IL,5),PV(IL+1,5),P(IL,5))
+        UE(3)=2.D0*RNDM(0)-1.D0
+        PHI=2.D0*PI*RNDM(0)
+        UT = SQRT(1.D0-UE(3)**2)
+        UE(1) = UT*COS(PHI)
+        UE(2) = UT*SIN(PHI)
+        DO J=1,3
+          P(IL,J)=PA*UE(J)
+          PV(IL+1,J)=-PA*UE(J)
+        ENDDO
+        P(IL,4)=SQRT(PA**2+P(IL,5)**2)
+        PV(IL+1,4)=SQRT(PA**2+PV(IL+1,5)**2)
+      ENDDO
 
 C...Lorentz transform decay products to lab frame
-      DO 310 J=1,4
-310   P(ND,J)=PV(ND,J)
-      DO 340 IL=ND-1,1,-1
-      DO 320 J=1,3
-320   BE(J)=PV(IL,J)/PV(IL,4)
-      GA=PV(IL,4)/PV(IL,5)
-      DO 340 I=IL,ND
-      BEP = BE(1)*P(I,1)+BE(2)*P(I,2)+BE(3)*P(I,3)
-      DO 330 J=1,3
-330   P(I,J)=P(I,J)+GA*(GA*BEP/(1.+GA)+P(I,4))*BE(J)
-340   P(I,4)=GA*(P(I,4)+BEP)
+      DO J=1,4
+        P(ND,J)=PV(ND,J)
+      ENDDO
+      DO IL=ND-1,1,-1
+        DO J=1,3
+          BE(J)=PV(IL,J)/PV(IL,4)
+        ENDDO
+        GA=PV(IL,4)/PV(IL,5)
+        DO I=IL,ND
+          BEP = BE(1)*P(I,1)+BE(2)*P(I,2)+BE(3)*P(I,3)
+          DO J=1,3
+            P(I,J)=P(I,J)+GA*(GA*BEP/(1.+GA)+P(I,4))*BE(J)
+          ENDDO
+          P(I,4)=GA*(P(I,4)+BEP)
+        ENDDO
+      ENDDO
 
 C...Weak decays
         IF (MAT .EQ. 1)  THEN
@@ -2621,14 +2631,17 @@ C...Weak decays
 
 C...Boost back for rapidly moving particle
       IF (MBST .EQ. 1)   THEN
-         DO 440 J=1,3
-440      BE(J)=P0(J)/P0(4)
-         GA= P0(4)/P0(5)
-         DO 460 I=1,ND
-         BEP=BE(1)*P(I,1)+BE(2)*P(I,2)+BE(3)*P(I,3)
-         DO 450 J=1,3
-450         P(I,J)=P(I,J)+GA*(GA*BEP/(1.+GA)+P(I,4))*BE(J)
-460         P(I,4)=GA*(P(I,4)+BEP)
+        DO J=1,3
+          BE(J)=P0(J)/P0(4)
+        ENDDO
+        GA= P0(4)/P0(5)
+        DO I=1,ND
+          BEP=BE(1)*P(I,1)+BE(2)*P(I,2)+BE(3)*P(I,3)
+          DO J=1,3
+            P(I,J)=P(I,J)+GA*(GA*BEP/(1.+GA)+P(I,4))*BE(J)
+          ENDDO
+          P(I,4)=GA*(P(I,4)+BEP)
+        ENDDO
       ENDIF
 
 C...labels for antiparticle decay
@@ -2804,8 +2817,9 @@ C********************************************************************
       IF(RNDM(0).GT.Y**(F-1.D0)) GOTO 10
    40 IF(N.EQ.0) GOTO 70
    50 Z = 1.D0
-      DO 60 I = 1,N
-   60 Z = Z*RNDM(0)
+      DO I = 1,N
+        Z = Z*RNDM(0)
+      ENDDO
       Y = Y-LOG(Z+1.D-7)
    70 PO_RNDGAM = Y/ALAM
 

--- a/src/ProgressBar.cpp
+++ b/src/ProgressBar.cpp
@@ -52,7 +52,7 @@ void ProgressBar::setPosition(unsigned long position) {
 		std::string s = " - Finished at ";
 		s.append(ctime(&currentTime));
 		char fs[255];
-		std::sprintf(fs, "%c[%d;%dm Finished %c[%dm", 27, 1, 32, 27, 0);
+		std::snprintf(fs, 255, "%c[%d;%dm Finished %c[%dm", 27, 1, 32, 27, 0);
 		std::printf(stringTmpl.c_str(), fs, 100, "Needed",
 				int(tElapsed / 3600), (int(tElapsed) % 3600) / 60,
 				int(tElapsed) % 60, s.c_str());
@@ -68,7 +68,7 @@ void ProgressBar::setError() {
 	std::string s = " - Finished at ";
 	s.append(ctime(&currentTime));
 	char fs[255];
-	std::sprintf(fs, "%c[%d;%dm  ERROR   %c[%dm", 27, 1, 31, 27, 0);
+	std::snprintf(fs, 255, "%c[%d;%dm  ERROR   %c[%dm", 27, 1, 31, 27, 0);
 	std::printf(stringTmpl.c_str(), fs, _currentCount, "Needed",
 			int(tElapsed / 3600), (int(tElapsed) % 3600) / 60,
 			int(tElapsed) % 60, s.c_str());

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -282,7 +282,8 @@ uint64_t Random::randInt64()
 {
 	int64_t a = randInt();
 	int64_t b = randInt();
-	return (b + a << 32);
+	// a is shifted to the left to create a proper 64 bit integer
+	return (b + (a << 32));
 }
 
 

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -390,11 +390,11 @@ void Random::initialize(const uint32_t seed) {
 void Random::reload() {
 	uint32_t *p = state;
 	int i;
-	for (i = N - M; i--; ++p)
+	for (i = +N - M; i--; ++p)
 		*p = twist(p[M], p[0], p[1]);
 	for (i = M; --i; ++p)
-		*p = twist(p[M - N], p[0], p[1]);
-	*p = twist(p[M - N], p[0], state[0]);
+		*p = twist(p[+M - N], p[0], p[1]);
+	*p = twist(p[+M - N], p[0], state[0]);
 
 	left = N, pNext = state;
 }

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -668,6 +668,7 @@ Variant Variant::fromString(const std::string& s, Type t) {
 			std::string s;
 			v.push_back(s);
 		}
+		return Variant(v);
 	} else {
 		std::string msg; 
 		msg += "fromString not implemented for type ";

--- a/src/Variant.cpp
+++ b/src/Variant.cpp
@@ -1011,7 +1011,7 @@ Variant::operator const std::vector<Variant>&() const {
 
 #define INT_FUNCTION(to_type, fun, to)                                                                                 \
 	to Variant::fun() const {                                                                                          \
-		switch (type) {                                                                                                \
+		switch (to_type) {                                                                                                \
 			case Variant::TYPE_BOOL:                                                                                   \
 				return data._t_bool ? 1 : 0;                                                                           \
 				break;                                                                                                 \

--- a/src/magneticField/CMZField.cpp
+++ b/src/magneticField/CMZField.cpp
@@ -192,7 +192,7 @@ Vector3d CMZField::getMCField(const Vector3d& pos) const {//Field in molecular c
         Bphi = - B1*exp(-z*z/Hc/Hc)*R/r;
     }
     else{
-        - B1*exp(-z*z/Hc/Hc)*R/r1*(3*r/r1- 2*r*r/r1*r1);
+        Bphi = - B1*exp(-z*z/Hc/Hc)*R/r1*(3*r/r1- 2*r*r/r1*r1);
     }
 
     b.x -= Bphi*sin(phi);

--- a/src/magneticField/MagneticField.cpp
+++ b/src/magneticField/MagneticField.cpp
@@ -26,7 +26,7 @@ Vector3d &PeriodicMagneticField::getExtends() {
 	return extends;
 }
 
-void PeriodicMagneticField::setExtends(const Vector3d &origin) {
+void PeriodicMagneticField::setExtends(const Vector3d &extends) {
 	this->extends = extends;
 }
 

--- a/src/magneticField/turbulentField/PlaneWaveTurbulence.cpp
+++ b/src/magneticField/turbulentField/PlaneWaveTurbulence.cpp
@@ -59,7 +59,7 @@
 
 #ifdef ENABLE_FAST_WAVES
 #include <immintrin.h>
-#include <memory.h>
+#include <memory>
 #endif
 
 namespace crpropa {

--- a/src/module/HDF5Output.cpp
+++ b/src/module/HDF5Output.cpp
@@ -222,7 +222,7 @@ void HDF5Output::open(const std::string& filename) {
 
 		attr_space = H5Screate_simple(0, dims, NULL);
 		char nameBuffer[256];
-		sprintf(nameBuffer, "SEED_%03lu", i);
+		snprintf(nameBuffer, 256, "SEED_%03lu", i);
 		KISS_LOG_DEBUG << "Creating HDF5 attribute: " << nameBuffer << " with dimensions " << dims[0] << "x" << dims[1] ;
 
 		version_attr = H5Acreate2(dset, nameBuffer, type, attr_space, H5P_DEFAULT, H5P_DEFAULT);

--- a/src/module/PhotonOutput1D.cpp
+++ b/src/module/PhotonOutput1D.cpp
@@ -52,16 +52,16 @@ void PhotonOutput1D::process(Candidate *candidate) const {
 	char buffer[1024];
 	size_t p = 0;
 
-	p += std::snprintf(buffer + p, 1024, "%4i\t", pid);
-	p += std::snprintf(buffer + p, 1024, "%g\t", candidate->current.getEnergy() / EeV);
-	p += std::snprintf(buffer + p, 1024, "%8.4f\t", candidate->current.getPosition().getR() / Mpc);
+	p += std::snprintf(buffer + p, 1024 - p, "%4i\t", pid);
+	p += std::snprintf(buffer + p, 1024 - p, "%g\t", candidate->current.getEnergy() / EeV);
+	p += std::snprintf(buffer + p, 1024 - p, "%8.4f\t", candidate->current.getPosition().getR() / Mpc);
 
-	p += std::snprintf(buffer + p, 1024, "%10i\t", candidate->created.getId());
-	p += std::snprintf(buffer + p, 1024, "%8.4f\t", candidate->created.getEnergy() / EeV);
+	p += std::snprintf(buffer + p, 1024 - p, "%10i\t", candidate->created.getId());
+	p += std::snprintf(buffer + p, 1024 - p, "%8.4f\t", candidate->created.getEnergy() / EeV);
 
-	p += std::snprintf(buffer + p, 1024, "%10i\t", candidate->source.getId());
-	p += std::snprintf(buffer + p, 1024, "%8.4f\t", candidate->source.getEnergy() / EeV);
-	p += std::snprintf(buffer + p, 1024, "%8.4f\n", candidate->source.getPosition().getR() / Mpc);
+	p += std::snprintf(buffer + p, 1024 - p, "%10i\t", candidate->source.getId());
+	p += std::snprintf(buffer + p, 1024 - p, "%8.4f\t", candidate->source.getEnergy() / EeV);
+	p += std::snprintf(buffer + p, 1024 - p, "%8.4f\n", candidate->source.getPosition().getR() / Mpc);
 
 #pragma omp critical(FileOutput)
 	{

--- a/src/module/PhotonOutput1D.cpp
+++ b/src/module/PhotonOutput1D.cpp
@@ -52,16 +52,16 @@ void PhotonOutput1D::process(Candidate *candidate) const {
 	char buffer[1024];
 	size_t p = 0;
 
-	p += std::sprintf(buffer + p, "%4i\t", pid);
-	p += std::sprintf(buffer + p, "%g\t", candidate->current.getEnergy() / EeV);
-	p += std::sprintf(buffer + p, "%8.4f\t", candidate->current.getPosition().getR() / Mpc);
+	p += std::snprintf(buffer + p, 1024, "%4i\t", pid);
+	p += std::snprintf(buffer + p, 1024, "%g\t", candidate->current.getEnergy() / EeV);
+	p += std::snprintf(buffer + p, 1024, "%8.4f\t", candidate->current.getPosition().getR() / Mpc);
 
-	p += std::sprintf(buffer + p, "%10i\t", candidate->created.getId());
-	p += std::sprintf(buffer + p, "%8.4f\t", candidate->created.getEnergy() / EeV);
+	p += std::snprintf(buffer + p, 1024, "%10i\t", candidate->created.getId());
+	p += std::snprintf(buffer + p, 1024, "%8.4f\t", candidate->created.getEnergy() / EeV);
 
-	p += std::sprintf(buffer + p, "%10i\t", candidate->source.getId());
-	p += std::sprintf(buffer + p, "%8.4f\t", candidate->source.getEnergy() / EeV);
-	p += std::sprintf(buffer + p, "%8.4f\n", candidate->source.getPosition().getR() / Mpc);
+	p += std::snprintf(buffer + p, 1024, "%10i\t", candidate->source.getId());
+	p += std::snprintf(buffer + p, 1024, "%8.4f\t", candidate->source.getEnergy() / EeV);
+	p += std::snprintf(buffer + p, 1024, "%8.4f\n", candidate->source.getPosition().getR() / Mpc);
 
 #pragma omp critical(FileOutput)
 	{

--- a/src/module/TextOutput.cpp
+++ b/src/module/TextOutput.cpp
@@ -182,7 +182,7 @@ void TextOutput::process(Candidate *c) const {
 		p += std::snprintf(buffer + p, 1024, "%1.5E\t", c->getRedshift());
 
 	if (fields.test(SerialNumberColumn))
-		p += std::snprintf(buffer + p, 1024, "%10lu\t",
+		p += std::snprintf(buffer + p, 1024, "%10llu\t",
 				c->getSerialNumber());
 	if (fields.test(CurrentIdColumn))
 		p += std::snprintf(buffer + p, 1024, "%10i\t", c->current.getId());
@@ -208,7 +208,7 @@ void TextOutput::process(Candidate *c) const {
 	}
 
 	if (fields.test(SerialNumberColumn))
-		p += std::snprintf(buffer + p, 1024, "%10lu\t", c->getSourceSerialNumber());
+		p += std::snprintf(buffer + p, 1024, "%10llu\t", c->getSourceSerialNumber());
 	if (fields.test(SourceIdColumn))
 		p += std::snprintf(buffer + p, 1024, "%10i\t", c->source.getId());
 	if (fields.test(SourceEnergyColumn))
@@ -234,7 +234,7 @@ void TextOutput::process(Candidate *c) const {
 	}
 
 	if (fields.test(SerialNumberColumn))
-		p += std::snprintf(buffer + p, 1024, "%10lu\t",
+		p += std::snprintf(buffer + p, 1024, "%10llu\t",
 				c->getCreatedSerialNumber());
 	if (fields.test(CreatedIdColumn))
 		p += std::snprintf(buffer + p, 1024, "%10i\t", c->created.getId());

--- a/src/module/TextOutput.cpp
+++ b/src/module/TextOutput.cpp
@@ -172,97 +172,97 @@ void TextOutput::process(Candidate *c) const {
 	std::locale old_locale = std::locale::global(std::locale::classic());
 
 	if (fields.test(TrajectoryLengthColumn))
-		p += std::sprintf(buffer + p, "%8.5E\t",
+		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
 				c->getTrajectoryLength() / lengthScale);
 	if (fields.test(TimeColumn))
-		p += std::sprintf(buffer + p, "%8.5E\t",
+		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
 				c->getTime() / timeScale);
 
 	if (fields.test(RedshiftColumn))
-		p += std::sprintf(buffer + p, "%1.5E\t", c->getRedshift());
+		p += std::snprintf(buffer + p, 1024, "%1.5E\t", c->getRedshift());
 
 	if (fields.test(SerialNumberColumn))
-		p += std::sprintf(buffer + p, "%10lu\t",
+		p += std::snprintf(buffer + p, 1024, "%10lu\t",
 				c->getSerialNumber());
 	if (fields.test(CurrentIdColumn))
-		p += std::sprintf(buffer + p, "%10i\t", c->current.getId());
+		p += std::snprintf(buffer + p, 1024, "%10i\t", c->current.getId());
 	if (fields.test(CurrentEnergyColumn))
-		p += std::sprintf(buffer + p, "%8.5E\t",
+		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
 				c->current.getEnergy() / energyScale);
 	if (fields.test(CurrentPositionColumn)) {
 		if (oneDimensional) {
-			p += std::sprintf(buffer + p, "%8.5E\t",
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t",
 					c->current.getPosition().x / lengthScale);
 		} else {
 			const Vector3d pos = c->current.getPosition() / lengthScale;
-			p += std::sprintf(buffer + p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 	if (fields.test(CurrentDirectionColumn)) {
 		if (not oneDimensional) {
 			const Vector3d pos = c->current.getDirection();
-			p += std::sprintf(buffer + p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 
 	if (fields.test(SerialNumberColumn))
-		p += std::sprintf(buffer + p, "%10lu\t", c->getSourceSerialNumber());
+		p += std::snprintf(buffer + p, 1024, "%10lu\t", c->getSourceSerialNumber());
 	if (fields.test(SourceIdColumn))
-		p += std::sprintf(buffer + p, "%10i\t", c->source.getId());
+		p += std::snprintf(buffer + p, 1024, "%10i\t", c->source.getId());
 	if (fields.test(SourceEnergyColumn))
-		p += std::sprintf(buffer + p, "%8.5E\t",
+		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
 				c->source.getEnergy() / energyScale);
 	if (fields.test(SourcePositionColumn)) {
 		if (oneDimensional) {
-			p += std::sprintf(buffer + p, "%8.5E\t",
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t",
 					c->source.getPosition().x / lengthScale);
 		} else {
 			const Vector3d pos = c->source.getPosition() / lengthScale;
-			p += std::sprintf(buffer + p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 	if (fields.test(SourceDirectionColumn)) {
 		if (not oneDimensional) {
 			const Vector3d pos = c->source.getDirection();
-			p += std::sprintf(buffer + p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 
 	}
 
 	if (fields.test(SerialNumberColumn))
-		p += std::sprintf(buffer + p, "%10lu\t",
+		p += std::snprintf(buffer + p, 1024, "%10lu\t",
 				c->getCreatedSerialNumber());
 	if (fields.test(CreatedIdColumn))
-		p += std::sprintf(buffer + p, "%10i\t", c->created.getId());
+		p += std::snprintf(buffer + p, 1024, "%10i\t", c->created.getId());
 	if (fields.test(CreatedEnergyColumn))
-		p += std::sprintf(buffer + p, "%8.5E\t",
+		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
 				c->created.getEnergy() / energyScale);
 	if (fields.test(CreatedPositionColumn)) {
 		if (oneDimensional) {
-			p += std::sprintf(buffer + p, "%8.5E\t",
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t",
 					c->created.getPosition().x / lengthScale);
 		} else {
 			const Vector3d pos = c->created.getPosition() / lengthScale;
-			p += std::sprintf(buffer + p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 	if (fields.test(CreatedDirectionColumn)) {
 		if (not oneDimensional) {
 			const Vector3d pos = c->created.getDirection();
-			p += std::sprintf(buffer + p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 	if (fields.test(WeightColumn)) {
-		p += std::sprintf(buffer + p, "%8.5E\t", c->getWeight());
+		p += std::snprintf(buffer + p, 1024, "%8.5E\t", c->getWeight());
 	}
 	if (fields.test(CandidateTagColumn)) {
-		p += std::sprintf(buffer + p, "%s\t", c->getTagOrigin().c_str());
+		p += std::snprintf(buffer + p, 1024, "%s\t", c->getTagOrigin().c_str());
 	}
 
 	for(std::vector<Output::Property>::const_iterator iter = properties.begin();
@@ -273,8 +273,8 @@ void TextOutput::process(Candidate *c) const {
 			} else {
 				v = (*iter).defaultValue;
 			}
-			p += std::sprintf(buffer + p, "%s", v.toString("\t").c_str());
-			p += std::sprintf(buffer + p, "\t");
+			p += std::snprintf(buffer + p, 1024, "%s", v.toString("\t").c_str());
+			p += std::snprintf(buffer + p, 1024, "\t");
 	}
 	buffer[p - 1] = '\n';
 

--- a/src/module/TextOutput.cpp
+++ b/src/module/TextOutput.cpp
@@ -9,6 +9,7 @@
 
 #include <sstream>
 #include <cstdio>
+#include <cinttypes>
 #include <stdexcept>
 #include <iostream>
 
@@ -166,103 +167,104 @@ void TextOutput::process(Candidate *c) const {
 	if (fields.none() && properties.empty())
 		return;
 
-	char buffer[1024];
+	size_t buffersize = 2048;
+	char buffer[buffersize];
 	size_t p = 0;
 
 	std::locale old_locale = std::locale::global(std::locale::classic());
 
 	if (fields.test(TrajectoryLengthColumn))
-		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
+		p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t",
 				c->getTrajectoryLength() / lengthScale);
 	if (fields.test(TimeColumn))
-		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
+		p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t",
 				c->getTime() / timeScale);
 
 	if (fields.test(RedshiftColumn))
-		p += std::snprintf(buffer + p, 1024, "%1.5E\t", c->getRedshift());
+		p += std::snprintf(buffer + p, buffersize - p, "%1.5E\t", c->getRedshift());
 
 	if (fields.test(SerialNumberColumn))
-		p += std::snprintf(buffer + p, 1024, "%10llu\t",
+		p += std::snprintf(buffer + p, buffersize - p, "%10" PRIu64 "\t",
 				c->getSerialNumber());
 	if (fields.test(CurrentIdColumn))
-		p += std::snprintf(buffer + p, 1024, "%10i\t", c->current.getId());
+		p += std::snprintf(buffer + p, buffersize - p, "%10i\t", c->current.getId());
 	if (fields.test(CurrentEnergyColumn))
-		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
+		p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t",
 				c->current.getEnergy() / energyScale);
 	if (fields.test(CurrentPositionColumn)) {
 		if (oneDimensional) {
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t",
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t",
 					c->current.getPosition().x / lengthScale);
 		} else {
 			const Vector3d pos = c->current.getPosition() / lengthScale;
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 	if (fields.test(CurrentDirectionColumn)) {
 		if (not oneDimensional) {
 			const Vector3d pos = c->current.getDirection();
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 
 	if (fields.test(SerialNumberColumn))
-		p += std::snprintf(buffer + p, 1024, "%10llu\t", c->getSourceSerialNumber());
+		p += std::snprintf(buffer + p, buffersize - p, "%10" PRIu64 "\t", c->getSourceSerialNumber());
 	if (fields.test(SourceIdColumn))
-		p += std::snprintf(buffer + p, 1024, "%10i\t", c->source.getId());
+		p += std::snprintf(buffer + p, buffersize - p, "%10i\t", c->source.getId());
 	if (fields.test(SourceEnergyColumn))
-		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
+		p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t",
 				c->source.getEnergy() / energyScale);
 	if (fields.test(SourcePositionColumn)) {
 		if (oneDimensional) {
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t",
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t",
 					c->source.getPosition().x / lengthScale);
 		} else {
 			const Vector3d pos = c->source.getPosition() / lengthScale;
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 	if (fields.test(SourceDirectionColumn)) {
 		if (not oneDimensional) {
 			const Vector3d pos = c->source.getDirection();
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 
 	}
 
 	if (fields.test(SerialNumberColumn))
-		p += std::snprintf(buffer + p, 1024, "%10llu\t",
+		p += std::snprintf(buffer + p, buffersize - p, "%10" PRIu64 "\t",
 				c->getCreatedSerialNumber());
 	if (fields.test(CreatedIdColumn))
-		p += std::snprintf(buffer + p, 1024, "%10i\t", c->created.getId());
+		p += std::snprintf(buffer + p, buffersize - p, "%10i\t", c->created.getId());
 	if (fields.test(CreatedEnergyColumn))
-		p += std::snprintf(buffer + p, 1024, "%8.5E\t",
+		p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t",
 				c->created.getEnergy() / energyScale);
 	if (fields.test(CreatedPositionColumn)) {
 		if (oneDimensional) {
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t",
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t",
 					c->created.getPosition().x / lengthScale);
 		} else {
 			const Vector3d pos = c->created.getPosition() / lengthScale;
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 	if (fields.test(CreatedDirectionColumn)) {
 		if (not oneDimensional) {
 			const Vector3d pos = c->created.getDirection();
-			p += std::snprintf(buffer + p, 1024, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
+			p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t%8.5E\t%8.5E\t", pos.x, pos.y,
 					pos.z);
 		}
 	}
 	if (fields.test(WeightColumn)) {
-		p += std::snprintf(buffer + p, 1024, "%8.5E\t", c->getWeight());
+		p += std::snprintf(buffer + p, buffersize - p, "%8.5E\t", c->getWeight());
 	}
 	if (fields.test(CandidateTagColumn)) {
-		p += std::snprintf(buffer + p, 1024, "%s\t", c->getTagOrigin().c_str());
+		p += std::snprintf(buffer + p, buffersize - p, "%s\t", c->getTagOrigin().c_str());
 	}
 
 	for(std::vector<Output::Property>::const_iterator iter = properties.begin();
@@ -273,8 +275,8 @@ void TextOutput::process(Candidate *c) const {
 			} else {
 				v = (*iter).defaultValue;
 			}
-			p += std::snprintf(buffer + p, 1024, "%s", v.toString("\t").c_str());
-			p += std::snprintf(buffer + p, 1024, "\t");
+			p += std::snprintf(buffer + p, buffersize - p, "%s", v.toString("\t").c_str());
+			p += std::snprintf(buffer + p, buffersize - p, "\t");
 	}
 	buffer[p - 1] = '\n';
 


### PR DESCRIPTION
Hey,

with this PR I want to introduce the new CXX standard 23 to CRPropa, it enables us to use more modern code in future additions which should make it easier to contribute.
Furthermore CXX23 introduces the new deducing this which enables us to use CRTP (Curious Reoccurring Template Patterns) instead of vtables while keeping the fundamental structures of CRPropa, this is important for an eventual GPU extension.

I also tried to tackle many warnings that arose in the past, in the process of that I discovered some major bugs which I also fixed here (see comments in code for more details):
- `type`  instead of `to_type` in `Variant.cpp`
- missing return in `Variant.cpp`
- deprecated / missing `ENDDO` statements in `sophia_interface.f` 
- broken doxygen commands
- depricated `sprintf` replaced with `snprintf`
- missing include path in `FindGooglePerfTools.cmake`
- missing brackets in `Random.cpp`
- not initialized `constScaleBendover` in preconstructor
- `extends` never set in `PeriodicMagneticField::setExtends`
- never set `Bphi` in `CMZField.cpp` if r<=r1
- issue between `clang` and `gcc` when formatting `uint64_t`, now using macro `"%10" PRIu64 "\t"` which set it automatically
- added more modern build tool `ninja` to workflows