### PR TITLE
Small editorial fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 * Fixed r term in source distribution for SNR and Pulsar
 * Fixed wrong mass inheritance for secondaries other than nuclei or electron/positron
 * Fixed wrong generation of interval ranges in ObserverTimeEvolution
+* Fixed several compile warnings, e.g., in sophia_interface.f
+* Fixed broken doxygen commands
+* Fixed Bphi component for r<=r1 in CMZField
+* Fixed several issues in Variant and Random
+* Fixed setExtends in PeriodicMagneticField
+* Fixed constantScaleBendover which was not initialized 
 
 ### New features:
 
@@ -17,6 +23,7 @@
 
 
 ### Interface changes:
+* The next CRPropa relase will likely require support for the CXX 23 standard
 
 ### Features that are deprecated and will be removed after this release
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CRPropa
 ![stable release](https://img.shields.io/badge/stable\_release-3.2.1-darkblue)
 
 [![Build: ubuntu22](https://github.com/CRPropa/CRPropa3/actions/workflows/testing_ubuntu22.yml/badge.svg)](https://github.com/CRPropa/CRPropa3/actions/workflows/testing_ubuntu22.yml)
-[![Build: ubuntu20](https://github.com/CRPropa/CRPropa3/actions/workflows/testing_ubuntu20.yml/badge.svg)](https://github.com/CRPropa/CRPropa3/actions/workflows/testing_ubuntu20.yml)
+[![Build: ubuntu20](https://github.com/CRPropa/CRPropa3/actions/workflows/testing_ubuntu24.yml/badge.svg)](https://github.com/CRPropa/CRPropa3/actions/workflows/testing_ubuntu24.yml)
 [![Build: macos14](https://github.com/CRPropa/CRPropa3/actions/workflows/testing_OSX.yml/badge.svg)](https://github.com/CRPropa/CRPropa3/actions/workflows/testing_OSX.yml)
 [![Examples](https://github.com/CRPropa/CRPropa3/actions/workflows/test_examples.yml/badge.svg)](https://github.com/CRPropa/CRPropa3/actions/workflows/test_examples.yml)
 


### PR DESCRIPTION
This PR adds 
- a list of the bug fixes introduced with PR #537 to the CHANGELOG file

Furthermore, it fixes
- the displayed badges in the README file that have been broken since the test runners have been updated from ubuntu 20 to ubuntu 24