### PR TITLE
add deprecation for Galactic Magnetic Lenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * The next CRPropa relase will likely require support for the CXX 23 standard
 
 ### Features that are deprecated and will be removed after this release
+* Galactic Magnetic Lenses
 
 ### Removed features
 *  AMRMagneticField - underlying library (saga) is no longer supported.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ SET(EIGEN_PATH  "" CACHE STRING "Use EIGEN from this path instead of the version
 SET(WITH_GALACTIC_LENSES FALSE)
 
 if(ENABLE_GALACTICMAGNETICLENS)
-  message(DEPRECATE "Galactic magnetic lens support is deprecated and will be removed in a future release.")
+  message(DEPRECATION "Galactic magnetic lens support is deprecated and will be removed in a future release.")
   SET(WITH_GALACTIC_LENSES TRUE)
 
   if(EIGEN_PATH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ SET(EIGEN_PATH  "" CACHE STRING "Use EIGEN from this path instead of the version
 SET(WITH_GALACTIC_LENSES FALSE)
 
 if(ENABLE_GALACTICMAGNETICLENS)
+  message(DEPRECATE "Galactic magnetic lens support is deprecated and will be removed in a future release.")
   SET(WITH_GALACTIC_LENSES TRUE)
 
   if(EIGEN_PATH)


### PR DESCRIPTION
For the next version (3.2.2) we will deprecate the lenses. They are not working with any current numpy / python version. 
They will be removed in version 3.3. 
