### PR TITLE
Bugfixes workflows

### DIFF
--- a/.github/workflows/create_conda_package_arm.yml
+++ b/.github/workflows/create_conda_package_arm.yml
@@ -13,17 +13,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    branches:
-      - master
-      - releases/**
   
 
 jobs:
   arm:
     if: github.repository=='CRPropa/CRPropa3'
     runs-on: ubuntu-22.04-arm
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/create_conda_package_arm.yml
+++ b/.github/workflows/create_conda_package_arm.yml
@@ -17,47 +17,8 @@ on:
       - master
       - releases/**
   
-  
 
 jobs:
-  x64:
-    if: github.repository=='CRPropa/CRPropa3'
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Preinstall
-        run: |
-          set -ex
-          ldd --version
-          conda init &> /dev/null
-          conda update -n base conda -y &> /dev/null
-          conda install conda-build anaconda-client -y &> /dev/null
-      - name: Build Conda Package
-        env:
-          accountName: ${{ secrets.ANACONDA_ACCOUNTNAME }}
-          token: ${{ secrets.ANACONDA_TOKEN }}
-          FAST_WAVES: "ON"
-          SIMD_EXTENSIONS: "avx+fma"
-        run: |
-          set -ex
-          conda init &> /dev/null
-          cd conda-bld
-          conda config --set anaconda_upload yes 
-          export CRPROPA_VERSION=${GITHUB_REF_NAME,,}
-          conda build -m conda_build_config.yaml -c conda-forge . -k \
-            --user $accountName \
-            --token $token \
-            | tee build.log
-      - name: Archive Build Logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: "Anaconda_Build_x64_Log"
-          path: conda-bld/build.log
-
   arm:
     if: github.repository=='CRPropa/CRPropa3'
     runs-on: ubuntu-22.04-arm

--- a/.github/workflows/create_conda_package_x64.yml
+++ b/.github/workflows/create_conda_package_x64.yml
@@ -1,0 +1,58 @@
+name: create_conda_package
+on:
+  push:
+    branches: 
+      - master
+      - releases/**
+    paths:
+      - "**.cpp"
+      - "**.h"
+      - "**.py"
+      - "**.i"
+      - "**/CMakeLists.txt"
+  release:
+    types: [published]
+  workflow_dispatch:
+    branches:
+      - master
+      - releases/**
+  
+
+jobs:
+  x64:
+    if: github.repository=='CRPropa/CRPropa3'
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Preinstall
+        run: |
+          set -ex
+          ldd --version
+          conda init &> /dev/null
+          conda update -n base conda -y &> /dev/null
+          conda install conda-build anaconda-client -y &> /dev/null
+      - name: Build Conda Package
+        env:
+          accountName: ${{ secrets.ANACONDA_ACCOUNTNAME }}
+          token: ${{ secrets.ANACONDA_TOKEN }}
+          FAST_WAVES: "ON"
+          SIMD_EXTENSIONS: "avx+fma"
+        run: |
+          set -ex
+          conda init &> /dev/null
+          cd conda-bld
+          conda config --set anaconda_upload yes 
+          export CRPROPA_VERSION=${GITHUB_REF_NAME,,}
+          conda build -m conda_build_config.yaml -c conda-forge . -k \
+            --user $accountName \
+            --token $token \
+            | tee build.log
+      - name: Archive Build Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "Anaconda_Build_x64_Log"
+          path: conda-bld/build.log

--- a/.github/workflows/create_conda_package_x64.yml
+++ b/.github/workflows/create_conda_package_x64.yml
@@ -13,17 +13,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    branches:
-      - master
-      - releases/**
   
 
 jobs:
   x64:
     if: github.repository=='CRPropa/CRPropa3'
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/create_coverage_report.yml
+++ b/.github/workflows/create_coverage_report.yml
@@ -3,19 +3,18 @@ on: [workflow_dispatch]
 
 jobs: 
     create-coverage-report: 
-      runs-on: ubuntu-latest
-  
+      runs-on: ${{ matrix.config.os }}
       strategy:
         fail-fast: false
         matrix:
           config:
-            - name: "ubuntu-22"
-              os: ubuntu-22.04
-              cxx: "g++-11"
-              cc: "gcc-11"
-              fc: "gfortran-11"
-              swig_builtin: "On" #uses swig 4.0.2
-              py: "/usr/bin/python3" #python 3.10
+            - name: "ubuntu-24"
+              os: ubuntu-24.04
+              cxx: "g++-14"
+              cc: "gcc-14"
+              fc: "gfortran-14"
+              swig_builtin: "On" 
+              py: "/usr/bin/python3"
       # define steps to take
       steps: 
         - name: Checkout repository

--- a/.github/workflows/create_coverage_report.yml
+++ b/.github/workflows/create_coverage_report.yml
@@ -35,7 +35,7 @@ jobs:
         - name: run test
           run: | 
             cd build
-            ctest --output-on-failure
+            ctest --output-on-failure --repeat until-pass:3
           continue-on-error: true
         - name: coverage report
           run: |

--- a/.github/workflows/create_coverage_report.yml
+++ b/.github/workflows/create_coverage_report.yml
@@ -25,7 +25,6 @@ jobs:
             pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
         - name: Set up the build
           run: |
-            set -ex
             mkdir build
             cd build
             cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=OFF -DENABLE_COVERAGE=On

--- a/.github/workflows/create_coverage_report.yml
+++ b/.github/workflows/create_coverage_report.yml
@@ -10,9 +10,6 @@ jobs:
           config:
             - name: "ubuntu-24"
               os: ubuntu-24.04
-              cxx: "g++-14"
-              cc: "gcc-14"
-              fc: "gfortran-14"
               swig_builtin: "On" 
               py: "/usr/bin/python3"
       # define steps to take
@@ -27,11 +24,8 @@ jobs:
             pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
             pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
         - name: Set up the build
-          env:
-            CXX: ${{ matrix.config.cxx }}
-            CC: ${{ matrix.config.cc }}
-            FC: ${{ matrix.config.fc }}
           run: |
+            set -ex
             mkdir build
             cd build
             cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=OFF -DENABLE_COVERAGE=On

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -45,6 +45,8 @@ jobs:
         run: |
           set -ex
           cd build
+          cp -r ../doc doc-source
+          cp -r xml doc-source/
           ninja doc
           cp -r coverageReport doc/pages/coverageReport
           tar -zcvf documentation.tar.gz doc  

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -22,17 +22,16 @@ jobs:
           sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz
           sudo apt-get install pandoc # do not only use pip to install pandoc, see https://stackoverflow.com/questions/62398231/building-docs-fails-due-to-missing-pandoc
           pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
-          pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
+          pip install ninja sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
       - name: Set up the build
         run: |
-          set -ex
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build
-          make -j
+          cmake --build .
       - name: run test
         run: | 
           cd build
@@ -41,11 +40,12 @@ jobs:
       - name: coverage report
         run: |
           cd build
-          make coverage
+          ninja coverage
       - name: build documentation
         run: |
+          set -ex
           cd build
-          make doc
+          ninja doc
           cp -r coverageReport doc/pages/coverageReport
           tar -zcvf documentation.tar.gz doc  
       - name: archive documentation

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -3,20 +3,18 @@ on: [workflow_dispatch]
 
 jobs: 
   create-documentation: 
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
         config:
-          - name: "ubuntu-22"
-            os: ubuntu-22.04
-            cxx: "g++-11"
-            cc: "gcc-11"
-            fc: "gfortran-11"
-            swig_builtin: "On" #uses swig 4.0.2
-            py: "/usr/bin/python3" #python 3.10
-    
+          - name: "ubuntu-24"
+            os: ubuntu-24.04
+            cxx: "g++-14"
+            cc: "gcc-14"
+            fc: "gfortran-14"
+            swig_builtin: "On" 
+            py: "/usr/bin/python3"
     # define steps to take
     steps: 
       - name: Checkout repository

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: run test
         run: | 
           cd build
-          ctest --output-on-failure
+          ctest --output-on-failure --repeat until-pass:3
         continue-on-error: true
       - name: coverage report
         run: |

--- a/.github/workflows/create_documentation.yml
+++ b/.github/workflows/create_documentation.yml
@@ -10,9 +10,6 @@ jobs:
         config:
           - name: "ubuntu-24"
             os: ubuntu-24.04
-            cxx: "g++-14"
-            cc: "gcc-14"
-            fc: "gfortran-14"
             swig_builtin: "On" 
             py: "/usr/bin/python3"
     # define steps to take
@@ -27,11 +24,8 @@ jobs:
           pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
           pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
       - name: Set up the build
-        env:
-          CXX: ${{ matrix.config.cxx }}
-          CC: ${{ matrix.config.cc }}
-          FC: ${{ matrix.config.fc }}
         run: |
+          set -ex
           mkdir build
           cd build
           cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On

--- a/.github/workflows/deploy_new_documentation.yml
+++ b/.github/workflows/deploy_new_documentation.yml
@@ -7,20 +7,19 @@ on:
 
 jobs: 
   build-and-deploy: 
-    runs-on: ubuntu-latest
-
+    if: github.repository=='CRPropa/CRPropa3'
+    runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
         config:
-          - name: "ubuntu-22"
-            os: ubuntu-22.04
-            cxx: "g++-11"
-            cc: "gcc-11"
-            fc: "gfortran-11"
-            swig_builtin: "On" #uses swig 4.0.2
-            py: "/usr/bin/python3" #python 3.10
-    
+          - name: "ubuntu-24"
+            os: ubuntu-24.04
+            cxx: "g++-14"
+            cc: "gcc-14"
+            fc: "gfortran-14"
+            swig_builtin: "On" 
+            py: "/usr/bin/python3"
     # define steps to take
     steps: 
       - name: Checkout repository

--- a/.github/workflows/deploy_new_documentation.yml
+++ b/.github/workflows/deploy_new_documentation.yml
@@ -47,7 +47,7 @@ jobs:
       - name: run test
         run: | 
           cd build
-          ctest --output-on-failure
+          ctest --output-on-failure --repeat until-pass:3
         continue-on-error: true
       - name: coverage report
         run: |

--- a/.github/workflows/testing_OSX.yml
+++ b/.github/workflows/testing_OSX.yml
@@ -54,7 +54,7 @@ jobs:
          CRPROPA_DATA_PATH: "/Users/runner/work/CRPropa3/CRPropa3/build/data"
        run: |
          cd build
-         ctest --output-on-failure
+         ctest --output-on-failure --repeat until-pass:3
      - name: Archive test results
        if: always()
        uses: actions/upload-artifact@v4

--- a/.github/workflows/testing_ubuntu22.yml
+++ b/.github/workflows/testing_ubuntu22.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          ctest --output-on-failure
+          ctest --output-on-failure --repeat until-pass:3
       - name: Archive test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/testing_ubuntu24.yml
+++ b/.github/workflows/testing_ubuntu24.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          ctest --output-on-failure
+          ctest --output-on-failure --repeat until-pass:3
       - name: Archive test results
         if: always()
         uses: actions/upload-artifact@v4
@@ -84,7 +84,7 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          ctest --output-on-failure
+          ctest --output-on-failure --repeat until-pass:3
       - name: Archive test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,9 @@ if(ENABLE_COVERAGE)
       )
       add_custom_target(coverage
         # generate coverage data
-        COMMAND ${LCOV_PATH} --directory ${CMAKE_CURRENT_BINARY_DIR} --capture --output-file ${CMAKE_CURRENT_BINARY_DIR}/coverage.info --ignore-errors negative,inconsistent,unused VERBATIM
+        COMMAND ${LCOV_PATH} --directory ${CMAKE_CURRENT_BINARY_DIR} --capture --output-file ${CMAKE_CURRENT_BINARY_DIR}/coverage.info --ignore-errors "branch,callback,child,corrupt,count,deprecated,empty,excessive,fork,format,gcov,graph,inconsistent,internal,mismatch,missing,negative,package,parent,range,source,unreachable,unsupported,unused,usage,utility,version" VERBATIM
         # clean external libs
-        COMMAND ${LCOV_PATH} --remove ${CMAKE_CURRENT_BINARY_DIR}/coverage.info "/usr/include/*" "/usr/lib/*" "*/libs/gtest/*" "*/libs/eigen3/*" "*/libs/zstream-cpp/*" "*/build/*" -o ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned --ignore-errors negative,inconsistent,unused VERBATIM
+        COMMAND ${LCOV_PATH} --remove ${CMAKE_CURRENT_BINARY_DIR}/coverage.info "/usr/include/*" "/usr/lib/*" "*/libs/gtest/*" "*/libs/eigen3/*" "*/libs/zstream-cpp/*" "*/build/*" -o ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned --ignore-errors "branch,callback,child,corrupt,count,deprecated,empty,excessive,fork,format,gcov,graph,inconsistent,internal,mismatch,missing,negative,package,parent,range,source,unreachable,unsupported,unused,usage,utility,version" VERBATIM
         # Generate html output
         COMMAND ${GENHTML_PATH} -o ${CMAKE_CURRENT_BINARY_DIR}/coverageReport ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned VERBATIM
         COMMAND echo "Generated coverage report in ${CMAKE_CURRENT_BINARY_DIR}/coverageReport/index.html"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,7 +580,9 @@ if(BUILD_DOC AND DOXYGEN_FOUND AND SPHINX_EXECUTABLE)
   find_package_handle_standard_args(Sphinx
                                     "Failed to find sphinx-build executable"
                                     SPHINX_EXECUTABLE)
-  set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/doc)
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/doc "${CMAKE_CURRENT_BINARY_DIR}/doc-source")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/xml "${CMAKE_CURRENT_BINARY_DIR}/doc-source/xml")
+  set(SPHINX_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/doc-source")
   set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/doc)
   add_custom_target(doc
                     ${SPHINX_EXECUTABLE} -b html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,9 @@ if(ENABLE_COVERAGE)
       )
       add_custom_target(coverage
         # generate coverage data
-        COMMAND ${LCOV_PATH} --directory ${CMAKE_CURRENT_BINARY_DIR} --capture --output-file ${CMAKE_CURRENT_BINARY_DIR}/coverage.info VERBATIM
+        COMMAND ${LCOV_PATH} --directory ${CMAKE_CURRENT_BINARY_DIR} --capture --output-file ${CMAKE_CURRENT_BINARY_DIR}/coverage.info --ignore-errors negative,inconsistent,unused VERBATIM
         # clean external libs
-        COMMAND ${LCOV_PATH} --remove ${CMAKE_CURRENT_BINARY_DIR}/coverage.info "/usr/include/*" "/usr/lib/*" "*/libs/gtest/*" "*/libs/eigen3/*" "*/libs/zstream-cpp/*" "*/build/*" -o ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned VERBATIM
+        COMMAND ${LCOV_PATH} --remove ${CMAKE_CURRENT_BINARY_DIR}/coverage.info "/usr/include/*" "/usr/lib/*" "*/libs/gtest/*" "*/libs/eigen3/*" "*/libs/zstream-cpp/*" "*/build/*" -o ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned --ignore-errors negative,inconsistent,unused VERBATIM
         # Generate html output
         COMMAND ${GENHTML_PATH} -o ${CMAKE_CURRENT_BINARY_DIR}/coverageReport ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned VERBATIM
         COMMAND echo "Generated coverage report in ${CMAKE_CURRENT_BINARY_DIR}/coverageReport/index.html"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,9 @@ if(ENABLE_COVERAGE)
       )
       add_custom_target(coverage
         # generate coverage data
-        COMMAND ${LCOV_PATH} --directory ${CMAKE_CURRENT_BINARY_DIR} --capture --output-file ${CMAKE_CURRENT_BINARY_DIR}/coverage.info --ignore-errors "branch,callback,child,corrupt,count,deprecated,empty,excessive,fork,format,gcov,graph,inconsistent,internal,mismatch,missing,negative,package,parent,range,source,unreachable,unsupported,unused,usage,utility,version" VERBATIM
+        COMMAND ${LCOV_PATH} --directory ${CMAKE_CURRENT_BINARY_DIR} --capture --output-file ${CMAKE_CURRENT_BINARY_DIR}/coverage.info --ignore-errors negative,inconsistent,unused VERBATIM
         # clean external libs
-        COMMAND ${LCOV_PATH} --remove ${CMAKE_CURRENT_BINARY_DIR}/coverage.info "/usr/include/*" "/usr/lib/*" "*/libs/gtest/*" "*/libs/eigen3/*" "*/libs/zstream-cpp/*" "*/build/*" -o ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned --ignore-errors "branch,callback,child,corrupt,count,deprecated,empty,excessive,fork,format,gcov,graph,inconsistent,internal,mismatch,missing,negative,package,parent,range,source,unreachable,unsupported,unused,usage,utility,version" VERBATIM
+        COMMAND ${LCOV_PATH} --remove ${CMAKE_CURRENT_BINARY_DIR}/coverage.info "/usr/include/*" "/usr/lib/*" "*/libs/gtest/*" "*/libs/eigen3/*" "*/libs/zstream-cpp/*" "*/build/*" -o ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned --ignore-errors negative,inconsistent,unused VERBATIM
         # Generate html output
         COMMAND ${GENHTML_PATH} -o ${CMAKE_CURRENT_BINARY_DIR}/coverageReport ${CMAKE_CURRENT_BINARY_DIR}/coverage.info.cleaned VERBATIM
         COMMAND echo "Generated coverage report in ${CMAKE_CURRENT_BINARY_DIR}/coverageReport/index.html"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,7 +450,7 @@ endif(BUILD_DOC)
 # ----------------------------------------------------------------------------
 option(ENABLE_PYTHON "Create python library via SWIG" ON)
 
-find_package(Python 3.0 REQUIRED COMPONENTS Interpreter Development NumPy)
+find_package(Python 3.0 COMPONENTS Interpreter Development NumPy)
 
 if(ENABLE_PYTHON AND Python_FOUND)
   find_package(SWIG 3.0 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,8 @@ endif(BUILD_DOC)
 # ----------------------------------------------------------------------------
 option(ENABLE_PYTHON "Create python library via SWIG" ON)
 
+set(Python_FIND_VIRTUALENV "FIRST")
+set(Python_FIND_STRATEGY "LOCATION")
 find_package(Python 3.0 COMPONENTS Interpreter Development NumPy)
 
 if(ENABLE_PYTHON AND Python_FOUND)

--- a/conda-bld/build.sh
+++ b/conda-bld/build.sh
@@ -41,7 +41,7 @@ cp -r libs/ $PREFIX/share/crpropa/test/
 # copy ctest instructions
 cp CTestTestfile.cmake $PREFIX/share/crpropa/test/
 # generate executable test file
-echo ctest --test-dir $PREFIX/share/crpropa/test/ --output-on-failure > $PREFIX/bin/testCRPropa
+echo ctest --test-dir $PREFIX/share/crpropa/test/ --output-on-failure --repeat until-pass:3 > $PREFIX/bin/testCRPropa
 chmod +x $PREFIX/bin/testCRPropa
 
 # Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.


### PR DESCRIPTION
Hey,

@JulienDoerner and I worked on some bugfixes for the current workflows:
- splitted conda workflows in two files to be able to restart them separately
- fixed `.github/workflows/create_coverage_report.yml` workflow and updated to ubuntu24
- fixed `.github/workflows/create_documentation.yml` workflow and updated to ubuntu24
- fixed `.github/workflows/deploy_new_documentation.yml` workflow and updated to ubuntu24
- removed `REQUIRED` flag from python since we can compile without it
- added extra python hints so cmake is able to find virtual envs and conda environments first
- added `--repeat until-pass:3` to all ctest (was addressed in #456). Since we checking the success of stochastic processes it is possible that some tests fail randomly. With `--repeat until-pass:3` we can counter that behavior by making it extremely unlikely tests fail 3 times in a row.

Links to successfully run workflows:
- [create-documentation](https://github.com/JanNiklasB/CRPropa3/actions/runs/26526591326/job/78131787825)
- [create-coverage-report](https://github.com/JanNiklasB/CRPropa3/actions/runs/26514666007/job/78088314917)