### PR TITLE
quick fix for deploy_new_documentation.yaml

### DIFF
--- a/.github/workflows/deploy_new_documentation.yml
+++ b/.github/workflows/deploy_new_documentation.yml
@@ -15,9 +15,6 @@ jobs:
         config:
           - name: "ubuntu-24"
             os: ubuntu-24.04
-            cxx: "g++-14"
-            cc: "gcc-14"
-            fc: "gfortran-14"
             swig_builtin: "On" 
             py: "/usr/bin/python3"
     # define steps to take
@@ -30,20 +27,16 @@ jobs:
           sudo apt-get install libmuparser-dev libhdf5-serial-dev libomp5 libomp-dev libfftw3-dev libcfitsio-dev lcov doxygen graphviz
           sudo apt-get install pandoc # do not only use pip to install pandoc, see https://stackoverflow.com/questions/62398231/building-docs-fails-due-to-missing-pandoc
           pip install -r doc/pages/example_notebooks/requirements.txt # load requirements for notebooks
-          pip install sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
+          pip install ninja sphinx==7.2.6 sphinx_rtd_theme m2r2 nbsphinx lxml_html_clean breathe pandoc exhale # load requirements for documentation
       - name: Set up the build
-        env:
-          CXX: ${{ matrix.config.cxx }}
-          CC: ${{ matrix.config.cc }}
-          FC: ${{ matrix.config.fc }}
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DENABLE_PYTHON=True -DPython_EXECUTABLE=${{ matrix.config.py }} -DENABLE_TESTING=On -DENABLE_SWIG_BUILTIN=${{ matrix.config.swig_builtin }} -DSIMD_EXTENSIONS=native -DPython_INSTALL_PACKAGE_DIR=/home/runner/.local/ -DBUILD_DOC=On -DENABLE_COVERAGE=On
       - name: Build CRPropa
         run: |
           cd build
-          make -j
+          cmake --build .
       - name: run test
         run: | 
           cd build
@@ -52,15 +45,19 @@ jobs:
       - name: coverage report
         run: |
           cd build
-          make coverage
+          ninja coverage
       - name: build documentation
         run: |
+          set -ex
           cd build
-          make doc
+          cp -r ../doc doc-source
+          cp -r xml doc-source/
+          ninja doc
+          cp -r coverageReport doc/pages/coverageReport
+          tar -zcvf documentation.tar.gz doc
       - name: move final documentation # to avoid conflict with .gitignore
         run: | 
-          mv build/doc ~/final_doc 
-          cp -r build/coverageReport ~/final_doc/pages/coverageReport
+          mv build/doc ~/final_doc
       - name: deploy documentation #deploys the documentation to the gh-pages branch
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
In the last merge #544 I forgot to update the deploy_new_documentation workflow with the fixes I applied to create_documentation workflow, this PR should fix that (see test [here](https://github.com/JanNiklasB/CRPropa3/actions/runs/27349593212/job/80807453676)]