### PR TITLE
Downgrade github-pages-deploy-action to version 5

### DIFF
--- a/.github/workflows/create_conda_package_arm.yml
+++ b/.github/workflows/create_conda_package_arm.yml
@@ -1,4 +1,4 @@
-name: create_conda_package
+name: create_conda_package_arm
 on:
   push:
     branches: 

--- a/.github/workflows/create_conda_package_macos.yml
+++ b/.github/workflows/create_conda_package_macos.yml
@@ -1,4 +1,4 @@
-name: create_conda_package
+name: create_conda_package_macos
 on:
   push:
     branches: 

--- a/.github/workflows/create_conda_package_x64.yml
+++ b/.github/workflows/create_conda_package_x64.yml
@@ -1,4 +1,4 @@
-name: create_conda_package
+name: create_conda_package_x64
 on:
   push:
     branches: 

--- a/.github/workflows/deploy_new_documentation.yml
+++ b/.github/workflows/deploy_new_documentation.yml
@@ -59,7 +59,7 @@ jobs:
         run: | 
           mv build/doc ~/final_doc
       - name: deploy documentation #deploys the documentation to the gh-pages branch
-        uses: JamesIves/github-pages-deploy-action@v7
+        uses: JamesIves/github-pages-deploy-action@v5
         with:
             folder: ~/final_doc
             


### PR DESCRIPTION
Version 5 is the most up-to-date version at this moment