### PR TITLE
bugfix: threshold calculation for PhotoPionProduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CRPropa vNext
 
 ### Bug fixes:
+* threshold calculation in PhotoPionProduction
 
 ### New features:
 * Improved plugin-template and added test to ensure the template is working

--- a/src/module/PhotoPionProduction.cpp
+++ b/src/module/PhotoPionProduction.cpp
@@ -217,13 +217,13 @@ void PhotoPionProduction::performInteraction(Candidate *candidate, bool onProton
 	int sign = (id > 0) ? 1 : -1;
 
 	// check if below SOPHIA's energy threshold
-	double E_threshold = (photonField->getFieldName() == "CMB") ? 3.72e18 * eV : 5.83e15 * eV;
-	if (EpA * (1 + z) < E_threshold)
-		return;
-
+	double Ein = EpA / GeV;  // GeV is the SOPHIA standard unit
+	double epsThreshold = epsMinInteraction(onProton, Ein);
+	if (epsThreshold > photonField->getMaximumPhotonEnergy(z)/eV) {
+		return;   
+ 	}
 	// SOPHIA - input:
 	int nature = 1 - static_cast<int>(onProton);  // 0=proton, 1=neutron
-	double Ein = EpA / GeV;  // GeV is the SOPHIA standard unit
 	double eps = sampleEps(onProton, EpA, z) / GeV;  // GeV for SOPHIA
 
 	// SOPHIA - output:


### PR DESCRIPTION
Hello everybody,
I have noticed (and fixed) a bug in `PhotoPionProduction` when working with custom photon fields.

### The Problem

The CRPropa implementation to check if an interaction is below the threshold energy threshold is

`double E_threshold = (photonField->getFieldName() == "CMB") ? 3.72e18 * eV : 5.83e15 * eV;`

These are the hard-coded limits for the CMB and IRB photon fields. For higher energy photon fields this does not apply. 

### Changes
I replaced this check by comparing the minimal interaction photon energy at the primary energy `epsMinInteraction(onProton, Ein)`  with the maximum photon energy of the photon field
 `photonField->getMaximumPhotonEnergy(z)/eV)`. This holds true for arbitrary photon fields.

### Tests
I included two test of a powerlaw injection of protons: one using a black body photon field at $10^7$ Kelvin, one using the CMB. The CMB in the fixed version should behave exactly as the main branch version (which it does), while the Xray-field should allow for production of more (lower energy) secondaries since lower primaries are able to interact. I have plotted the photon secondary energies in these tests below. Everything you need for reproduction is attached.
**Note** I modified the CRPropa-data to produce interaction tables below ~ $10^6$ GeV.

<img width="640" height="480" alt="comparison_plot" src="https://github.com/user-attachments/assets/bc9e9d8c-386a-4149-847f-43c894ca4893" />

[plots.py](https://github.com/user-attachments/files/29502959/plots.py)
[setup.py](https://github.com/user-attachments/files/29502962/setup.py)
[xray_field.py](https://github.com/user-attachments/files/29502963/xray_field.py)
