### PR TITLE
Expose interaction rates for electromagnetic processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Improved plugin-template and added test to ensure the template is working
 * Added position-dependent photon fields
 * Secondaries are now distributed over multiple threads if OpenMP parallelisation is enabled
+* Exposed `getRate` function for electromagnetic interactions
 
 ### Interface changes:
 

--- a/include/crpropa/module/EMDoublePairProduction.h
+++ b/include/crpropa/module/EMDoublePairProduction.h
@@ -89,6 +89,16 @@ public:
 	 * @param path The name of the file/folder containing the interaction rates
 	 */
 	void initRate(std::string path);
+
+	/**
+	 * Get the interaction rate for a given energy, position, and redshift.
+	 * For now, this function uses a redshift scaling factor for the interaction rate.
+	 * Future releases will include a more accurate treatment of the redshift evolution of the photon field.
+	 * @param E Energy of the primary particle
+	 * @param position Position of the primary particle
+	 * @param z Redshift of the primary particle
+	 */
+	double getRate(double E, const Vector3d &position = Vector3d(0.), double z = 0) const;
 	
 	void process(Candidate *candidate) const;
 	void performInteraction(Candidate *candidate) const;

--- a/include/crpropa/module/EMInverseComptonScattering.h
+++ b/include/crpropa/module/EMInverseComptonScattering.h
@@ -53,7 +53,7 @@ public:
 	void setHavePhotons(bool havePhotons);
 	
 	/** limit the step to a fraction of the mean free path
-	 @param limit	fraction of the mean free path, should be between 0 and 1
+	 * @param limit	fraction of the mean free path, should be between 0 and 1
 	 */
 	void setLimit(double limit);
 	
@@ -95,6 +95,16 @@ public:
 	 * @param path The name of the file/folder containing the interaction rates
 	 */
 	void initCumulativeRate(std::string path);
+
+	/**
+	 * Get the interaction rate for a given energy, position, and redshift.
+	 * For now, this function uses a redshift scaling factor for the interaction rate.
+	 * Future releases will include a more accurate treatment of the redshift evolution of the photon field.
+	 * @param E Energy of the primary particle
+	 * @param position Position of the primary particle
+	 * @param z Redshift of the primary particle
+	 */
+	double getRate(double E, const Vector3d &position = Vector3d(0.), double z = 0) const;
 
 	void process(Candidate *candidate) const;
 	void performInteraction(Candidate *candidate) const;

--- a/include/crpropa/module/EMPairProduction.h
+++ b/include/crpropa/module/EMPairProduction.h
@@ -97,6 +97,16 @@ public:
 	 * @param path The name of the file/folder containing the interaction rates
 	 */
 	void initCumulativeRate(std::string path);
+
+	/**
+	 * Get the interaction rate for a given energy, position, and redshift.
+	 * For now, this function uses a redshift scaling factor for the interaction rate.
+	 * Future releases will include a more accurate treatment of the redshift evolution of the photon field.
+	 * @param E Energy of the primary particle
+	 * @param position Position of the primary particle
+	 * @param z Redshift of the primary particle
+	 */
+	double getRate(double E, const Vector3d &position = Vector3d(0.), double z = 0) const;
 		
 	void performInteraction(Candidate *candidate) const;
 	void process(Candidate *candidate) const;

--- a/include/crpropa/module/EMTripletPairProduction.h
+++ b/include/crpropa/module/EMTripletPairProduction.h
@@ -95,6 +95,16 @@ public:
 	 * @param path The name of the file/folder containing the interaction rates
 	 */
 	void initCumulativeRate(std::string path);
+
+	/**
+	 * Get the interaction rate for a given energy, position, and redshift.
+	 * For now, this function uses a redshift scaling factor for the interaction rate.
+	 * Future releases will include a more accurate treatment of the redshift evolution of the photon field.
+	 * @param E Energy of the primary particle
+	 * @param position Position of the primary particle
+	 * @param z Redshift of the primary particle
+	 */
+	double getRate(double E, const Vector3d &position = Vector3d(0.), double z = 0) const;
 		
 	void process(Candidate *candidate) const;
 	void performInteraction(Candidate *candidate) const;

--- a/src/InteractionRates.cpp
+++ b/src/InteractionRates.cpp
@@ -11,14 +11,14 @@
 
 namespace crpropa {
 
-InteractionRatesHomogeneous::InteractionRatesHomogeneous(std::string RateFile, std::string CumulativeRateFile) {
+InteractionRatesHomogeneous::InteractionRatesHomogeneous(std::string rateFile, std::string cumulativeRateFile) {
 	this->ratesName = "interactionRatesHomogeneous";
 	this->isPositionDependent = false;
 
-	if (RateFile!="")
-		initRate(RateFile);
-	if (CumulativeRateFile!="")
-		initCumulativeRate(CumulativeRateFile);
+	if (rateFile != "")
+		initRate(rateFile);
+	if (cumulativeRateFile != "")
+		initCumulativeRate(cumulativeRateFile);
 }
 
 double InteractionRatesHomogeneous::getProcessRate(const double E, const Vector3d &position) const {
@@ -131,16 +131,16 @@ void InteractionRatesHomogeneous::initCumulativeRate(std::string filename){
 
 
 InteractionRatesPositionDependent::InteractionRatesPositionDependent(
-	std::string RateFilePath, std::string CumulativeRateFilePath, ref_ptr<Surface> surface) {
+	std::string rateFilePath, std::string cumulativeRateFilePath, ref_ptr<Surface> surface) {
 	
 	this->ratesName = "interactionRatesPositionDependent";
 	this->isPositionDependent = true;
 	this->surface = surface;
 
-	if (RateFilePath!="")
-		initRate(RateFilePath);
-	if (CumulativeRateFilePath!="")
-		initCumulativeRate(CumulativeRateFilePath);
+	if (rateFilePath != "")
+		initRate(rateFilePath);
+	if (cumulativeRateFilePath != "")
+		initCumulativeRate(cumulativeRateFilePath);
 }
 
 int InteractionRatesPositionDependent::findClosestGridPoint(const Vector3d &position) const {
@@ -335,7 +335,7 @@ void InteractionRatesPositionDependent::initCumulativeRate(std::string filepath)
 	std::vector<std::string> dirs;
 	if(!list_directory(filepath, dirs))
 		throw std::runtime_error("Could not find any files in " + filepath + "!\n");
- 
+
 	for (auto const& filename : dirs) {
 		
 		std::vector<double> vecE;

--- a/src/module/EMDoublePairProduction.cpp
+++ b/src/module/EMDoublePairProduction.cpp
@@ -68,6 +68,10 @@ void EMDoublePairProduction::initRate(std::string path) {
 	this->interactionRates->initRate(path);
 }
 
+double EMDoublePairProduction::getRate(double E, const Vector3d &position, double z) const {
+	return this->interactionRates->getProcessRate(E, position) * pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
+}
+
 void EMDoublePairProduction::performInteraction(Candidate *candidate) const {
 
 	// Use assumption of Lee 96 arXiv:9604098
@@ -110,13 +114,10 @@ void EMDoublePairProduction::process(Candidate *candidate) const {
 	Vector3d position = candidate->current.getPosition();
 
 	// interaction rate
-	double rate = this->interactionRates->getProcessRate(E, position);
-		
+	double rate = getRate(E, position, z);
 	if (rate < 0)
 		return;
 		
-	rate *= pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
-
 	// check for interaction
 	Random &random = Random::instance();
 	double randDistance = -log(random.rand()) / rate;

--- a/src/module/EMInverseComptonScattering.cpp
+++ b/src/module/EMInverseComptonScattering.cpp
@@ -142,6 +142,10 @@ class ICSSecondariesEnergyDistribution {
 		}
 };
 
+double EMInverseComptonScattering::getRate(double E, const Vector3d &position, double z) const {
+	return this->interactionRates->getProcessRate(E, position) * pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
+}
+
 void EMInverseComptonScattering::performInteraction(Candidate *candidate) const {
 
 	// scale the particle energy instead of background photons
@@ -197,8 +201,7 @@ void EMInverseComptonScattering::process(Candidate *candidate) const {
 	Vector3d position = candidate->current.getPosition();
 	
 	// interaction rate
-	double rate = this->interactionRates->getProcessRate(E, position);
-	
+	double rate = getRate(E, position, z);
 	if (rate < 0)
 		return;
 	

--- a/src/module/EMPairProduction.cpp
+++ b/src/module/EMPairProduction.cpp
@@ -147,6 +147,10 @@ public:
 	
 };
 
+double EMPairProduction::getRate(double E, const Vector3d &position, double z) const {
+	return this->interactionRates->getProcessRate(E, position) * pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
+}
+
 void EMPairProduction::performInteraction(Candidate *candidate) const {
 	
 	// scale particle energy instead of background photon energy
@@ -228,19 +232,16 @@ void EMPairProduction::process(Candidate *candidate) const {
 	double E = candidate->current.getEnergy() * (1 + z);
 	Vector3d position = candidate->current.getPosition();
 	
-	double rate = this->interactionRates->getProcessRate(E, position);
-	
+	double rate = getRate(E, position, z);
 	if (rate < 0)
 		return;
-	
-	rate *= pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
 	
 	// run this loop at least once to limit the step size
 	double step = candidate->getCurrentStep();
 	Random &random = Random::instance();
 	do {
 		double randDistance = -log(random.rand()) / rate;
-		// check for interaction; if it doesn't ocurr, limit next step
+		// check for interaction; if it doesn't occur, limit next step
 		if (step < randDistance) {
 			candidate->limitNextStep(limit / rate);
 		} else {

--- a/src/module/EMTripletPairProduction.cpp
+++ b/src/module/EMTripletPairProduction.cpp
@@ -72,6 +72,10 @@ void EMTripletPairProduction::initCumulativeRate(std::string path) {
 	this->interactionRates->initCumulativeRate(path);
 }
 
+double EMTripletPairProduction::getRate(double E, const Vector3d &position, double z) const {
+	return this->interactionRates->getProcessRate(E, position) * pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
+}
+
 void EMTripletPairProduction::performInteraction(Candidate *candidate) const {
 	
 	// scale the particle energy instead of background photons
@@ -130,13 +134,11 @@ void EMTripletPairProduction::process(Candidate *candidate) const {
 	double E = (1 + z) * candidate->current.getEnergy();
 	Vector3d position = candidate->current.getPosition();
 	
-	double scaling = pow_integer<2>(1 + z) * photonField->getRedshiftScaling(z);
-	double rate = this->interactionRates->getProcessRate(E, position);
-	
+	// interaction rate
+	double rate = getRate(E, position, z);
 	if (rate < 0)
 		return;
 	
-	rate *= scaling;
 	
 	// run this loop at least once to limit the step size
 	double step = candidate->getCurrentStep();


### PR DESCRIPTION
This PR implements an explicit `getRate` method for all electromagnetic interactions.
This is similar to the `lossLength` implementation for photohadronic processes.
Ultimately, it allows users to directly access interaction rates for these processes, which are private in the current implementation.

This implementation supports an external plugin that requires this functionality.


