### PR TITLE
Fixing missing RPATH for unix swig interface files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,11 @@ if(ENABLE_PYTHON AND Python_FOUND)
       INSTALL_RPATH "@loader_path;${CMAKE_INSTALL_FULL_LIBDIR}"
     )
     set_property(TARGET crpropa-swig APPEND PROPERTY LINK_FLAGS "-flat_namespace -undefined suppress")
+  else()
+    set_target_properties(crpropa-swig PROPERTIES
+      BUILD_RPATH "$<TARGET_FILE_DIR:crpropa>"
+      INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}"
+    )
   endif(APPLE)
   
 

--- a/plugin-template/CMakeLists.txt
+++ b/plugin-template/CMakeLists.txt
@@ -263,10 +263,10 @@ if(ENABLE_PYTHON)
 		)
 
 		if(APPLE)
-			set_target_properties(${pluginName}-swig PROPERTIES INSTALL_RPATH "@loader_path;${CMAKE_INSTALL_PREFIX}/lib")
+			set_target_properties(${pluginName}-swig PROPERTIES INSTALL_RPATH "@loader_path;${CMAKE_INSTALL_FULL_LIBDIR}")
 			set_property(TARGET ${pluginName}-swig APPEND PROPERTY LINK_FLAGS "-flat_namespace -undefined suppress")
 		else()
-			set_target_properties(${pluginName}-swig PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+			set_target_properties(${pluginName}-swig PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
 		endif(APPLE)
 
 	endif(Python_FOUND)

--- a/plugin-template/CMakeLists.txt
+++ b/plugin-template/CMakeLists.txt
@@ -265,6 +265,8 @@ if(ENABLE_PYTHON)
 		if(APPLE)
 			set_target_properties(${pluginName}-swig PROPERTIES INSTALL_RPATH "@loader_path;${CMAKE_INSTALL_PREFIX}/lib")
 			set_property(TARGET ${pluginName}-swig APPEND PROPERTY LINK_FLAGS "-flat_namespace -undefined suppress")
+		else()
+			set_target_properties(${pluginName}-swig PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 		endif(APPLE)
 
 	endif(Python_FOUND)


### PR DESCRIPTION
Hi,

this PR attempts to fix #568 by adding the explicit RPATH to the swig interface.