### PR TITLE
Fix for particle mass 

### DIFF
--- a/src/ParticleMass.cpp
+++ b/src/ParticleMass.cpp
@@ -22,6 +22,8 @@ struct NuclearMassTable {
 	}
 
 	void init() {
+		if(initialized)
+			return;
 		std::string filename = getDataPath("nuclear_mass.txt");
 		std::ifstream infile(filename.c_str());
 


### PR DESCRIPTION
This PR fixes #577 by adding an additional check if data are initialized to prevent the new assignment of the data table.